### PR TITLE
feat: security reviewer agent, dry-run mode, and OSS maintainer persona

### DIFF
--- a/.claude/agent-memory/architect/MEMORY.md
+++ b/.claude/agent-memory/architect/MEMORY.md
@@ -1,3 +1,7 @@
 # Architect Agent Memory
 
-No memories recorded yet.
+## Memory Files
+
+- [project_specrails_structure.md](project_specrails_structure.md) — repo layout, key files, self-hosting pattern
+- [project_implement_pipeline.md](project_implement_pipeline.md) — implement command phase structure and variable conventions
+- [setup_flow_and_personas.md](setup_flow_and_personas.md) — /setup phase map, persona system, install.sh→/setup handoff pattern

--- a/.claude/agent-memory/architect/project_implement_pipeline.md
+++ b/.claude/agent-memory/architect/project_implement_pipeline.md
@@ -1,0 +1,63 @@
+---
+name: implement command pipeline
+description: Phase structure, variable conventions, and insertion points for the /implement command
+type: project
+---
+
+The `/implement` command pipeline phases in order:
+
+```
+Phase -1  Environment Setup (cloud pre-flight)
+Phase 0   Parse input and determine mode
+Phase 1   Explore (parallel, product-manager agents) — only if area names passed with no backlog
+Phase 2   Select — only if Phase 1 ran
+Phase 3a  Architect (parallel) — creates openspec/changes/<name>/
+  3a.1  Identify shared file conflicts
+  3a.2  Pre-validate architect output
+Phase 3b  Implement (developer agents)
+Phase 4   Merge & Review
+  4a. Merge worktree changes to main repo
+  4b. Launch Reviewer agent
+  4c. Ship — Git & backlog updates
+      [GIT_AUTO=true section]
+      [GIT_AUTO=false section]
+      [Backlog updates — BACKLOG_WRITE gated]
+  4d. Monitor CI
+  4e. Report
+Error Handling
+```
+
+**Key variables:**
+- `SINGLE_MODE` — true when only one feature, disables worktrees
+- `GIT_AUTO` — controls automatic git ops in 4c
+- `BACKLOG_WRITE` — controls issue commenting in 4c
+- `GH_AVAILABLE` — set in Phase -1 from gh auth status
+
+**Architect output:** always goes to `openspec/changes/<name>/` (not cached in dry-run)
+**Developer output:** written to working tree (or cache in dry-run mode)
+
+**Input modes:**
+1. Issue numbers: `#85, #71` — fetched via `gh issue view`, skips Phase 1+2
+2. Text description: single-feature mode, skips Phase 1+2
+3. Area names: triggers Phase 1+2 exploration
+
+**Change name derivation:** kebab-case from issue title or text description.
+
+---
+
+## Pending pipeline change: security-reviewer agent (Issue #4)
+
+OpenSpec artifacts created at `openspec/changes/security-reviewer-agent/`.
+
+The planned Phase 4 structure after this change ships:
+```
+4b.     Launch Reviewer agent (CI/quality gate)
+4b-sec. Launch Security Reviewer agent (security gate)
+4c.     Ship — blocked if SECURITY_BLOCKED=true
+4d.     Monitor CI
+4e.     Report (Security column added to table)
+```
+
+`SECURITY_STATUS:` (last line of security-reviewer output): `BLOCKED | WARNINGS | CLEAN`
+
+New variable: `SECURITY_BLOCKED` — set from security-reviewer output, gates Phase 4c.

--- a/.claude/agent-memory/architect/project_specrails_structure.md
+++ b/.claude/agent-memory/architect/project_specrails_structure.md
@@ -1,0 +1,28 @@
+---
+name: specrails repo structure
+description: Key files, directories, and the self-hosting pattern in specrails
+type: project
+---
+
+specrails is self-hosting: it uses its own agent workflow to develop itself.
+
+**Critical duality:** Two files are always kept in sync:
+- `templates/commands/implement.md` — source template with `{{PLACEHOLDER}}` tokens
+- `.claude/commands/implement.md` — generated/active command with placeholders resolved
+
+Changes to the implement command MUST update both files in the same commit.
+
+**Key directories:**
+- `templates/` — source templates (agents, commands, rules, personas, settings)
+- `.claude/` — generated output for specrails itself (agents, commands, rules, skills, agent-memory)
+- `openspec/specs/` — spec source of truth (currently sparse — implement.md did not exist as of 2026-03-13)
+- `openspec/changes/` — pending changes; `openspec/changes/archive/` for completed ones
+
+**Existing orchestrator variables (Phase 4c):**
+- `GIT_AUTO` (boolean) — controls automatic git shipping
+- `BACKLOG_WRITE` (boolean) — controls backlog issue commenting
+- `GH_AVAILABLE` (boolean) — set in Phase -1, controls whether gh CLI ops are attempted
+
+New flags follow the same inline-variable pattern (no `{{PLACEHOLDER}}` needed).
+
+**Why:** specrails is pre-code phase — no CI, no test framework. Manual verification is the only QA path.

--- a/.claude/agent-memory/architect/setup_flow_and_personas.md
+++ b/.claude/agent-memory/architect/setup_flow_and_personas.md
@@ -1,0 +1,44 @@
+---
+name: setup flow and persona system
+description: How /setup works phase by phase, how personas are generated, and the template-to-output mapping for personas
+type: project
+---
+
+## /setup phase structure
+
+- Phase 1: Codebase analysis + display findings (1.4 is the confirmation step)
+- Phase 2: User persona discovery (2.1 ask, 2.2 research, 2.3 generate VPC personas, 2.4 present)
+- Phase 3: Configuration (agents, backlog provider, git workflow, commands)
+- Phase 4: Generate files (4.1 agents, 4.2 personas, 4.3 commands, 4.4 rules, 4.5 CLAUDE.md, 4.6 settings, 4.7 memory)
+- Phase 5: Cleanup (5.1 rm scaffolding, 5.2 verify, 5.3 summary)
+
+## Persona system
+
+Three pre-authored personas ship with specrails:
+- `the-lead-dev.md` — "Alex"
+- `the-product-founder.md` — "Sara"
+- `the-maintainer.md` — "Kai"
+
+Location: `.claude/agents/personas/` (specrails's own setup)
+Template source: `templates/personas/` (what gets copied to target repos)
+
+**The maintainer persona is NOT parameterized** — it ships verbatim, not via {{PLACEHOLDER}} substitution. It is copied as-is to `.claude/agents/personas/the-maintainer.md` in target repos.
+
+User-generated personas use `templates/personas/persona.md` as a template.
+
+## product-manager agent and personas
+
+The product-manager template (`templates/agents/product-manager.md`) uses:
+- `{{PERSONA_FILE_LIST}}` — list of persona file paths (user-generated)
+- `{{MAINTAINER_PERSONA_LINE}}` — added by formalize-oss-maintainer feature; conditional on IS_OSS
+- `{{PERSONA_COUNT}}` — total count including Maintainer when IS_OSS=true
+
+The agent reads ALL files in `.claude/agents/personas/` dynamically, so presence of a file is sufficient for it to include the persona in VPC scoring.
+
+## install.sh → /setup handoff
+
+install.sh writes detection results to `.claude/setup-templates/` (temporary scaffolding directory).
+/setup reads those files during Phase 1-4.
+Phase 5.1 cleans up all of setup-templates with `rm -rf`.
+
+The `.oss-detection.json` file follows this pattern.

--- a/.claude/agent-memory/security-reviewer/MEMORY.md
+++ b/.claude/agent-memory/security-reviewer/MEMORY.md
@@ -1,0 +1,3 @@
+# Security Reviewer Agent Memory
+
+No memories recorded yet.

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,0 +1,178 @@
+---
+name: security-reviewer
+description: "Use this agent to scan all modified files for secrets, hardcoded credentials, and security vulnerability patterns after implementation. Runs as part of Phase 4 in the implement pipeline. Do NOT use this agent to fix issues — it scans and reports only.
+
+Examples:
+
+- Example 1:
+  user: (orchestrator) Reviewer completed. Now run the security scan.
+  assistant: \"Launching the security-reviewer agent to scan modified files for secrets and vulnerabilities.\"
+
+- Example 2:
+  user: (orchestrator) Implementation complete. Run security gate before shipping.
+  assistant: \"I'll launch the security-reviewer agent to perform the security scan.\""
+model: sonnet
+color: orange
+memory: project
+---
+
+You are a security-focused code auditor. You scan code for hardcoded secrets, credentials, and OWASP vulnerability patterns. You produce a structured findings report — you never fix code, never suggest changes, and never ask for clarification.
+
+## Your Mission
+
+- Scan every file in MODIFIED_FILES_LIST for secrets and vulnerabilities
+- Detect secrets using the patterns defined below
+- Detect OWASP vulnerability patterns in code files
+- Produce a structured report and set SECURITY_STATUS as the final line of your output
+
+## What You Receive
+
+The orchestrator injects three inputs into your invocation prompt:
+
+- **MODIFIED_FILES_LIST**: the complete list of files created or modified during this implementation run. Scan every file in this list (except those you are instructed to skip).
+- **PIPELINE_CONTEXT**: a brief description of what was implemented — feature names and change names. Use this for context when assessing findings.
+- The exemptions config at `.claude/security-exemptions.yaml`: read this file before reporting to check whether any findings should be suppressed.
+
+## Files to Skip
+
+Do not scan:
+- Binary files (images, compiled artifacts, fonts, archives)
+- `node_modules/`, `vendor/`, `.git/`
+- Lock files: `package-lock.json`, `yarn.lock`, `go.sum`, `Cargo.lock`
+- Files listed under exemptions in `.claude/security-exemptions.yaml`
+
+For every file you skip, note the reason briefly in your findings.
+
+## Secrets Detection
+
+Scan all non-skipped files for the following patterns:
+
+| Category | Pattern | Severity |
+|----------|---------|----------|
+| AWS Access Key ID | `AKIA[0-9A-Z]{16}` | Critical |
+| AWS Secret Access Key | 40-char alphanumeric after `aws_secret` keyword | Critical |
+| GitHub Token | `gh[pousr]_[A-Za-z0-9]{36}` | Critical |
+| Google API Key | `AIza[0-9A-Za-z\-_]{35}` | Critical |
+| Private Key Block | `-----BEGIN (RSA\|EC\|DSA\|OPENSSH) PRIVATE KEY-----` | Critical |
+| Database URL with credentials | `(postgres\|mysql\|mongodb)://[^:]+:[^@]+@` | Critical |
+| Generic API Key (20+ chars) | `api[_-]?key\s*[:=]\s*["'][A-Za-z0-9+/]{20,}` | Critical |
+| Generic Token (20+ chars) | `token\s*[:=]\s*["'][A-Za-z0-9+/]{20,}` | Critical |
+| Slack Webhook | `https://hooks.slack.com/services/T[A-Z0-9]+/` | High |
+| JWT Secret literal | `jwt[_-]?secret\s*[:=]` with non-env-var value | High |
+| Generic Password literal | `password\s*[:=]\s*["'][^"']{8,}` not from env | High |
+
+### Safe patterns — skip these, they are not secrets
+
+- Values referencing `process.env.*`, `os.environ[...]`, or shell `$VAR` syntax
+- Template placeholders: `{{...}}`, `<YOUR_KEY_HERE>`, `PLACEHOLDER`, `<...>`
+- Values in test files (`*.test.*`, `*.spec.*`, `*_test.go`, paths under `testdata/`) — if found, downgrade to Medium rather than skipping entirely
+
+### Entropy heuristic
+
+For any string longer than 20 characters assigned to a variable whose name contains `key`, `token`, `secret`, `password`, `credential`, or `auth`:
+- Estimate Shannon entropy
+- If entropy > 4.5 bits/char AND the value does not match a safe pattern above: flag as High severity
+
+## OWASP Vulnerability Patterns
+
+Apply these checks to code files only. Skip markdown, YAML, JSON, and config files.
+
+| Vulnerability | What to look for | Severity |
+|---------------|-----------------|----------|
+| SQL Injection | String concatenation into SQL queries | High |
+| XSS | Unsanitized user input in `innerHTML`, `dangerouslySetInnerHTML`, `document.write` | High |
+| Insecure Deserialization | `eval()` on user-controlled input, `pickle.loads()`, PHP `unserialize()` | High |
+| Weak JWT | `algorithm: 'none'` or `verify: false` in JWT operations | Critical |
+| Hardcoded credentials | Credentials in config files outside `.env.example` patterns | Critical |
+| Path traversal | User input directly in `path.join()`, `open()`, `fs.readFile()` without validation | High |
+| Command injection | User input in `exec()`, `spawn()`, `subprocess.run()`, `os.system()` | High |
+
+## Exemption Handling
+
+Before finalizing your report:
+
+1. Read `.claude/security-exemptions.yaml`
+2. For each finding, check whether it matches an exemption entry:
+   - Secrets finding: check `exemptions.secrets[].pattern` against the flagged pattern
+   - Vulnerability finding: check `exemptions.vulnerabilities[].rule` and `exemptions.vulnerabilities[].file`
+3. If a match is found: remove the finding from the Critical/High/Medium tables and add a row to the Exemptions Applied table
+4. Exception: Critical findings with a matching exemption are NOT fully suppressed — list them as "Warning: exempted Critical" in the Critical table. Critical exemptions must always be visible.
+
+## Severity Definitions
+
+| Severity | Definition | Pipeline effect |
+|----------|------------|-----------------|
+| Critical | Active credential format, live key, private key block, or OWASP critical pattern | Blocks pipeline — sets SECURITY_STATUS: BLOCKED |
+| High | Likely vulnerability, high-entropy suspicious value, or OWASP high-severity pattern | Warning — sets SECURITY_STATUS: WARNINGS if no Critical |
+| Medium | Possible false positive, test-context concern, or downgraded pattern | Report only, no pipeline impact |
+| Info | Observations about security posture | Report only, no pipeline impact |
+
+## Output Format
+
+Produce exactly this report structure:
+
+```
+## Security Scan Results
+
+### Summary
+- Files scanned: N
+- Findings: X Critical, Y High, Z Medium, W Info
+- Exemptions applied: E
+
+### Critical Findings (BLOCKS MERGE)
+| File | Line | Finding | Pattern |
+|------|------|---------|---------|
+(rows or "None")
+
+### High Findings (Warning)
+| File | Line | Finding | Pattern |
+|------|------|---------|---------|
+(rows or "None")
+
+### Medium Findings (Info)
+| File | Line | Finding | Notes |
+|------|------|---------|-------|
+(rows or "None")
+
+### Exemptions Applied
+| File | Finding | Exemption reason |
+|------|---------|-----------------|
+(rows or "None")
+
+---
+SECURITY_STATUS: BLOCKED
+```
+
+Set the `SECURITY_STATUS:` value as follows:
+- `BLOCKED` — one or more Critical findings exist after exemptions
+- `WARNINGS` — no Critical findings, but one or more High findings exist
+- `CLEAN` — no Critical or High findings
+
+The `SECURITY_STATUS:` line MUST be the very last line of your output. Nothing may follow it.
+
+## Rules
+
+- Never fix code. Never suggest code changes. Scan and report only.
+- Never ask for clarification. Complete the scan with available information.
+- Always scan every file in MODIFIED_FILES_LIST — never skip a file without noting why in your output.
+- Always emit the `SECURITY_STATUS:` line as the very last line of output.
+
+# Persistent Agent Memory
+
+You have a persistent agent memory directory at `.claude/agent-memory/security-reviewer/`. Its contents persist across conversations.
+
+As you work, consult your memory files to build on previous experience.
+
+Guidelines:
+- `MEMORY.md` is always loaded — keep it under 200 lines
+- Create separate topic files for detailed notes and link to them from MEMORY.md
+- Update or remove memories that turn out to be wrong or outdated
+
+What to save:
+- False positive patterns you discovered in this repo (patterns that look like secrets but are not)
+- File types or directories that commonly trigger false positives in this repo
+- Recurring true-positive patterns that have been exempted (to watch for recurrences)
+
+## MEMORY.md
+
+Your MEMORY.md is currently empty.

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -75,6 +75,31 @@ Print a setup report:
 
 ## Phase 0: Parse input and determine mode
 
+### Flag Detection
+
+Before parsing input, scan `$ARGUMENTS` for control flags:
+
+- If `--dry-run` or `--preview` is present in `$ARGUMENTS`:
+  - Set `DRY_RUN=true`
+  - Strip the flag from the arguments before further parsing
+  - Print: `[dry-run] Preview mode active — no git, PR, or backlog operations will run.`
+  - Set `CACHE_DIR=.claude/.dry-run/<kebab-case-feature-name>` (derive after parsing the remaining input)
+  - Note: if a cache already exists at `CACHE_DIR`, print `[dry-run] Overwriting existing cache at CACHE_DIR` before overwriting.
+
+- If `--apply <feature-name>` is present in `$ARGUMENTS`:
+  - Set `APPLY_MODE=true`
+  - Set `APPLY_TARGET=<feature-name>` (the argument immediately following `--apply`)
+  - Set `CACHE_DIR=.claude/.dry-run/<feature-name>`
+  - Verify `CACHE_DIR` exists. If it does not: print `[apply] Error: no cached dry-run found at CACHE_DIR` and stop.
+  - Skip Phases 1–4b. Go directly to Phase 4c (the apply path handles the rest).
+  - Strip `--apply` and the feature name before further parsing.
+
+If neither flag is present: `DRY_RUN=false`, `APPLY_MODE=false`. Pipeline runs as normal.
+
+Note: `CACHE_DIR` for `--dry-run` is finalized after the feature name is derived from the remaining input. All subsequent phases that reference `CACHE_DIR` have access to it.
+
+---
+
 **If the user passed a text description** (e.g. `"add feature X"`):
 - **Single-feature mode**. Derive a kebab-case change name.
 - Set `SINGLE_MODE = true`. No worktrees, no parallelism.
@@ -143,6 +168,23 @@ Before launching any developer agent, run a trivial Bash command to confirm Bash
 
 **Read reviewer learnings:** Check `.claude/agent-memory/reviewer/common-fixes.md` and include in developer prompts.
 
+#### Dry-Run: Redirect developer writes
+
+**If `DRY_RUN=true`**, include the following in every developer agent prompt:
+
+> IMPORTANT: This is a dry-run. Write all new or modified files under:
+>   .claude/.dry-run/\<feature-name\>/
+>
+> Mirror the real destination path within this directory. For example:
+>   Real path:   src/utils/parser.ts
+>   Write to:    .claude/.dry-run/\<feature-name\>/src/utils/parser.ts
+>
+> Do NOT write to real file paths. After writing each file, append an entry
+> to .claude/.dry-run/\<feature-name\>/.cache-manifest.json using this JSON format:
+>   {"cached_path": "...", "real_path": "...", "operation": "create|modify"}
+
+**If `DRY_RUN=false`**: developer agent instructions are unchanged.
+
 #### Choosing the right developer agent
 
 All tasks currently route to the full-stack **developer** agent since the project doesn't have separate backend/frontend layers yet.
@@ -160,7 +202,9 @@ Wait for all developers to complete.
 
 ### 4a. Merge worktree changes to main repo
 
-If `SINGLE_MODE`: skip. Otherwise copy feature-specific files, merge shared files manually, clean up worktrees.
+- If `SINGLE_MODE`: skip (no worktrees were used).
+- If `DRY_RUN=true`: merge worktree outputs to `CACHE_DIR` instead of the main repo. Apply the same merge logic (copy feature-specific files, handle shared files) but destination is `CACHE_DIR/<file-path>`.
+- Otherwise: merge to main repo working tree as normal (copy feature-specific files, merge shared files manually, clean up worktrees).
 
 ### 4b. Launch Reviewer agent
 
@@ -170,7 +214,59 @@ Launch a single **reviewer** agent to validate ALL merged changes. Include:
 - Record learnings to `common-fixes.md`
 - Archive completed changes via OpenSpec
 
+**If `DRY_RUN=true`**, add the following to the reviewer agent prompt:
+
+> Note: This is a dry-run review. Developer files are under .claude/.dry-run/\<feature-name\>/.
+> Read modified files from there. Write any reviewer fixes back to CACHE_DIR (not real paths).
+> CI commands may be run — they read the real repo, but be aware developer changes are not
+> yet applied to real paths.
+
+### 4b-sec. Launch Security Reviewer agent
+
+After the reviewer agent completes, launch a **security-reviewer** agent (`subagent_type: security-reviewer`).
+
+Construct the agent invocation prompt to include:
+- **MODIFIED_FILES_LIST**: the complete list of files created or modified during this implementation run
+- **PIPELINE_CONTEXT**: brief description — feature names and change names implemented
+- The exemptions config path: `.claude/security-exemptions.yaml`
+
+Wait for the security-reviewer to complete. Parse the final line of its output:
+- `SECURITY_STATUS: BLOCKED` → set `SECURITY_BLOCKED=true`
+- `SECURITY_STATUS: WARNINGS` → set `SECURITY_BLOCKED=false`, capture warning summary
+- `SECURITY_STATUS: CLEAN` → set `SECURITY_BLOCKED=false`
+
 ### 4c. Ship — Git & backlog updates
+
+**Security gate:** If `SECURITY_BLOCKED=true`:
+1. Print all Critical findings from the security-reviewer output
+2. Do NOT create a branch, commit, push, or PR
+3. Print: "Pipeline blocked by security findings. Fix the Critical issues listed above and re-run /implement."
+4. Skip to Phase 4e.
+
+### Dry-Run Gate
+
+**If `DRY_RUN=true`:**
+Print: `[dry-run] Skipping all git and backlog operations.`
+Record skipped operations to `.cache-manifest.json` under `skipped_operations`:
+- `"git: branch creation (feat/<name>)"`
+- `"git: commit"`
+- `"git: push"`
+- `"github: pr creation"` (if `GH_AVAILABLE=true`)
+- `"github: issue comment #N"` for each issue in scope (if `BACKLOG_WRITE=true`)
+
+Then skip the rest of Phase 4c and proceed directly to Phase 4e.
+
+**If `APPLY_MODE=true`:**
+1. Read `.cache-manifest.json` from `CACHE_DIR`.
+2. For each entry in `files`: copy `cached_path` to `real_path`, creating directories as needed.
+3. Print: `[apply] Copied N files from .claude/.dry-run/<feature-name>/ to real locations.`
+4. Then proceed with Phase 4c normally (GIT_AUTO logic, backlog updates) using the real files.
+5. On successful completion of Phase 4c: delete `CACHE_DIR` and print `[apply] Cache cleaned up.`
+   If Phase 4c fails: preserve `CACHE_DIR` for re-run.
+
+**Otherwise:** proceed as normal.
+
+---
 
 This phase uses **automatic** shipping (GIT_AUTO=true) and **read & write** backlog access (BACKLOG_WRITE=true).
 
@@ -216,9 +312,50 @@ Check CI status after pushing. Fix failures (up to 2 retries).
 
 ### 4e. Report
 
+**If `DRY_RUN=true`**, show this report instead of the standard pipeline table:
+
+---
+
+## Dry-Run Preview Report
+
+### Artifacts Generated
+
+| Type | Location |
+|------|----------|
+| OpenSpec proposal | openspec/changes/\<name\>/proposal.md |
+| OpenSpec design | openspec/changes/\<name\>/design.md |
+| OpenSpec tasks | openspec/changes/\<name\>/tasks.md |
+| OpenSpec context-bundle | openspec/changes/\<name\>/context-bundle.md |
+| Developer files | .claude/.dry-run/\<name\>/ (N files) |
+
+### What Would Change
+
+[For each file in `.cache-manifest.json` `files` array:]
+- `<real_path>` — [new file / modified] ([approximate line delta if available])
+
+### Operations Skipped
+
+[List items from `.cache-manifest.json` `skipped_operations` array]
+
+### Next Steps
+
+To apply these changes and ship:
 ```
-| Area | Feature | Change Name | Architect | Developer | Reviewer | Tests | CI | Status |
-|------|---------|-------------|-----------|-----------|----------|-------|----|--------|
+/implement --apply <feature-name>
+```
+
+To discard this dry run:
+```
+rm -rf .claude/.dry-run/<feature-name>/
+```
+
+---
+
+**Otherwise**, show the standard pipeline table:
+
+```
+| Area | Feature | Change Name | Architect | Developer | Reviewer | Security | Tests | CI | Status |
+|------|---------|-------------|-----------|-----------|----------|----------|-------|----|--------|
 ```
 
 Include PR URL, CI status, and backlog updates made.

--- a/.claude/security-exemptions.yaml
+++ b/.claude/security-exemptions.yaml
@@ -1,0 +1,20 @@
+# Security scan exemptions for specrails
+#
+# Add entries here to suppress known false positives from the security-reviewer agent.
+# All exemptions are tracked in git — every addition is auditable.
+#
+# Fields:
+#   secrets.pattern   - Description of the pattern being exempted (for documentation)
+#   secrets.reason    - Required: why this is a known false positive
+#   secrets.added_by  - Required: who added this exemption
+#   secrets.added_on  - Required: ISO 8601 date (YYYY-MM-DD)
+#
+#   vulnerabilities.rule    - The vulnerability rule name being exempted
+#   vulnerabilities.file    - Optional: scope exemption to a specific file path
+#   vulnerabilities.reason  - Required: justification
+#   vulnerabilities.added_by - Required
+#   vulnerabilities.added_on - Required
+
+exemptions:
+  secrets: []
+  vulnerabilities: []

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.claude/.dry-run/

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -71,6 +71,27 @@ Display the detected architecture to the user:
 - TypeScript: strict mode, functional components
 - Testing: pytest fixtures with scope="function"
 
+### OSS Project Detection
+
+Read `.claude/setup-templates/.oss-detection.json` if it exists.
+
+| Signal | Status |
+|--------|--------|
+| Public repository | [Yes / No / Unknown] |
+| CI workflows (.github/workflows/) | [Yes / No] |
+| CONTRIBUTING.md | [Yes / No] |
+| **Result** | **OSS detected / Not detected / Could not check** |
+
+If `is_oss: false` but at least one signal is `true`:
+> "Some OSS signals were found but not all three. Is this an open-source project? (yes/no)"
+
+If `.oss-detection.json` does not exist:
+> "Is this an open-source project? (yes/no)"
+
+When `IS_OSS=false` and no signals are present, skip OSS output entirely to avoid cluttering the display for non-OSS projects.
+
+Store the final OSS determination as `IS_OSS` for use throughout the rest of setup.
+
 [Confirm] [Modify] [Rescan]
 ```
 
@@ -83,6 +104,11 @@ Wait for user confirmation. If they want to modify, ask what to change.
 ### 2.1 Ask about target users
 
 Ask the user:
+
+> If IS_OSS=true, prepend:
+> "This is an OSS project. The **Maintainer** persona (Kai) is automatically included —
+> you do not need to add 'open-source maintainers' to your list.
+> Describe your other target user types below."
 
 > **Who are the target users of your software?**
 >
@@ -381,6 +407,18 @@ When generating each agent:
 
 ### 4.2 Generate personas
 
+If IS_OSS=true:
+1. Copy `setup-templates/personas/the-maintainer.md` to `.claude/agents/personas/the-maintainer.md`
+2. Log: "Maintainer persona included"
+3. Set MAINTAINER_INCLUDED=true for use in template substitution
+4. Set `{{MAINTAINER_PERSONA_LINE}}` = `- \`.claude/agents/personas/the-maintainer.md\` — "Kai" the Maintainer (open-source maintainer)`
+5. Increment `{{PERSONA_COUNT}}` by 1 to account for the Maintainer
+
+If IS_OSS=false:
+- Set `{{MAINTAINER_PERSONA_LINE}}` = *(empty string)*
+
+Then for each user-defined VPC persona from Phase 2.3:
+
 Write each persona to `.claude/agents/personas/`:
 - Use the VPC personas generated in Phase 2
 - File naming: kebab-case of persona nickname (e.g., `the-developer.md`, `the-admin.md`)
@@ -545,9 +583,12 @@ Display the complete installation summary:
 | product-manager | .claude/agents/product-manager.md | Opus |
 
 ### Personas Created
-| Persona | File |
-|---------|------|
-| "[Name]" — The [Role] | .claude/agents/personas/[name].md |
+| Persona | File | Source |
+|---------|------|--------|
+[If IS_OSS=true:]
+| "Kai" — The Maintainer | .claude/agents/personas/the-maintainer.md | Auto-included (OSS) |
+[For each user-generated persona:]
+| "[Name]" — The [Role] | .claude/agents/personas/[name].md | Generated |
 
 ### Commands Installed
 | Command | File |

--- a/install.sh
+++ b/install.sh
@@ -134,7 +134,30 @@ else
     HAS_GH=false
 fi
 
-# 1.6 JIRA CLI (optional)
+# 1.6 OSS detection (requires gh auth; degrades gracefully)
+IS_OSS=false
+HAS_PUBLIC_REPO=false
+HAS_CI=false
+HAS_CONTRIBUTING=false
+
+if [ "$HAS_GH" = true ]; then
+    _REPO_PRIVATE=$(gh repo view --json isPrivate --jq '.isPrivate' 2>/dev/null || echo "unknown")
+    if [ "$_REPO_PRIVATE" = "false" ]; then
+        HAS_PUBLIC_REPO=true
+    fi
+    if ls "$REPO_ROOT/.github/workflows/"*.yml > /dev/null 2>&1; then
+        HAS_CI=true
+    fi
+    if [ -f "$REPO_ROOT/CONTRIBUTING.md" ] || [ -f "$REPO_ROOT/.github/CONTRIBUTING.md" ]; then
+        HAS_CONTRIBUTING=true
+    fi
+    if [ "$HAS_PUBLIC_REPO" = true ] && [ "$HAS_CI" = true ] && [ "$HAS_CONTRIBUTING" = true ]; then
+        IS_OSS=true
+        ok "OSS project detected (public repo + CI + CONTRIBUTING.md)"
+    fi
+fi
+
+# 1.7 JIRA CLI (optional)
 if command -v jira &> /dev/null; then
     ok "JIRA CLI: found"
     HAS_JIRA=true
@@ -208,6 +231,25 @@ ok "Installed /setup command"
 # Copy templates
 cp -r "$SCRIPT_DIR/templates/"* "$REPO_ROOT/.claude/setup-templates/"
 ok "Installed setup templates"
+
+# Write OSS detection results for /setup
+cat > "$REPO_ROOT/.claude/setup-templates/.oss-detection.json" << EOF
+{
+  "is_oss": $IS_OSS,
+  "signals": {
+    "public_repo": $HAS_PUBLIC_REPO,
+    "has_ci": $HAS_CI,
+    "has_contributing": $HAS_CONTRIBUTING
+  }
+}
+EOF
+ok "OSS detection results written"
+
+# Copy security exemptions config (skip if already exists — preserve user exemptions)
+if [ ! -f "${REPO_ROOT}/.claude/security-exemptions.yaml" ]; then
+    cp "${SCRIPT_DIR}/templates/security/security-exemptions.yaml" "${REPO_ROOT}/.claude/security-exemptions.yaml"
+    ok "Created .claude/security-exemptions.yaml"
+fi
 
 # Copy prompts
 if [ -d "$SCRIPT_DIR/prompts" ] && [ "$(ls -A "$SCRIPT_DIR/prompts" 2>/dev/null)" ]; then

--- a/openspec/changes/archive/2026-03-13-dry-run-preview-mode/context-bundle.md
+++ b/openspec/changes/archive/2026-03-13-dry-run-preview-mode/context-bundle.md
@@ -1,0 +1,264 @@
+# Context Bundle: Local Agent Dry-Run / Preview Mode
+
+Everything a developer needs to implement this feature without reading additional files.
+
+---
+
+## What You Are Building
+
+A `--dry-run` flag (alias `--preview`) for the `/implement` command. When active:
+
+- All agents (architect, developer, reviewer) run as normal
+- Developer file output is redirected to `.claude/.dry-run/<feature-name>/` instead of real paths
+- Phase 4c (git branch, commit, push, PR creation, backlog issue comments) is entirely skipped
+- A preview report shows diffs and skipped operations at the end
+- A companion `--apply <feature-name>` flag copies cached files to real locations and then runs Phase 4c
+
+The entire feature is implemented as prose changes to two Markdown command files. There is no new code, no new agents, no new tools.
+
+---
+
+## Files to Change
+
+| File | Change type | Notes |
+|------|-------------|-------|
+| `templates/commands/implement.md` | Modify | Source template — authoritative |
+| `.claude/commands/implement.md` | Modify | Active generated command — must match template |
+| `openspec/specs/implement.md` | Create | New spec file for the implement command |
+| `.gitignore` | Create or modify | Add `.claude/.dry-run/` |
+
+---
+
+## Current Structure of `implement.md`
+
+The command has these phases in order:
+
+```
+Phase -1  Environment Setup
+Phase 0   Parse input and determine mode
+Phase 1   Explore (parallel, product-manager agents)
+Phase 2   Select
+Phase 3a  Architect (parallel)
+  3a.1  Identify shared file conflicts
+  3a.2  Pre-validate architect output
+Phase 3b  Implement (developer agents)
+  Pre-flight: Verify Bash permission
+  Launch developers
+Phase 4   Merge & Review
+  4a. Merge worktree changes to main repo
+  4b. Launch Reviewer agent
+  4c. Ship — Git & backlog updates
+    [GIT_AUTO=true section]
+    [GIT_AUTO=false section]
+    [Backlog updates section]
+  4d. Monitor CI
+  4e. Report
+Error Handling
+```
+
+The template version (`templates/commands/implement.md`) has `{{PLACEHOLDER}}` tokens for stack-specific values. The generated version (`.claude/commands/implement.md`) has these resolved.
+
+Key existing variables in Phase 4c: `GIT_AUTO` (boolean), `BACKLOG_WRITE` (boolean), `GH_AVAILABLE` (boolean set in Phase -1).
+
+---
+
+## Where Each Task Inserts Content
+
+### Phase 0 — Insert at the very top, before "If the user passed a text description..."
+
+```markdown
+### Flag Detection
+
+Before parsing input, scan $ARGUMENTS for control flags:
+
+- If `--dry-run` or `--preview` is present in $ARGUMENTS:
+  - Set `DRY_RUN=true`
+  - Strip the flag from the arguments before further parsing
+  - Print: `[dry-run] Preview mode active — no git, PR, or backlog operations will run.`
+  - Set `CACHE_DIR=.claude/.dry-run/<kebab-case-feature-name>` (derive after parsing the remaining input)
+
+- If `--apply <feature-name>` is present in $ARGUMENTS:
+  - Set `APPLY_MODE=true`
+  - Set `APPLY_TARGET=<feature-name>` (the argument immediately following --apply)
+  - Set `CACHE_DIR=.claude/.dry-run/<feature-name>`
+  - Verify CACHE_DIR exists. If it does not: print `[apply] Error: no cached dry-run found at CACHE_DIR` and stop.
+  - Skip Phases 1–4b. Go directly to Phase 4c (the apply path handles the rest).
+  - Strip --apply and the feature name before further parsing.
+
+If neither flag is present: `DRY_RUN=false`, `APPLY_MODE=false`. Pipeline runs as normal.
+
+Note: `CACHE_DIR` for `--dry-run` is finalized after the feature name is derived from the remaining input. All subsequent phases that reference CACHE_DIR have access to it.
+```
+
+### Phase 3b — After "Read reviewer learnings", before "Choosing the right developer agent"
+
+```markdown
+#### Dry-Run: Redirect developer writes
+
+**If `DRY_RUN=true`**, include the following in every developer agent prompt:
+
+> IMPORTANT: This is a dry-run. Write all new or modified files under:
+>   .claude/.dry-run/<feature-name>/
+>
+> Mirror the real destination path within this directory. For example:
+>   Real path:   src/utils/parser.ts
+>   Write to:    .claude/.dry-run/<feature-name>/src/utils/parser.ts
+>
+> Do NOT write to real file paths. After writing each file, append an entry
+> to .claude/.dry-run/<feature-name>/.cache-manifest.json using this JSON format:
+>   {"cached_path": "...", "real_path": "...", "operation": "create|modify"}
+
+**If `DRY_RUN=false`**: developer agent instructions are unchanged.
+```
+
+### Phase 4a — Replace the opening line with a three-way conditional
+
+**Current:**
+```
+If `SINGLE_MODE`: skip. Otherwise copy feature-specific files...
+```
+
+**Replace with:**
+```
+- If `SINGLE_MODE`: skip (no worktrees were used).
+- If `DRY_RUN=true`: merge worktree outputs to `CACHE_DIR` instead of the main repo. Apply the same merge logic (copy feature-specific files, handle shared files) but destination is `CACHE_DIR/<file-path>`.
+- Otherwise: merge to main repo working tree as normal.
+```
+
+### Phase 4b — After the existing reviewer agent description, add a conditional block
+
+```markdown
+**If `DRY_RUN=true`**, add to the reviewer agent prompt:
+
+> Note: This is a dry-run review. Developer files are under .claude/.dry-run/<feature-name>/.
+> Read modified files from there. Write any reviewer fixes back to CACHE_DIR (not real paths).
+> CI commands may be run — they read the real repo, but be aware developer changes are not
+> yet applied to real paths.
+```
+
+### Phase 4c — Insert "Dry-Run Gate" as the FIRST block, before "If GIT_AUTO=true..."
+
+```markdown
+### Dry-Run Gate
+
+**If `DRY_RUN=true`:**
+Print: `[dry-run] Skipping all git and backlog operations.`
+Record skipped operations to `.cache-manifest.json`:
+- "git: branch creation (feat/<name>)"
+- "git: commit"
+- "git: push"
+- "github: pr creation" (if GH_AVAILABLE=true)
+- "github: issue comment #N" for each issue in scope (if BACKLOG_WRITE=true)
+Then skip the rest of Phase 4c and proceed directly to Phase 4e.
+
+**If `APPLY_MODE=true`:**
+1. Read `.cache-manifest.json` from `CACHE_DIR`.
+2. For each entry in `files`: copy `cached_path` to `real_path`, creating directories as needed.
+3. Print: `[apply] Copied N files from .claude/.dry-run/<feature-name>/ to real locations.`
+4. Then proceed with Phase 4c normally (GIT_AUTO logic, backlog updates) using the real files.
+5. On successful completion of Phase 4c: delete `CACHE_DIR` and print `[apply] Cache cleaned up.`
+   If Phase 4c fails: preserve `CACHE_DIR` for re-run.
+
+**Otherwise:** proceed as normal.
+```
+
+### Phase 4e — Insert "Dry-Run Preview Report" as a conditional block BEFORE the standard table
+
+```markdown
+**If `DRY_RUN=true`**, show this report instead of the standard pipeline table:
+
+---
+## Dry-Run Preview Report
+
+### Artifacts Generated
+| Type | Location |
+|------|----------|
+| OpenSpec proposal | openspec/changes/<name>/proposal.md |
+| OpenSpec design | openspec/changes/<name>/design.md |
+| OpenSpec tasks | openspec/changes/<name>/tasks.md |
+| OpenSpec context-bundle | openspec/changes/<name>/context-bundle.md |
+| Developer files | .claude/.dry-run/<name>/ (N files) |
+
+### What Would Change
+[For each file in .cache-manifest.json `files` array:]
+- `<real_path>` — [new file / modified] ([approximate line delta if available])
+
+### Operations Skipped
+[List items from .cache-manifest.json `skipped_operations` array]
+
+### Next Steps
+To apply these changes and ship:
+  /implement --apply <feature-name>
+
+To discard this dry run:
+  rm -rf .claude/.dry-run/<feature-name>/
+---
+```
+
+---
+
+## Cache Manifest Schema
+
+File: `.claude/.dry-run/<feature-name>/.cache-manifest.json`
+
+```json
+{
+  "feature": "dry-run-preview-mode",
+  "created_at": "2026-03-13T00:00:00Z",
+  "dry_run": true,
+  "files": [
+    {
+      "cached_path": ".claude/.dry-run/dry-run-preview-mode/templates/commands/implement.md",
+      "real_path": "templates/commands/implement.md",
+      "operation": "modify"
+    }
+  ],
+  "openspec_changes": "dry-run-preview-mode",
+  "skipped_operations": [
+    "git: branch creation (feat/dry-run-preview-mode)",
+    "git: commit",
+    "git: push",
+    "github: pr creation",
+    "github: issue comment #18"
+  ]
+}
+```
+
+---
+
+## Existing Patterns to Follow
+
+The new dry-run logic follows the same conditional-flag pattern already in Phase 4c:
+
+```
+#### If `GIT_AUTO=true` (automatic shipping)
+...
+
+#### If `GIT_AUTO=false` (manual shipping)
+...
+```
+
+The dry-run gate sits above these. When `DRY_RUN=false` and `APPLY_MODE=false`, the `GIT_AUTO` logic runs exactly as before — no behavior change.
+
+---
+
+## Conventions Checklist
+
+- No `{{PLACEHOLDER}}` tokens for dry-run logic — use inline variable names (`DRY_RUN`, `CACHE_DIR`) matching the `GIT_AUTO` / `BACKLOG_WRITE` pattern
+- All headings use `###` (third level) to match surrounding Phase 4c structure
+- Variable names: `UPPER_SNAKE_CASE`
+- File paths: kebab-case directories, no uppercase
+- The template and generated command must be updated in the same commit
+- After editing, run: `grep -r '{{[A-Z_]*}}' .claude/commands/` to verify no broken placeholders
+
+---
+
+## Risks
+
+1. **Developer agent path discipline**: Dry-run correctness depends entirely on the developer agent following the cache path instruction. If the agent writes to real paths, the dry-run silently fails. Mitigation: make the instruction prominent and explicit in the prompt; include the prohibition ("Do NOT write to real file paths") explicitly.
+
+2. **Reviewer CI gap**: In dry-run mode, CI runs against the real repo (developer changes not applied). CI results may not reflect what the final code would produce. Mitigation: the reviewer prompt explicitly notes this caveat. The user is informed in the preview report.
+
+3. **Stale cache on re-run**: If `--dry-run` is run twice with the same feature name, the second run overwrites the first. Mitigation: print a warning ("[dry-run] Overwriting existing cache at CACHE_DIR") before overwriting.
+
+4. **`CACHE_DIR` finalization timing**: `CACHE_DIR` requires the feature name, which is derived from input parsing. The flag detection section must note that `CACHE_DIR` is finalized after the feature name is known. Phases 3a onward can reference it without issue.

--- a/openspec/changes/archive/2026-03-13-dry-run-preview-mode/delta-spec.md
+++ b/openspec/changes/archive/2026-03-13-dry-run-preview-mode/delta-spec.md
@@ -1,0 +1,133 @@
+# Delta Spec: Local Agent Dry-Run / Preview Mode
+
+This document describes the exact changes to existing specs and conventions introduced by this feature. It is not a full spec rewrite — only deltas are recorded.
+
+---
+
+## 1. `openspec/specs/implement.md` (does not yet exist — create)
+
+The implement command does not currently have a spec file in `openspec/specs/`. Create it and capture the dry-run behavior as part of the baseline spec.
+
+**File to create:** `openspec/specs/implement.md`
+
+**Content to add:**
+
+```markdown
+# Spec: /implement Command
+
+## Flags
+
+### --dry-run / --preview
+
+When passed, the pipeline runs fully (all agents execute) but no external side effects fire:
+- No git branch creation, commits, pushes
+- No PR creation
+- No GitHub/backlog issue comments
+
+Generated artifacts are cached at `.claude/.dry-run/<feature-name>/`.
+
+The pipeline ends with a preview report showing what would have changed and what operations were skipped.
+
+### --apply <feature-name>
+
+Reads cached artifacts from `.claude/.dry-run/<feature-name>/`, copies them to their real destinations, then executes Phase 4c (git + backlog operations) normally.
+
+Deletes the cache on successful completion.
+
+## Cache Directory
+
+Location: `.claude/.dry-run/<feature-name>/`
+
+Structure:
+- Mirrors real file paths under the cache root
+- `.cache-manifest.json` — manifest of cached files, their real paths, and skipped operations
+- `.preview-report.md` — the rendered preview report from Phase 4e
+
+The `.claude/.dry-run/` directory is gitignored.
+
+## Behavior Matrix
+
+| Flag | Agents run | Files written | Git ops | Backlog ops | Cache |
+|------|-----------|---------------|---------|-------------|-------|
+| (none) | yes | real paths | yes | yes | no |
+| --dry-run | yes | cache | no | no | created |
+| --apply | no | real paths (from cache) | yes | yes | deleted on success |
+```
+
+---
+
+## 2. `templates/commands/implement.md` — Phase 0 additions
+
+**Section:** Phase 0: Parse input and determine mode
+
+**Delta:** Add a "Flag Detection" subsection at the top of Phase 0, before all existing input parsing. See `design.md` for the exact prose to insert.
+
+**Variables introduced:**
+- `DRY_RUN` (boolean, default false)
+- `APPLY_MODE` (boolean, default false)
+- `APPLY_TARGET` (string, the feature name following --apply)
+- `CACHE_DIR` (string path, set when DRY_RUN or APPLY_MODE is true)
+
+---
+
+## 3. `templates/commands/implement.md` — Phase 3b additions
+
+**Section:** Phase 3b: Implement — developer agent prompt
+
+**Delta:** When `DRY_RUN=true`, add instruction block to developer agent prompt redirecting writes to `CACHE_DIR`. See `design.md` for exact text.
+
+---
+
+## 4. `templates/commands/implement.md` — Phase 4a additions
+
+**Section:** Phase 4a: Merge worktree changes to main repo
+
+**Delta:** Add conditional: when `DRY_RUN=true`, merge worktree outputs to `CACHE_DIR` instead of main repo working tree.
+
+---
+
+## 5. `templates/commands/implement.md` — Phase 4b additions
+
+**Section:** Phase 4b: Launch Reviewer agent
+
+**Delta:** When `DRY_RUN=true`, add instruction block to reviewer agent prompt directing it to read developer files from `CACHE_DIR`.
+
+---
+
+## 6. `templates/commands/implement.md` — Phase 4c dry-run gate
+
+**Section:** Phase 4c: Ship — Git & backlog updates
+
+**Delta:** Add a "Dry-Run Gate" block at the very top of Phase 4c, before all existing content. This block:
+1. When `DRY_RUN=true`: skips Phase 4c entirely and jumps to Phase 4e.
+2. When `APPLY_MODE=true`: runs the apply-from-cache logic, then proceeds with Phase 4c as normal.
+
+---
+
+## 7. `templates/commands/implement.md` — Phase 4e preview report
+
+**Section:** Phase 4e: Report
+
+**Delta:** When `DRY_RUN=true`, show the Preview Report format instead of the standard pipeline report table. See `design.md` for the exact format.
+
+---
+
+## 8. `.claude/commands/implement.md` — identical changes
+
+The generated command receives the same changes as the template. Both files must be updated in the same commit.
+
+---
+
+## 9. `.gitignore`
+
+**Delta:** Add `.claude/.dry-run/` to the project `.gitignore`.
+
+If no `.gitignore` exists yet, create one with this entry.
+
+---
+
+## Conventions Unchanged
+
+- `{{PLACEHOLDER}}` syntax is not used for dry-run logic — the new sections are plain prose/markdown with inline variable names (`DRY_RUN`, `CACHE_DIR`), consistent with how `GIT_AUTO` and `BACKLOG_WRITE` are handled in Phase 4c today.
+- All new prose follows existing heading levels and formatting conventions.
+- No new template placeholders are introduced.

--- a/openspec/changes/archive/2026-03-13-dry-run-preview-mode/design.md
+++ b/openspec/changes/archive/2026-03-13-dry-run-preview-mode/design.md
@@ -1,0 +1,282 @@
+# Technical Design: Local Agent Dry-Run / Preview Mode
+
+## Overview
+
+The dry-run feature is a pure orchestration-layer concern. No agent prompt changes. No new agents. No new tools. The entire implementation is confined to the `/implement` command's Markdown prose — specifically, two new parsing rules in Phase 0 and a conditional gate in Phase 4c.
+
+The cache mechanism is a directory convention, not a database or state file. Simplicity is the guiding principle.
+
+---
+
+## Architecture
+
+```
+/implement --dry-run #18
+     |
+     v
+Phase 0: Parse flags
+  - Detect --dry-run or --preview
+  - Set DRY_RUN=true
+  - Set CACHE_DIR=.claude/.dry-run/<feature-name>
+     |
+     v
+Phase -1, 1, 2, 3a, 3b: Run normally
+  BUT: developer agent writes to CACHE_DIR instead of real locations
+     |
+     v
+Phase 4a: Merge to CACHE_DIR (not main repo)
+     |
+     v
+Phase 4b: Reviewer reads from CACHE_DIR
+     |
+     v
+Phase 4c: SKIPPED (no git, no PR, no backlog updates)
+     |
+     v
+Phase 4e: Preview report (diffs, artifact list, skipped ops)
+     |
+     v
+User runs: /implement --apply <feature-name>
+     |
+     v
+Phase 0 (apply): Detect --apply, locate CACHE_DIR
+     |
+     v
+Apply: Copy files from CACHE_DIR to real locations
+     |
+     v
+Phase 4c: Run normally (branch, commit, push, PR, backlog)
+```
+
+---
+
+## File Changes
+
+### 1. `templates/commands/implement.md` (template source)
+
+This is the authoritative source. All changes described below apply here first.
+
+### 2. `.claude/commands/implement.md` (active generated command)
+
+Receives identical changes. Since specrails is self-hosting, this IS the running command.
+
+---
+
+## Detailed Changes Per Phase
+
+### Phase 0: Parse input and determine mode
+
+**Add at the top of Phase 0**, before existing input parsing logic:
+
+```
+### Flag Detection
+
+Before parsing input, scan $ARGUMENTS for control flags:
+
+- If `--dry-run` or `--preview` is present in $ARGUMENTS:
+  - Set `DRY_RUN=true`
+  - Strip the flag from the arguments before further parsing
+  - Print: `[dry-run] Preview mode active — no git, PR, or backlog operations will run.`
+
+- If `--apply` is present in $ARGUMENTS followed by a feature name:
+  - Set `APPLY_MODE=true`
+  - Set `APPLY_TARGET=<feature-name>` (the argument after --apply)
+  - Set `CACHE_DIR=.claude/.dry-run/<feature-name>`
+  - Verify CACHE_DIR exists. If not: print error and stop.
+  - Skip all phases except 4c. Go directly to the Apply step (see Phase 4c).
+  - Strip the flag and feature name before further parsing.
+
+If neither flag is present: `DRY_RUN=false`, `APPLY_MODE=false`. Pipeline runs as normal.
+```
+
+**Cache directory naming convention:**
+
+`CACHE_DIR = .claude/.dry-run/<kebab-case-feature-name>/`
+
+The feature name is derived the same way as the change name — from the issue title or text description, kebab-cased. Examples:
+- Issue #18 "Local Agent Dry-Run / Preview Mode" → `.claude/.dry-run/dry-run-preview-mode/`
+- Text "add price history chart" → `.claude/.dry-run/add-price-history-chart/`
+
+**Cache directory structure:**
+
+```
+.claude/.dry-run/<feature-name>/
+  openspec/changes/<feature-name>/    # Architect artifacts (proposal, design, tasks, etc.)
+  <real-file-paths-mirrored>/         # Developer file changes, mirrored from repo root
+  .cache-manifest.json                # List of files changed, their real destinations, timestamp
+  .preview-report.md                  # Generated at end of Phase 4e
+```
+
+The `.cache-manifest.json` format:
+
+```json
+{
+  "feature": "<feature-name>",
+  "created_at": "<ISO timestamp>",
+  "dry_run": true,
+  "files": [
+    {
+      "cached_path": ".claude/.dry-run/<feature-name>/path/to/file",
+      "real_path": "path/to/file",
+      "operation": "create|modify"
+    }
+  ],
+  "openspec_changes": "<feature-name>",
+  "skipped_operations": [
+    "git: branch creation (feat/<name>)",
+    "git: commit",
+    "git: push",
+    "github: pr creation",
+    "github: issue comment #18"
+  ]
+}
+```
+
+### Phase 3a: Architect
+
+**No change to agent invocation.** The architect always writes to `openspec/changes/<name>/`. This is fine — OpenSpec artifacts are not git-committed by the pipeline; they live in the working tree. In dry-run mode they still go to `openspec/changes/<name>/` as normal.
+
+Rationale: OpenSpec changes are not side effects that reach remotes. They are local design artifacts. Moving them to the cache would break the reviewer's ability to read them by standard path. Keeping them in `openspec/changes/<name>/` is the simpler, correct choice.
+
+**Note the architect output is NOT cached separately** — it remains at its normal location. Only developer-produced file changes (code, tests, docs written to the repo) are redirected to CACHE_DIR.
+
+### Phase 3b: Implement — developer agent instructions
+
+**When `DRY_RUN=true`**, add to the developer agent prompt:
+
+```
+IMPORTANT: This is a dry-run. Write all new or modified files under:
+  .claude/.dry-run/<feature-name>/
+
+Mirror the real destination path within this directory. For example:
+  Real path:   src/utils/parser.ts
+  Write to:    .claude/.dry-run/<feature-name>/src/utils/parser.ts
+
+Do NOT write to real file paths. After writing each file, append an entry
+to .claude/.dry-run/<feature-name>/.cache-manifest.json.
+```
+
+**When `DRY_RUN=false`**: developer agent instructions are unchanged.
+
+### Phase 4a: Merge worktree changes
+
+**When `DRY_RUN=true`**: Merge worktree outputs into `CACHE_DIR` instead of the main repo working tree. The merge logic is identical; only the destination changes.
+
+**When `DRY_RUN=false`**: unchanged.
+
+### Phase 4b: Reviewer agent
+
+**When `DRY_RUN=true`**: The reviewer reads files from `CACHE_DIR` when it needs to inspect developer output. The reviewer's prompt must include:
+
+```
+Note: This is a dry-run review. Developer files are under .claude/.dry-run/<feature-name>/.
+Read modified files from there. Do NOT write fixes to real paths — write them to CACHE_DIR.
+CI commands may be run (they read the real repo), but understand that developer changes
+are in the cache and not yet applied.
+```
+
+**When `DRY_RUN=false`**: unchanged.
+
+### Phase 4c: Ship — CORE CHANGE
+
+**Add at the top of Phase 4c:**
+
+```
+### Dry-Run Gate
+
+IF `DRY_RUN=true`:
+  SKIP this entire phase (4c).
+  Do not create branches.
+  Do not commit.
+  Do not push.
+  Do not create PRs.
+  Do not comment on issues.
+  Proceed directly to Phase 4e (Report).
+
+IF `APPLY_MODE=true`:
+  Read .cache-manifest.json from CACHE_DIR.
+  For each file in the manifest:
+    Copy from cached_path to real_path (create directories as needed).
+  Print: "[apply] Copied N files from cache to real locations."
+  Then run Phase 4c normally (branch, commit, push, PR, backlog updates).
+  After shipping, delete CACHE_DIR.
+```
+
+### Phase 4e: Report
+
+**When `DRY_RUN=true`**, replace or augment the standard report table with a **Preview Report**:
+
+```
+## Dry-Run Preview Report
+
+### Artifacts Generated
+| Type | Location |
+|------|----------|
+| OpenSpec proposal | openspec/changes/<name>/proposal.md |
+| OpenSpec design | openspec/changes/<name>/design.md |
+| OpenSpec tasks | openspec/changes/<name>/tasks.md |
+| OpenSpec context-bundle | openspec/changes/<name>/context-bundle.md |
+| Developer files | .claude/.dry-run/<name>/ (N files) |
+
+### What Would Change (diff preview)
+[For each file in .cache-manifest.json, show a summary: new file / modified (N lines +/- M)]
+
+### Operations Skipped
+[List from .cache-manifest.json skipped_operations field]
+
+### Next Steps
+To apply these changes and ship:
+  /implement --apply <feature-name>
+
+To discard this dry run:
+  rm -rf .claude/.dry-run/<feature-name>/
+```
+
+**When `DRY_RUN=false`**: report is unchanged.
+
+---
+
+## Cache Lifecycle
+
+| Event | Action |
+|-------|--------|
+| `--dry-run` completes | Cache persists at `.claude/.dry-run/<name>/` |
+| `--apply <name>` completes successfully | Cache is deleted |
+| `--apply <name>` fails mid-way | Cache is preserved (re-runnable) |
+| Manual discard | `rm -rf .claude/.dry-run/<name>/` |
+| Multiple dry runs, same name | New run overwrites the cache (with a warning) |
+
+The `.claude/.dry-run/` directory should be added to `.gitignore` so cached previews are not accidentally committed.
+
+---
+
+## Integration Points
+
+| Component | Interaction |
+|-----------|-------------|
+| Phase 0 | New flag parsing, DRY_RUN/APPLY_MODE vars set |
+| Phase 3b developer prompt | Redirected write path when DRY_RUN=true |
+| Phase 4a merge | Destination changes to CACHE_DIR when DRY_RUN=true |
+| Phase 4b reviewer prompt | Read path hint when DRY_RUN=true |
+| Phase 4c | Conditional skip gate (DRY_RUN) or apply-from-cache entry point (APPLY_MODE) |
+| Phase 4e | Extended preview report when DRY_RUN=true |
+| `.gitignore` | `.claude/.dry-run/` added |
+
+---
+
+## Key Design Decisions
+
+**Why not a separate `/dry-run` command?**
+A flag on `/implement` is discoverable, consistent with how `GIT_AUTO` and `BACKLOG_WRITE` already parameterize behavior, and requires no new command scaffolding.
+
+**Why mirror file paths in the cache rather than a flat list?**
+Mirrored paths make the apply step trivial (just copy by path) and make diffs readable without any path translation.
+
+**Why keep OpenSpec artifacts at their real location even in dry-run?**
+OpenSpec changes are local design files, not pushed to remote. Moving them to the cache adds complexity for no safety benefit. The reviewer and subsequent phases read them from standard paths.
+
+**Why a JSON manifest rather than a directory scan on apply?**
+The manifest captures intent (create vs. modify) and the list of skipped operations for the report. A directory scan would lose this metadata.
+
+**Why delete the cache on successful `--apply`?**
+Prevents stale caches from confusing future runs. If apply fails, the cache is preserved so the user can re-run `--apply` safely.

--- a/openspec/changes/archive/2026-03-13-dry-run-preview-mode/proposal.md
+++ b/openspec/changes/archive/2026-03-13-dry-run-preview-mode/proposal.md
@@ -1,0 +1,45 @@
+# Proposal: Local Agent Dry-Run / Preview Mode
+
+## Problem
+
+The `/implement` pipeline is a powerful but irreversible sequence of actions: it creates branches, pushes commits, opens PRs, and comments on GitHub Issues. There is no way to preview what the pipeline would produce — code changes, OpenSpec artifacts, test output — before those side effects fire.
+
+This makes `/implement` unsafe to run experimentally. Developers who want to explore whether a feature idea is feasible, or verify that agents interpret a spec correctly, must either commit to the full pipeline or avoid running it altogether. The result is a workflow where iteration is expensive and mistakes are visible in the repo and backlog before they can be caught.
+
+## Solution
+
+Add a `--dry-run` flag (alias: `--preview`) to `/implement`.
+
+When `--dry-run` is active:
+
+- All agents run normally: product-manager explores, architect designs, developer implements, reviewer validates.
+- All generated artifacts — OpenSpec files, code, tests, documentation — are written to a cache directory (`.claude/.dry-run/<feature-name>/`) instead of their real locations.
+- Git operations are suppressed: no branch creation, no commits, no push, no PR.
+- GitHub/backlog operations are suppressed: no issue comments.
+- A full preview report is shown: diffs of what would change, a summary of all artifacts generated, and a list of operations that were skipped.
+- The cache is retained so re-running with `--apply` copies artifacts to real locations and proceeds with Phase 4c shipping.
+
+## Non-Goals
+
+- This does not add a dry-run mode to individual agents. The flag is an orchestrator-level concern.
+- This does not sandbox file system access during agent execution. Files are written to the cache directory under `.claude/.dry-run/`; real repo files are not touched.
+- This does not add rollback to non-dry-run runs. Rollback is a separate concern.
+- This does not change the behavior of `/implement` without the flag. The default pipeline is unchanged.
+
+## Scope
+
+Two files change:
+
+1. `templates/commands/implement.md` — the source template, which drives all future installs.
+2. `.claude/commands/implement.md` — the currently-active generated command in this repo.
+
+Both files receive identical changes because specrails is self-hosting: the generated command IS the active command. Changes to the template propagate to target repos on their next `/setup` run.
+
+## Success Criteria
+
+- `--dry-run` flag is parsed in Phase 0 and a `DRY_RUN` boolean is set.
+- Phases 3a and 3b write output to `.claude/.dry-run/<feature-name>/` when `DRY_RUN=true`.
+- Phase 4c git and backlog operations are entirely skipped when `DRY_RUN=true`.
+- A preview report is shown at the end of Phase 4e that includes diffs and a list of skipped operations.
+- `--apply` flag reads from cache and triggers Phase 4c shipping without re-running agents.
+- Pipeline is fully unchanged when neither flag is passed.

--- a/openspec/changes/archive/2026-03-13-dry-run-preview-mode/tasks.md
+++ b/openspec/changes/archive/2026-03-13-dry-run-preview-mode/tasks.md
@@ -1,0 +1,202 @@
+# Tasks: Local Agent Dry-Run / Preview Mode
+
+Tasks are ordered sequentially. Each task depends on the one before it.
+
+---
+
+## T1 — Add .gitignore entry for dry-run cache [core]
+
+**Description:**
+Create or update `.gitignore` at the repo root to exclude `.claude/.dry-run/`. This must happen before any dry-run runs so cached artifacts are never accidentally staged.
+
+**Files involved:**
+- `.gitignore` (create if absent)
+
+**Acceptance criteria:**
+- `.gitignore` contains the line `.claude/.dry-run/`
+- `git status` does not show `.claude/.dry-run/` contents as untracked after a dry-run cache is created
+
+**Dependencies:** none
+
+---
+
+## T2 — Add Flag Detection to Phase 0 in the template [templates]
+
+**Description:**
+Insert a "Flag Detection" subsection at the top of Phase 0 in `templates/commands/implement.md`. This subsection must:
+
+1. Detect `--dry-run` or `--preview` in `$ARGUMENTS`, set `DRY_RUN=true`, strip the flag, print a notice.
+2. Detect `--apply <feature-name>` in `$ARGUMENTS`, set `APPLY_MODE=true`, set `APPLY_TARGET` and `CACHE_DIR`, verify cache exists, then jump directly to Phase 4c (apply path). Stop with an error if cache is missing.
+3. Default both flags to false when absent.
+
+The subsection goes above the existing "If the user passed a text description..." block.
+
+**Files involved:**
+- `templates/commands/implement.md`
+
+**Acceptance criteria:**
+- Phase 0 has a "Flag Detection" subsection as its first content block
+- Variables `DRY_RUN`, `APPLY_MODE`, `APPLY_TARGET`, `CACHE_DIR` are defined
+- The prose clearly states: strip flags before further input parsing
+- `--apply` path verifies cache existence before proceeding
+- No `{{PLACEHOLDER}}` syntax used (inline variable names, consistent with GIT_AUTO pattern)
+
+**Dependencies:** none
+
+---
+
+## T3 — Add dry-run cache redirect to Phase 3b developer prompt [templates]
+
+**Description:**
+In `templates/commands/implement.md`, add a conditional block in Phase 3b under "Launch developers". When `DRY_RUN=true`, the developer agent prompt must include instructions to:
+- Write all new/modified files under `CACHE_DIR` mirroring real paths
+- Append each file entry to `.cache-manifest.json` in CACHE_DIR
+
+**Files involved:**
+- `templates/commands/implement.md`
+
+**Acceptance criteria:**
+- Phase 3b has a conditional block gated on `DRY_RUN=true`
+- Developer prompt text includes: write destination, path mirroring rule, manifest update instruction
+- Condition is clearly separated from the existing developer launch prose
+
+**Dependencies:** T2
+
+---
+
+## T4 — Add dry-run merge redirect to Phase 4a [templates]
+
+**Description:**
+In `templates/commands/implement.md`, add a conditional at the start of Phase 4a. When `DRY_RUN=true`, worktree merge output goes to `CACHE_DIR` rather than the main repo working tree.
+
+**Files involved:**
+- `templates/commands/implement.md`
+
+**Acceptance criteria:**
+- Phase 4a has an explicit conditional: `If SINGLE_MODE: skip. If DRY_RUN=true: merge to CACHE_DIR. Otherwise: merge to main repo.`
+- Existing merge logic is unchanged for non-dry-run paths
+
+**Dependencies:** T2
+
+---
+
+## T5 — Add dry-run reviewer path hint to Phase 4b [templates]
+
+**Description:**
+In `templates/commands/implement.md`, add a conditional block in Phase 4b. When `DRY_RUN=true`, the reviewer agent prompt must include instructions to:
+- Read developer-produced files from `CACHE_DIR`
+- Write any fixes back to `CACHE_DIR` (not real paths)
+- Understand CI commands read the real repo (no developer changes applied yet)
+
+**Files involved:**
+- `templates/commands/implement.md`
+
+**Acceptance criteria:**
+- Phase 4b has a conditional block gated on `DRY_RUN=true`
+- Reviewer prompt text covers: read path, write path, CI caveat
+- Normal reviewer path is unchanged
+
+**Dependencies:** T2
+
+---
+
+## T6 — Add Dry-Run Gate to Phase 4c [templates]
+
+**Description:**
+In `templates/commands/implement.md`, insert a "Dry-Run Gate" block at the very top of Phase 4c, before the existing `GIT_AUTO` conditional. This block handles two cases:
+
+1. `DRY_RUN=true`: Print "[dry-run] Skipping all git and backlog operations." then jump to Phase 4e.
+2. `APPLY_MODE=true`: Read `.cache-manifest.json`, copy each file from `cached_path` to `real_path`, print "[apply] Copied N files.", then fall through to the existing Phase 4c logic (GIT_AUTO branch). On successful completion, delete CACHE_DIR.
+
+**Files involved:**
+- `templates/commands/implement.md`
+
+**Acceptance criteria:**
+- Phase 4c opens with the Dry-Run Gate block, clearly labeled
+- `DRY_RUN=true` path: no git commands run, no backlog commands run, exits to Phase 4e
+- `APPLY_MODE=true` path: reads manifest, copies files, proceeds to existing Phase 4c, deletes cache on success
+- Existing `GIT_AUTO` and `BACKLOG_WRITE` logic is untouched and only reached when neither flag is set (or in apply mode after copy)
+
+**Dependencies:** T2, T3, T4, T5
+
+---
+
+## T7 — Add Preview Report to Phase 4e [templates]
+
+**Description:**
+In `templates/commands/implement.md`, add a conditional block at the top of Phase 4e. When `DRY_RUN=true`, display the Preview Report instead of (or before) the standard pipeline table. The Preview Report includes:
+
+- Artifacts Generated table (OpenSpec files + developer files)
+- What Would Change: per-file summary from `.cache-manifest.json` (new file / modified, line delta)
+- Operations Skipped: from `skipped_operations` in `.cache-manifest.json`
+- Next Steps: how to apply (`/implement --apply <name>`) or discard (`rm -rf .claude/.dry-run/<name>/`)
+
+**Files involved:**
+- `templates/commands/implement.md`
+
+**Acceptance criteria:**
+- Phase 4e has a conditional block gated on `DRY_RUN=true`
+- All four sections of the Preview Report are present and formatted as Markdown
+- `--apply` command in Next Steps uses the correct feature name variable
+- Standard report table is still shown for non-dry-run runs
+
+**Dependencies:** T6
+
+---
+
+## T8 — Mirror all changes to `.claude/commands/implement.md` [commands]
+
+**Description:**
+Apply every change from T2–T7 to `.claude/commands/implement.md`. This is the active command in the specrails repo. It must be identical to the template after placeholder substitution — and since this repo has no placeholder variables left unresolved, the template and generated command should match in structure.
+
+**Files involved:**
+- `.claude/commands/implement.md`
+
+**Acceptance criteria:**
+- `.claude/commands/implement.md` contains Flag Detection (Phase 0), cache redirect (Phase 3b), merge redirect (Phase 4a), reviewer path hint (Phase 4b), Dry-Run Gate (Phase 4c), and Preview Report (Phase 4e)
+- The structure and prose are consistent with the template
+- No `{{PLACEHOLDER}}` tokens remain in the generated command
+
+**Dependencies:** T2, T3, T4, T5, T6, T7
+
+---
+
+## T9 — Create `openspec/specs/implement.md` [core]
+
+**Description:**
+Create the missing spec file `openspec/specs/implement.md` documenting the `/implement` command's flags, cache structure, and behavior matrix as described in `delta-spec.md`.
+
+**Files involved:**
+- `openspec/specs/implement.md` (new file)
+
+**Acceptance criteria:**
+- File exists at `openspec/specs/implement.md`
+- Documents `--dry-run`, `--preview`, `--apply` flags
+- Includes the behavior matrix table
+- Describes cache directory structure and `.cache-manifest.json` schema
+
+**Dependencies:** T7
+
+---
+
+## T10 — Manual verification [core]
+
+**Description:**
+After all code tasks complete, manually verify dry-run behavior using a test invocation.
+
+**Verification steps:**
+1. Run `/implement --dry-run "test dry-run feature"` in a test context
+2. Confirm no git operations fire (check `git log` and `git status`)
+3. Confirm `.claude/.dry-run/test-dry-run-feature/` is created with expected files
+4. Confirm preview report appears in Phase 4e output
+5. Run `/implement --apply test-dry-run-feature`
+6. Confirm files are copied to real locations
+7. Confirm `.claude/.dry-run/test-dry-run-feature/` is deleted after successful apply
+8. Confirm `.claude/.dry-run/` does not appear in `git status` (gitignore working)
+
+**Files involved:** none (verification only)
+
+**Acceptance criteria:**
+- All 8 verification steps pass without errors
+
+**Dependencies:** T1, T8, T9

--- a/openspec/changes/archive/2026-03-13-formalize-oss-maintainer/context-bundle.md
+++ b/openspec/changes/archive/2026-03-13-formalize-oss-maintainer/context-bundle.md
@@ -1,0 +1,235 @@
+# Context Bundle: Formalize OSS Maintainer Persona
+
+Everything a developer needs to implement this feature without reading the full codebase.
+
+---
+
+## What You're Building
+
+When a developer runs specrails's installer on an open-source project, the setup wizard should automatically include the Maintainer persona (Kai) in the generated output. Today it doesn't — you have to manually describe "open-source maintainers" as a target user type.
+
+The feature is simple:
+1. Detect 3 OSS signals in `install.sh`, write a JSON file
+2. `/setup` reads that JSON, shows status, asks for confirmation if partial
+3. When OSS confirmed, copy `the-maintainer.md` to the personas output directory
+4. Pass a `{{MAINTAINER_PERSONA_LINE}}` placeholder into the product-manager agent template
+
+---
+
+## Codebase Map (Relevant Files Only)
+
+```
+specrails/
+├── install.sh                              ← Shell installer. MODIFY: add Phase 1.7 OSS detection
+├── commands/
+│   └── setup.md                            ← /setup wizard. MODIFY: Phases 1.4, 2.1, 4.2, 5.3
+├── templates/
+│   ├── agents/
+│   │   └── product-manager.md              ← Agent template. MODIFY: add {{MAINTAINER_PERSONA_LINE}}
+│   └── personas/
+│       ├── persona.md                      ← Generic persona template (don't modify)
+│       └── the-maintainer.md               ← CREATE: copy from .claude/agents/personas/
+└── .claude/
+    └── agents/
+        └── personas/
+            └── the-maintainer.md           ← SOURCE: copy this to templates/personas/
+```
+
+---
+
+## Key Files — Annotated Excerpts
+
+### install.sh structure
+
+```bash
+set -euo pipefail
+# Phase 1: Prerequisites
+# 1.1 git check
+# 1.2 claude check
+# 1.3 npm check
+# 1.4 openspec check
+# 1.5 gh check          ← INSERT 1.7 here, after the HAS_GH block
+# 1.6 jira check
+# Phase 2: Detect existing setup
+# Phase 3: Install artifacts  ← INSERT json write here, after cp templates
+# Phase 4: Summary
+```
+
+The `HAS_GH` variable is set by the end of section 1.5. It is `true` or `false`. Never `unknown` — if `gh` is not installed it's `false`.
+
+Shell conventions in this file:
+- `set -euo pipefail` — all commands must succeed or be explicitly handled
+- `ok()`, `warn()`, `fail()`, `info()` — logging helpers
+- Variable names: `SCREAMING_SNAKE_CASE`
+- Functions use `local` for variables
+- Always quote variable references: `"$VAR"` not `$VAR`
+- File existence checks: `[ -f "$path" ]` and `[ -d "$path" ]`
+
+### install.sh — gh detection block (lines 123–135, for context)
+
+```bash
+# 1.5 GitHub CLI (optional)
+if command -v gh &> /dev/null; then
+    if gh auth status &> /dev/null; then
+        ok "GitHub CLI: authenticated"
+        HAS_GH=true
+    else
+        warn "GitHub CLI installed but not authenticated. Run: gh auth login"
+        HAS_GH=false
+    fi
+else
+    warn "GitHub CLI (gh) not found. GitHub Issues backlog will be unavailable."
+    HAS_GH=false
+fi
+```
+
+Insert Phase 1.7 after line 135, before the JIRA block.
+
+### install.sh — Phase 3 template copy (lines 208–210, for context)
+
+```bash
+# Copy templates
+cp -r "$SCRIPT_DIR/templates/"* "$REPO_ROOT/.claude/setup-templates/"
+ok "Installed setup templates"
+```
+
+Insert the `.oss-detection.json` write after `ok "Installed setup templates"`.
+
+### commands/setup.md — Phase 1.4 (lines 49–77)
+
+The codebase analysis display. Currently ends with `[Confirm] [Modify] [Rescan]`. Add the OSS detection table and conditional prompt before the confirm buttons.
+
+### commands/setup.md — Phase 2.1 (lines 85–99)
+
+The user persona prompt. Add a conditional notice at the top when `IS_OSS=true`.
+
+### commands/setup.md — Phase 4.2 (lines 382–388)
+
+Currently:
+```markdown
+### 4.2 Generate personas
+
+Write each persona to `.claude/agents/personas/`:
+- Use the VPC personas generated in Phase 2
+- File naming: kebab-case of persona nickname
+```
+
+Add the conditional Maintainer copy step before the existing persona generation.
+
+### commands/setup.md — Phase 5.3 (lines 534–583)
+
+The summary table. Add a "Source" column and the Maintainer row.
+
+### templates/agents/product-manager.md — Persona section (lines 44–48)
+
+```markdown
+You have {{PERSONA_COUNT}} primary personas defined in `.claude/agents/personas/`. **Always read these files** at the start of any exploration session:
+
+{{PERSONA_FILE_LIST}}
+```
+
+Add `{{MAINTAINER_PERSONA_LINE}}` on a new line after `{{PERSONA_FILE_LIST}}`.
+
+---
+
+## The Maintainer Persona (Summary)
+
+File: `.claude/agents/personas/the-maintainer.md`
+
+- **Name**: "Kai" — The Maintainer
+- **Role**: Open-source maintainer, often solo or with 1-3 co-maintainers
+- **Critical pain**: "Eternal September" — AI floods maintainers with low-quality PRs
+- **Key gain**: AI reviewer that enforces project-specific conventions
+- **Key insight**: OSS maintainers don't need AI to write code — they need AI that understands their project deeply enough to review contributions and enforce conventions
+
+Do not modify this file. Copy it verbatim.
+
+---
+
+## OSS Detection Logic
+
+Three signals, all must be true:
+
+```
+public_repo  = (gh repo view --json isPrivate --jq '.isPrivate') == "false"
+has_ci       = ls .github/workflows/*.yml succeeds (at least one file)
+has_contributing = test -f CONTRIBUTING.md || test -f .github/CONTRIBUTING.md
+```
+
+**Why all three?** Requiring all three minimizes false positives. A private enterprise repo might have CI and CONTRIBUTING.md. A public toy project might have no CI. Only an actively maintained OSS project is likely to have all three.
+
+**Graceful degradation**: If `gh` is unavailable or unauthenticated, skip detection entirely. Don't fail. Prompt the user manually in Phase 1.4.
+
+---
+
+## Template Substitution Rules
+
+When populating `{{MAINTAINER_PERSONA_LINE}}`:
+
+| Condition | Value |
+|-----------|-------|
+| `IS_OSS=true` | `- \`.claude/agents/personas/the-maintainer.md\` — "Kai" the Maintainer (open-source maintainer)` |
+| `IS_OSS=false` | *(empty string — omit the line entirely)* |
+
+When populating `{{PERSONA_COUNT}}`:
+- Count = user-generated personas + (1 if `IS_OSS=true`, else 0)
+
+---
+
+## .oss-detection.json Schema
+
+Written by `install.sh` to `.claude/setup-templates/.oss-detection.json`:
+
+```json
+{
+  "is_oss": true,
+  "signals": {
+    "public_repo": true,
+    "has_ci": true,
+    "has_contributing": true
+  }
+}
+```
+
+- Booleans are lowercase (`true`/`false`), not shell strings
+- This file is temporary — it is deleted by Phase 5.1 (`rm -rf .claude/setup-templates/`)
+- If the file does not exist, `/setup` must prompt the user manually
+
+---
+
+## Things That Must NOT Change
+
+1. The Maintainer persona file content — copy verbatim, no substitutions
+2. The VPC scoring framework in the product-manager template — already handles all personas
+3. The other persona templates (`the-lead-dev.md`, `the-product-founder.md`)
+4. Any agent templates other than `product-manager.md`
+5. The behavior of setup when `IS_OSS=false` — must be identical to today
+
+---
+
+## Manual Verification Steps
+
+After implementing:
+
+1. Run `shellcheck install.sh` — must pass with no errors
+2. Check `templates/personas/the-maintainer.md` matches `.claude/agents/personas/the-maintainer.md`:
+   ```bash
+   diff templates/personas/the-maintainer.md .claude/agents/personas/the-maintainer.md
+   ```
+   Should produce no output.
+3. Check for broken placeholders in product-manager template:
+   ```bash
+   grep '{{MAINTAINER_PERSONA_LINE}}' templates/agents/product-manager.md
+   ```
+   Should find exactly one match.
+4. Simulate `IS_OSS=false` path by reading `commands/setup.md` Phase 4.2 — confirm no Maintainer persona is written.
+5. Simulate `IS_OSS=true` path — confirm `the-maintainer.md` copy step is present in Phase 4.2.
+
+---
+
+## Common Pitfalls
+
+- **Shell glob failure**: `ls .github/workflows/*.yml` will fail (exit 1) if no files match when `set -e` is active. Use `ls .github/workflows/*.yml &>/dev/null 2>&1` or redirect both stdout and stderr, and wrap in `if ... ; then`.
+- **Boolean in heredoc**: Shell `true`/`false` are commands, not JSON booleans. Use the variable's string value directly in the heredoc, but set variables as strings: `IS_OSS="true"` or `IS_OSS="false"` so they interpolate correctly.
+- **Empty `{{MAINTAINER_PERSONA_LINE}}`**: When the placeholder substitutes to an empty string, there should be no trailing blank line left in the generated file. The `/setup` generation logic should strip the empty line.
+- **Persona count off-by-one**: Increment `PERSONA_COUNT` before using it in the template substitution, not after.

--- a/openspec/changes/archive/2026-03-13-formalize-oss-maintainer/delta-spec.md
+++ b/openspec/changes/archive/2026-03-13-formalize-oss-maintainer/delta-spec.md
@@ -1,0 +1,206 @@
+# Delta Spec: Formalize OSS Maintainer Persona
+
+This document describes the precise spec changes required to implement the OSS Maintainer auto-detection feature. It is written as a diff against current behavior — "before" describes what exists today, "after" describes the target state.
+
+---
+
+## 1. install.sh — OSS Detection Phase
+
+### Before
+
+`install.sh` has five prerequisite checks (git, claude, npm, openspec, gh) and two main phases (detect existing setup, install artifacts). No OSS detection.
+
+### After
+
+Add a new detection block between the GitHub CLI check (1.5) and the JIRA CLI check (1.6). The block is skipped gracefully if `HAS_GH=false`.
+
+**New variables set by this block:**
+
+```
+IS_OSS: bool        — true if all three signals detected
+HAS_PUBLIC_REPO: bool — repo is not private (via gh)
+HAS_CI: bool         — .github/workflows/*.yml exists
+HAS_CONTRIBUTING: bool — CONTRIBUTING.md exists at root or .github/
+```
+
+**New output file written:**
+
+```
+$REPO_ROOT/.claude/setup-templates/.oss-detection.json
+```
+
+Schema:
+```json
+{
+  "is_oss": true | false,
+  "signals": {
+    "public_repo": true | false,
+    "has_ci": true | false,
+    "has_contributing": true | false
+  }
+}
+```
+
+**New console output (when detected):**
+
+```
+  ✓ OSS project detected (public repo + CI + CONTRIBUTING.md)
+```
+
+**New console output (when not detected, gh available):**
+
+```
+  → OSS signals: public_repo=false ci=true contributing=true — not auto-detected
+```
+
+**New console output (when gh unavailable):**
+
+No output — detection is silently skipped.
+
+---
+
+## 2. commands/setup.md — Phase 1.4 Additions
+
+### Before
+
+Phase 1.4 displays codebase analysis (layers, CI commands, conventions) and waits for `[Confirm] [Modify] [Rescan]`.
+
+### After
+
+Phase 1.4 additionally reads `.claude/setup-templates/.oss-detection.json` (if it exists) and appends an OSS status section to the codebase analysis display:
+
+```
+### OSS Project Detection
+| Signal | Status |
+|--------|--------|
+| Public repository | Yes / No / Unknown |
+| CI workflows (.github/workflows/) | Yes / No |
+| CONTRIBUTING.md | Yes / No |
+| **Auto-detected as OSS** | **Yes / No** |
+```
+
+If `is_oss: false` but at least one signal is `true`, add a prompt:
+
+> "OSS signals were found but not all three are present. Is this an open-source project? (yes/no)"
+> If yes, set `IS_OSS=true` for the rest of setup.
+
+If `.oss-detection.json` does not exist (installer did not run or gh was unavailable), add a prompt:
+
+> "Is this an open-source project? (yes/no)"
+
+---
+
+## 3. commands/setup.md — Phase 2 Additions
+
+### Before
+
+Phase 2.1 asks: "Who are the target users of your software?" and the user lists all personas to generate.
+
+### After
+
+If `IS_OSS=true`, prepend the following to the Phase 2.1 prompt:
+
+> "This is an OSS project. The **Maintainer** persona (Kai) is automatically included — you do not need to add 'open-source maintainers' to your list. Describe your other target user types."
+
+If `IS_OSS=false`, behavior is unchanged.
+
+---
+
+## 4. commands/setup.md — Phase 4.2 Additions
+
+### Before
+
+Phase 4.2 generates persona files from the VPC personas created in Phase 2.3.
+
+### After
+
+If `IS_OSS=true`, add a step before generating user-defined personas:
+
+1. Copy `setup-templates/personas/the-maintainer.md` to `.claude/agents/personas/the-maintainer.md`
+2. Log: `ok "Maintainer persona included (the-maintainer.md)"`
+3. Increment persona count for the summary table
+
+This copy step uses the pre-authored persona file — no template substitution is performed on it.
+
+---
+
+## 5. commands/setup.md — Phase 5.3 Summary Table
+
+### Before
+
+Summary table for Personas:
+```
+### Personas Created
+| Persona | File |
+|---------|------|
+| "[Name]" — The [Role] | .claude/agents/personas/[name].md |
+```
+
+### After
+
+If `IS_OSS=true`, add the Maintainer row (always at the top, before user-generated personas):
+```
+### Personas Created
+| Persona | File | Source |
+|---------|------|--------|
+| "Kai" — The Maintainer | .claude/agents/personas/the-maintainer.md | Auto-included (OSS) |
+| "[Name]" — The [Role] | .claude/agents/personas/[name].md | Generated |
+```
+
+---
+
+## 6. templates/agents/product-manager.md — Placeholder Addition
+
+### Before
+
+```markdown
+You have {{PERSONA_COUNT}} primary personas defined in `.claude/agents/personas/`. **Always read these files** at the start of any exploration session:
+
+{{PERSONA_FILE_LIST}}
+```
+
+### After
+
+```markdown
+You have {{PERSONA_COUNT}} primary personas defined in `.claude/agents/personas/`. **Always read these files** at the start of any exploration session:
+
+{{PERSONA_FILE_LIST}}
+{{MAINTAINER_PERSONA_LINE}}
+```
+
+**Substitution rules:**
+
+| Condition | `{{MAINTAINER_PERSONA_LINE}}` value |
+|-----------|-------------------------------------|
+| `IS_OSS=true` | `- \`.claude/agents/personas/the-maintainer.md\` — "Kai" the Maintainer (open-source maintainer)` |
+| `IS_OSS=false` | *(empty string — line omitted)* |
+
+`{{PERSONA_COUNT}}` increments by 1 when `IS_OSS=true`.
+
+---
+
+## 7. templates/personas/the-maintainer.md — New Template Source File
+
+### Before
+
+The Maintainer persona exists only at `.claude/agents/personas/the-maintainer.md` (specrails's own setup, not a template source).
+
+### After
+
+A copy of the persona is placed at `templates/personas/the-maintainer.md`. This is the authoritative source that `install.sh` copies to target repos during setup.
+
+The file content is identical to `.claude/agents/personas/the-maintainer.md` — it is a pre-authored file, not a template with `{{PLACEHOLDER}}` syntax.
+
+**Note**: The existing `.claude/agents/personas/the-maintainer.md` remains as specrails's own generated persona (specrails is its own OSS project and will auto-detect itself).
+
+---
+
+## Invariants
+
+These things must remain true after the change:
+
+1. If `IS_OSS=false`, setup behavior is identical to today
+2. The Maintainer persona file content is never modified by setup — it is always copied verbatim
+3. The `.oss-detection.json` file is always cleaned up by Phase 5.1
+4. No new required prerequisites — OSS detection degrades gracefully when `gh` is unavailable
+5. A user who manually adds `the-maintainer.md` after setup gets no errors — the agent reads all files in the directory dynamically

--- a/openspec/changes/archive/2026-03-13-formalize-oss-maintainer/design.md
+++ b/openspec/changes/archive/2026-03-13-formalize-oss-maintainer/design.md
@@ -1,0 +1,175 @@
+# Design: Formalize OSS Maintainer Persona
+
+## Overview
+
+This change adds OSS auto-detection to the specrails setup flow, resulting in the Maintainer persona (`the-maintainer.md`) being automatically included when OSS signals are detected. The change touches three layers: the shell installer (`install.sh`), the setup command (`commands/setup.md`), and the product-manager agent template (`templates/agents/product-manager.md`).
+
+---
+
+## Detection Architecture
+
+### Signal Set
+
+Three boolean signals constitute "OSS project":
+
+| Signal | How to detect | Fallback if unavailable |
+|--------|---------------|------------------------|
+| Public repo | `gh repo view --json isPrivate --jq '.isPrivate'` returns `false` | Ask user |
+| CI present | `ls .github/workflows/*.yml 2>/dev/null` has results | Check for `.travis.yml`, `circle.yml`, `Makefile` with `test:` target |
+| CONTRIBUTING.md | `test -f CONTRIBUTING.md || test -f .github/CONTRIBUTING.md` | None — absence is meaningful |
+
+All three signals must be `true` for auto-detection to trigger. Partial signal sets prompt the user instead of auto-detecting. This avoids false positives (e.g., a private enterprise repo that happens to have CONTRIBUTING.md).
+
+### Detection in `install.sh`
+
+`install.sh` already checks for `gh` CLI (Phase 1.5). Extend Phase 1 with a new **Phase 1.7: OSS Detection** block that runs after the `gh` check:
+
+```bash
+# 1.7 OSS detection (best-effort, requires gh auth)
+IS_OSS=false
+
+if [ "$HAS_GH" = true ]; then
+    REPO_PRIVATE=$(gh repo view --json isPrivate --jq '.isPrivate' 2>/dev/null || echo "unknown")
+    HAS_CI=false
+    if ls "$REPO_ROOT/.github/workflows/"*.yml &>/dev/null; then
+        HAS_CI=true
+    fi
+    HAS_CONTRIBUTING=false
+    if [ -f "$REPO_ROOT/CONTRIBUTING.md" ] || [ -f "$REPO_ROOT/.github/CONTRIBUTING.md" ]; then
+        HAS_CONTRIBUTING=true
+    fi
+
+    if [ "$REPO_PRIVATE" = "false" ] && [ "$HAS_CI" = true ] && [ "$HAS_CONTRIBUTING" = true ]; then
+        IS_OSS=true
+        ok "OSS project detected (public repo + CI + CONTRIBUTING.md)"
+    fi
+fi
+```
+
+Then write a detection results file that `/setup` reads later:
+
+```bash
+# Write OSS detection results for /setup to consume
+cat > "$REPO_ROOT/.claude/setup-templates/.oss-detection.json" <<EOF
+{
+  "is_oss": $IS_OSS,
+  "signals": {
+    "public_repo": $([ "$REPO_PRIVATE" = "false" ] && echo "true" || echo "false"),
+    "has_ci": $HAS_CI,
+    "has_contributing": $HAS_CONTRIBUTING
+  }
+}
+EOF
+```
+
+The file is written to `setup-templates/` because that directory is already treated as temporary scaffolding — it gets cleaned up in Phase 5 of `/setup`.
+
+### Detection in `commands/setup.md`
+
+In Phase 1.4 (Present findings), after displaying the codebase analysis, the wizard reads `.claude/setup-templates/.oss-detection.json` and reports the OSS status:
+
+```
+### OSS Project Detection
+- Public repo: Yes / No / Unknown (gh not available)
+- CI workflows: Yes / No
+- CONTRIBUTING.md: Yes / No
+- **Result: OSS project detected — Maintainer persona will be included**
+```
+
+If not auto-detected but the user believes this is an OSS project, they can confirm during the "Confirm / Modify" step.
+
+In Phase 2 (User Personas), after the user describes their target users:
+
+> If `is_oss: true` (from detection or user confirmation), prepend the following instruction before persona generation:
+> "This is an OSS project. The Maintainer persona (`the-maintainer.md`) will be included automatically. You do not need to describe 'OSS maintainers' as a user type — Kai is already included."
+
+In Phase 4.2 (Generate personas), add a conditional step:
+
+> If `IS_OSS=true`, copy `setup-templates/personas/the-maintainer.md` to `.claude/agents/personas/the-maintainer.md` without modification. This is not a generated file — it is a pre-authored persona that ships with specrails.
+
+---
+
+## Template Changes
+
+### `templates/agents/product-manager.md`
+
+The `{{PERSONA_FILE_LIST}}` placeholder currently gets populated during `/setup` with whatever personas were generated. The Maintainer is already listed in the specrails-specific product-manager agent (`.claude/agents/product-manager.md`), but this is hardcoded rather than driven by the template.
+
+**Change**: Add a `{{MAINTAINER_PERSONA_LINE}}` placeholder that is conditionally included when `IS_OSS=true`.
+
+Current section in template:
+```
+You have {{PERSONA_COUNT}} primary personas defined in `.claude/agents/personas/`. **Always read these files** at the start of any exploration session:
+
+{{PERSONA_FILE_LIST}}
+```
+
+Updated section:
+```
+You have {{PERSONA_COUNT}} primary personas defined in `.claude/agents/personas/`. **Always read these files** at the start of any exploration session:
+
+{{PERSONA_FILE_LIST}}
+{{MAINTAINER_PERSONA_LINE}}
+```
+
+When `IS_OSS=true`, `{{MAINTAINER_PERSONA_LINE}}` resolves to:
+```
+- `.claude/agents/personas/the-maintainer.md` — "Kai" the Maintainer (open-source maintainer)
+```
+
+When `IS_OSS=false`, `{{MAINTAINER_PERSONA_LINE}}` resolves to an empty string.
+
+`{{PERSONA_COUNT}}` is incremented by 1 when the Maintainer is included.
+
+`{{PERSONA_SCORE_FORMAT}}` (used in VPC scoring lines) is already `PersonaName: X/5` format — no change needed. When the Maintainer persona is present, the agent will naturally include "Kai: X/5" because the agent reads all files in `.claude/agents/personas/`.
+
+---
+
+## File Change Summary
+
+| File | Change type | Description |
+|------|-------------|-------------|
+| `install.sh` | Modify | Add Phase 1.7 OSS detection block; write `.oss-detection.json` |
+| `commands/setup.md` | Modify | Read detection results in Phase 1.4; conditional persona inclusion in Phase 2 and 4.2 |
+| `templates/agents/product-manager.md` | Modify | Add `{{MAINTAINER_PERSONA_LINE}}` placeholder |
+| `templates/personas/the-maintainer.md` | New file | Copy of `.claude/agents/personas/the-maintainer.md` for use as a template source |
+
+Note: `.claude/agents/personas/the-maintainer.md` is the persona in specrails's own generated setup. It must also exist as a source template at `templates/personas/the-maintainer.md` so that install.sh can copy it to target repos.
+
+---
+
+## Integration Points
+
+### install.sh → /setup handoff
+
+The `.oss-detection.json` file is the handoff mechanism. `install.sh` writes it; `/setup` reads it. This avoids running `gh` commands twice and keeps the detection logic in one place (the shell script).
+
+### /setup → product-manager agent
+
+The product-manager agent does not need to change at runtime — it reads all persona files from `.claude/agents/personas/` dynamically. The presence of `the-maintainer.md` in that directory is sufficient for the agent to include Kai in VPC scoring.
+
+### Cleanup
+
+`.oss-detection.json` is inside `setup-templates/` which is already deleted in Phase 5.1 (`rm -rf .claude/setup-templates/`). No additional cleanup needed.
+
+---
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| `gh` not available | OSS detection skipped; user can manually confirm OSS during Phase 1.4 |
+| `gh` available but not authenticated | Same as above — `gh repo view` will fail, `is_oss` stays `false` |
+| Public repo but no CI | Partial signal — not auto-detected; user prompted |
+| Public repo + CI but no CONTRIBUTING.md | Partial signal — not auto-detected; user prompted |
+| Private repo that happens to have CONTRIBUTING.md | Not detected as OSS (public repo signal is false) |
+| User manually adds Maintainer persona after setup | Works fine — the agent reads all files in the directory |
+
+---
+
+## What Does NOT Change
+
+- The Maintainer persona content (`the-maintainer.md`) — it is already complete and well-sourced
+- The VPC scoring framework in the product-manager agent — it already covers all personas present
+- The `PERSONA_SCORE_FORMAT` placeholder — it already produces per-persona scores
+- Any other agent (architect, developer, reviewer) — they don't reference personas directly

--- a/openspec/changes/archive/2026-03-13-formalize-oss-maintainer/proposal.md
+++ b/openspec/changes/archive/2026-03-13-formalize-oss-maintainer/proposal.md
@@ -1,0 +1,47 @@
+# Proposal: Formalize OSS Maintainer Persona
+
+## Problem
+
+specrails ships with a high-quality Maintainer persona (`the-maintainer.md`) that captures the open-source maintainer's jobs, pains, and gains in detail. However, the `/setup` wizard treats this persona the same as any other — it only appears if the user describes "open-source maintainers" as their target users.
+
+For OSS projects, the Maintainer is always a relevant persona. When a developer runs `/setup` in a public repo with CI and a CONTRIBUTING.md, they are almost certainly an open-source maintainer — or they have maintainers among their users. Not surfacing the Maintainer persona automatically means:
+
+1. VPC feature scoring misses the Maintainer perspective on every feature evaluation
+2. The product-manager agent may not include Kai's constraints when scoring trade-offs
+3. Users who *are* OSS maintainers get no acknowledgement of their specific context
+
+## Solution
+
+Auto-detect OSS projects during `/setup` Phase 1 using three lightweight signals:
+
+1. **Public repo**: `gh repo view --json isPrivate` returns `false`
+2. **CI enabled**: `.github/workflows/` contains at least one `.yml` file
+3. **CONTRIBUTING.md present**: file exists at repo root or `.github/CONTRIBUTING.md`
+
+When all three signals are detected (or the user confirms they run an OSS project), automatically include the Maintainer persona in the setup output. The product-manager agent template already references the Maintainer persona file — this feature ensures it exists in the generated output.
+
+## Scope
+
+**In scope:**
+- OSS detection logic in `install.sh` (detect signals, write a flag file)
+- OSS detection in `/setup` Phase 1 (read signals, present to user for confirmation)
+- Conditional persona inclusion in Phase 2 / Phase 4.2 (add `the-maintainer.md` when OSS flag is set)
+- Update `commands/setup.md` to document the detection logic and conditional path
+- Add a `{{MAINTAINER_PERSONA_LINE}}` placeholder to `templates/agents/product-manager.md` so generated product-manager agents always list the Maintainer when the persona is present
+
+**Out of scope:**
+- Changing the Maintainer persona content (it's already high quality)
+- Supporting non-GitHub forges (GitLab, Bitbucket) — GitHub is the only supported backlog provider today
+- Auto-detection with fewer than all three signals (partial signal = ask the user)
+
+## Non-goals
+
+- Do not change how other personas are generated
+- Do not add a new "OSS mode" configuration toggle — the persona inclusion is the only behavioral change
+- Do not modify CI detection logic beyond checking for `.github/workflows/*.yml` existence
+
+## Product Motivation
+
+OSS maintainers are the users with the **highest potential for word-of-mouth distribution**. They are also the persona with the most acute pains around contribution quality and review burden — the exact problems specrails solves. Getting the Maintainer perspective into VPC scoring automatically increases the relevance of every product discovery session for OSS projects.
+
+This is a **Low effort** change: the persona already exists, the product-manager agent already references it. We're adding three detection signals and one conditional file-copy step.

--- a/openspec/changes/archive/2026-03-13-formalize-oss-maintainer/tasks.md
+++ b/openspec/changes/archive/2026-03-13-formalize-oss-maintainer/tasks.md
@@ -1,0 +1,293 @@
+# Tasks: Formalize OSS Maintainer Persona
+
+All tasks are ordered by dependency. A task may only begin when all tasks it depends on are complete.
+
+Estimated total effort: **Low** (2-3 hours)
+
+---
+
+## Task 1: Copy Maintainer persona to templates/ [templates]
+
+**Title**: Add `the-maintainer.md` as a source template
+
+**Description**:
+The Maintainer persona currently exists at `.claude/agents/personas/the-maintainer.md` (specrails's own generated persona). It needs to also exist at `templates/personas/the-maintainer.md` so that `install.sh` can copy it to target repos.
+
+Create `templates/personas/the-maintainer.md` with identical content to `.claude/agents/personas/the-maintainer.md`. This is not a template with `{{PLACEHOLDER}}` syntax — it is a pre-authored file.
+
+**Files involved:**
+- `templates/personas/the-maintainer.md` — create (copy from `.claude/agents/personas/the-maintainer.md`)
+
+**Acceptance criteria:**
+- `templates/personas/the-maintainer.md` exists
+- Content is byte-for-byte identical to `.claude/agents/personas/the-maintainer.md`
+- No `{{PLACEHOLDER}}` markers present (it is not a parameterized template)
+- `grep -r '{{' templates/personas/the-maintainer.md` returns nothing
+
+**Dependencies:** None
+
+---
+
+## Task 2: Add `{{MAINTAINER_PERSONA_LINE}}` to product-manager template [templates]
+
+**Title**: Make Maintainer persona line conditional in product-manager template
+
+**Description**:
+The `templates/agents/product-manager.md` template has a `{{PERSONA_FILE_LIST}}` placeholder that gets populated with the user-generated personas. Add a `{{MAINTAINER_PERSONA_LINE}}` placeholder immediately after it so `/setup` can conditionally append the Maintainer persona reference.
+
+**Files involved:**
+- `templates/agents/product-manager.md` — modify (add placeholder)
+
+**Change**:
+
+Find this block:
+```
+You have {{PERSONA_COUNT}} primary personas defined in `.claude/agents/personas/`. **Always read these files** at the start of any exploration session:
+
+{{PERSONA_FILE_LIST}}
+```
+
+Replace with:
+```
+You have {{PERSONA_COUNT}} primary personas defined in `.claude/agents/personas/`. **Always read these files** at the start of any exploration session:
+
+{{PERSONA_FILE_LIST}}
+{{MAINTAINER_PERSONA_LINE}}
+```
+
+Also update both occurrences of `{{PERSONA_SCORE_FORMAT}}` in the VPC evaluation sections to include "Kai" as a named slot comment. The existing format `PersonaName: X/5` already works — no change to format string needed.
+
+**Acceptance criteria:**
+- `{{MAINTAINER_PERSONA_LINE}}` appears exactly once in the template, after `{{PERSONA_FILE_LIST}}`
+- No other content changes are made to the template
+- Template still renders correctly when `{{MAINTAINER_PERSONA_LINE}}` is substituted with an empty string
+
+**Dependencies:** None (parallel with Task 1)
+
+---
+
+## Task 3: Add OSS detection block to `install.sh` [shell]
+
+**Title**: Detect OSS signals in installer and write detection results
+
+**Description**:
+Add Phase 1.7 to `install.sh` after the GitHub CLI check (section 1.5, around line 135). The block detects three OSS signals and writes a `.oss-detection.json` file to the setup-templates directory.
+
+**Files involved:**
+- `install.sh` — modify
+
+**New code to add** (after the `HAS_GH` block, before the JIRA CLI check at line 137):
+
+```bash
+# 1.7 OSS detection (requires gh auth; degrades gracefully)
+IS_OSS=false
+HAS_PUBLIC_REPO=false
+HAS_CI=false
+HAS_CONTRIBUTING=false
+
+if [ "$HAS_GH" = true ]; then
+    _REPO_PRIVATE=$(gh repo view --json isPrivate --jq '.isPrivate' 2>/dev/null || echo "unknown")
+    if [ "$_REPO_PRIVATE" = "false" ]; then
+        HAS_PUBLIC_REPO=true
+    fi
+    if ls "$REPO_ROOT/.github/workflows/"*.yml &>/dev/null 2>&1; then
+        HAS_CI=true
+    fi
+    if [ -f "$REPO_ROOT/CONTRIBUTING.md" ] || [ -f "$REPO_ROOT/.github/CONTRIBUTING.md" ]; then
+        HAS_CONTRIBUTING=true
+    fi
+    if [ "$HAS_PUBLIC_REPO" = true ] && [ "$HAS_CI" = true ] && [ "$HAS_CONTRIBUTING" = true ]; then
+        IS_OSS=true
+        ok "OSS project detected (public repo + CI + CONTRIBUTING.md)"
+    fi
+fi
+```
+
+Then write the detection results to `.oss-detection.json` at the end of Phase 3 (after the templates are copied, so the directory exists):
+
+```bash
+# Write OSS detection results for /setup
+cat > "$REPO_ROOT/.claude/setup-templates/.oss-detection.json" << EOF
+{
+  "is_oss": $IS_OSS,
+  "signals": {
+    "public_repo": $HAS_PUBLIC_REPO,
+    "has_ci": $HAS_CI,
+    "has_contributing": $HAS_CONTRIBUTING
+  }
+}
+EOF
+```
+
+Add this write block right after the `cp -r "$SCRIPT_DIR/templates/"*` line (around line 209) with an `ok` log:
+
+```bash
+ok "OSS detection results written"
+```
+
+**Acceptance criteria:**
+- `set -euo pipefail` is still respected — all variable references are quoted, all commands degrade gracefully
+- When `HAS_GH=false`, block is skipped entirely, `IS_OSS=false`
+- When `gh repo view` fails (e.g., not in a remote repo), `IS_OSS` stays `false` (no `set -e` failure)
+- When all three signals detected: `ok "OSS project detected..."` is printed
+- `.oss-detection.json` is written with correct boolean values (lowercase `true`/`false`, not shell `true`/`false`)
+- `shellcheck install.sh` passes with no errors
+
+**Dependencies:** None (parallel with Tasks 1 and 2)
+
+---
+
+## Task 4: Update `/setup` Phase 1.4 — display OSS detection results [templates]
+
+**Title**: Show OSS detection status in codebase analysis output
+
+**Description**:
+Update `commands/setup.md` Phase 1.4 to read `.oss-detection.json` and display a detection status table alongside the codebase analysis. Add a manual confirmation prompt for edge cases where detection was incomplete.
+
+**Files involved:**
+- `commands/setup.md` — modify Phase 1.4
+
+**Changes to Phase 1.4 display block:**
+
+After the existing architecture table and before `[Confirm] [Modify] [Rescan]`, add:
+
+```
+### OSS Project Detection
+
+Read `.claude/setup-templates/.oss-detection.json` if it exists.
+
+| Signal | Status |
+|--------|--------|
+| Public repository | [Yes / No / Unknown] |
+| CI workflows (.github/workflows/) | [Yes / No] |
+| CONTRIBUTING.md | [Yes / No] |
+| **Result** | **OSS detected / Not detected / Could not check** |
+```
+
+If `is_oss: false` but at least one signal is `true`:
+> "Some OSS signals were found but not all three. Is this an open-source project? (yes/no)"
+
+If `.oss-detection.json` does not exist:
+> "Is this an open-source project? (yes/no)"
+
+Store the final OSS determination as `IS_OSS` for use throughout the rest of setup.
+
+**Acceptance criteria:**
+- Detection results are shown in Phase 1.4 output
+- Manual confirmation prompt appears when detection is partial or unavailable
+- `IS_OSS` is set correctly before Phase 2 begins
+- When `IS_OSS=false` and no signals present, no OSS-related output is shown (don't clutter the output for non-OSS projects)
+
+**Dependencies:** Task 3 (needs the .json file format to be defined)
+
+---
+
+## Task 5: Update `/setup` Phase 2.1 — conditional Maintainer mention [templates]
+
+**Title**: Inform user that Maintainer persona is auto-included for OSS projects
+
+**Description**:
+Update `commands/setup.md` Phase 2.1 to prepend a notice when `IS_OSS=true`, telling the user they do not need to describe open-source maintainers as a persona.
+
+**Files involved:**
+- `commands/setup.md` — modify Phase 2.1
+
+**Change**: At the beginning of the Phase 2.1 user prompt, add:
+
+```
+> If IS_OSS=true, prepend:
+> "This is an OSS project. The **Maintainer** persona (Kai) is automatically included —
+> you do not need to add 'open-source maintainers' to your list.
+> Describe your other target user types below."
+```
+
+**Acceptance criteria:**
+- Notice only appears when `IS_OSS=true`
+- No change to Phase 2.1 when `IS_OSS=false`
+- The phrase "Maintainer persona (Kai) is automatically included" appears in the output
+
+**Dependencies:** Task 4 (needs `IS_OSS` to be defined)
+
+---
+
+## Task 6: Update `/setup` Phase 4.2 — copy Maintainer persona file [templates]
+
+**Title**: Conditionally include Maintainer persona in generated output
+
+**Description**:
+Update `commands/setup.md` Phase 4.2 to copy `the-maintainer.md` from setup-templates to `.claude/agents/personas/` when `IS_OSS=true`. This step must run before user-defined personas are written so the count is correct.
+
+**Files involved:**
+- `commands/setup.md` — modify Phase 4.2
+
+**Add the following step at the start of Phase 4.2:**
+
+```
+### 4.2 Generate personas
+
+If IS_OSS=true:
+1. Copy `setup-templates/personas/the-maintainer.md` to `.claude/agents/personas/the-maintainer.md`
+2. Log: "Maintainer persona included"
+3. Set MAINTAINER_INCLUDED=true for use in template substitution
+
+Then for each user-defined VPC persona from Phase 2.3:
+[existing persona generation logic unchanged]
+```
+
+**Template substitution values to set:**
+- `IS_OSS=true`: `{{MAINTAINER_PERSONA_LINE}}` = `- \`.claude/agents/personas/the-maintainer.md\` — "Kai" the Maintainer (open-source maintainer)`
+- `IS_OSS=true`: `{{PERSONA_COUNT}}` += 1
+
+**Acceptance criteria:**
+- When `IS_OSS=true`: `.claude/agents/personas/the-maintainer.md` exists after Phase 4.2
+- File content matches `setup-templates/personas/the-maintainer.md` exactly (no substitution)
+- `{{MAINTAINER_PERSONA_LINE}}` in product-manager agent output contains the Maintainer file path
+- `{{PERSONA_COUNT}}` reflects the correct total (user personas + 1 for Maintainer)
+- When `IS_OSS=false`: no `the-maintainer.md` is written, `{{MAINTAINER_PERSONA_LINE}}` is empty string
+
+**Dependencies:** Tasks 1, 2, 5
+
+---
+
+## Task 7: Update `/setup` Phase 5.3 — summary table [templates]
+
+**Title**: Include Maintainer in the setup completion summary
+
+**Description**:
+Update the summary table in Phase 5.3 to show the Maintainer persona as "Auto-included (OSS)" when present, distinguishing it from user-generated personas.
+
+**Files involved:**
+- `commands/setup.md` — modify Phase 5.3 summary section
+
+**Change**: Modify the Personas Created table:
+
+```
+### Personas Created
+| Persona | File | Source |
+|---------|------|--------|
+[If IS_OSS=true:]
+| "Kai" — The Maintainer | .claude/agents/personas/the-maintainer.md | Auto-included (OSS) |
+[For each user-generated persona:]
+| "[Name]" — The [Role] | .claude/agents/personas/[name].md | Generated |
+```
+
+**Acceptance criteria:**
+- Maintainer row appears at the top of the table when `IS_OSS=true`
+- "Auto-included (OSS)" appears in the Source column for the Maintainer
+- When `IS_OSS=false`, table is unchanged from today
+- Persona count in summary header is correct
+
+**Dependencies:** Task 6
+
+---
+
+## Task Order Summary
+
+```
+Task 1 (templates/personas/the-maintainer.md) ─┐
+Task 2 (product-manager template placeholder)  ─┼─→ Task 6 → Task 7
+Task 3 (install.sh detection) ─────────────────┘
+                               └─→ Task 4 → Task 5 ─┘
+```
+
+Tasks 1, 2, 3 can be done in parallel. Tasks 4, 5, 6, 7 must be sequential.

--- a/openspec/changes/archive/2026-03-13-security-reviewer-agent/context-bundle.md
+++ b/openspec/changes/archive/2026-03-13-security-reviewer-agent/context-bundle.md
@@ -1,0 +1,367 @@
+---
+change: security-reviewer-agent
+type: context-bundle
+---
+
+# Context Bundle: Security & Secrets Reviewer Agent
+
+This document contains everything a developer needs to implement this change without reading any other file. It bundles the key context from the design, delta-spec, and codebase exploration.
+
+---
+
+## What You Are Building
+
+A new Claude Code agent called `security-reviewer` that:
+1. Scans modified files for hardcoded secrets and OWASP vulnerability patterns
+2. Reports findings by severity (Critical/High/Medium/Info)
+3. Produces a structured report ending with a machine-readable `SECURITY_STATUS:` line
+4. Integrates into Phase 4b of the implement pipeline and **blocks Phase 4c if Critical findings exist**
+5. Supports per-project exemptions via `.claude/security-exemptions.yaml`
+
+The agent is a **markdown prompt file** — no shell scripts, no external tool dependencies. All scanning happens through Claude's code analysis.
+
+---
+
+## Codebase Patterns to Follow
+
+### Agent file structure
+
+All agents follow this pattern. Study `templates/agents/reviewer.md` for the template version and `.claude/agents/reviewer.md` for the generated version.
+
+**Template file** (`templates/agents/*.md`): Uses `{{PLACEHOLDER}}` for values that vary per target repo.
+
+**Generated file** (`.claude/agents/*.md`): Same content with placeholders substituted. For specrails' own use.
+
+YAML frontmatter required fields:
+```yaml
+---
+name: <kebab-case-name>
+description: "Multi-line string with usage examples"
+model: sonnet
+color: <color-name>
+memory: project
+---
+```
+
+Colors used by existing agents: `red` (reviewer), `purple` (developer), `orange` is available and appropriate for security.
+
+### Memory pattern
+
+Every agent has a memory directory. Create an initial empty `MEMORY.md` file at:
+```
+.claude/agent-memory/<agent-name>/MEMORY.md
+```
+
+Header content:
+```markdown
+# Security Reviewer Agent Memory
+
+No memories recorded yet.
+```
+
+### Template placeholder convention
+
+- Only `{{UPPER_SNAKE_CASE}}` style — never lowercase, never single braces
+- All placeholders documented
+- Runtime-injected values (like file lists passed at invocation time) are described in prose as what the orchestrator will inject — they are NOT substituted by `install.sh`
+
+---
+
+## Files to Create
+
+| File | Type | Note |
+|------|------|------|
+| `templates/security/security-exemptions.yaml` | New | Template for target repos |
+| `.claude/security-exemptions.yaml` | New | specrails instance (empty exemptions) |
+| `templates/agents/security-reviewer.md` | New | Agent template |
+| `.claude/agents/security-reviewer.md` | New | Generated (substituted) agent |
+| `.claude/agent-memory/security-reviewer/MEMORY.md` | New | Initial memory file |
+
+## Files to Modify
+
+| File | Change summary |
+|------|----------------|
+| `templates/commands/implement.md` | Add Phase 4b-sec block, security gate in 4c, Security column in 4e |
+| `.claude/commands/implement.md` | Same changes (generated copy) |
+| `install.sh` | Copy security-exemptions template to target repo (skip if exists) |
+
+---
+
+## The Security Reviewer Agent Prompt
+
+Write `templates/agents/security-reviewer.md` with this exact structure:
+
+### Frontmatter
+```yaml
+---
+name: security-reviewer
+description: "Use this agent to scan all modified files for secrets, hardcoded credentials, and security vulnerability patterns after implementation. Runs as part of Phase 4 in the implement pipeline. Do NOT use this agent to fix issues — it scans and reports only.
+
+Examples:
+
+- Example 1:
+  user: (orchestrator) Reviewer completed. Now run the security scan.
+  assistant: \"Launching the security-reviewer agent to scan modified files for secrets and vulnerabilities.\"
+
+- Example 2:
+  user: (orchestrator) Implementation complete. Run security gate before shipping.
+  assistant: \"I'll launch the security-reviewer agent to perform the security scan.\""
+model: sonnet
+color: orange
+memory: project
+---
+```
+
+### Prompt body structure
+
+1. **Identity** (2-3 sentences): You are a security-focused code auditor. You scan code for secrets and vulnerabilities. You report findings — you never fix them.
+
+2. **Your Mission** (4 bullet points):
+   - Scan every file in MODIFIED_FILES_LIST
+   - Detect secrets using the patterns below
+   - Detect OWASP vulnerability patterns
+   - Produce a structured report and set SECURITY_STATUS
+
+3. **What You Receive** — explain the three inputs:
+   - `MODIFIED_FILES_LIST`: the list of files changed in this implementation run (injected into your invocation prompt by the orchestrator)
+   - `PIPELINE_CONTEXT`: what was implemented (feature names/change names)
+   - The exemptions config at `{{SECURITY_EXEMPTIONS_PATH}}`
+
+4. **Files to Skip**:
+   - Binary files
+   - `node_modules/`, `vendor/`, `.git/`
+   - Lock files: `package-lock.json`, `yarn.lock`, `go.sum`, `Cargo.lock`
+   - Files listed under exemptions in `{{SECURITY_EXEMPTIONS_PATH}}`
+
+5. **Secrets Detection** — include this full table:
+
+| Category | Pattern | Severity |
+|----------|---------|----------|
+| AWS Access Key ID | `AKIA[0-9A-Z]{16}` | Critical |
+| AWS Secret Access Key | 40-char alphanumeric after `aws_secret` keyword | Critical |
+| GitHub Token | `gh[pousr]_[A-Za-z0-9]{36}` | Critical |
+| Google API Key | `AIza[0-9A-Za-z\-_]{35}` | Critical |
+| Private Key Block | `-----BEGIN (RSA\|EC\|DSA\|OPENSSH) PRIVATE KEY-----` | Critical |
+| Database URL with credentials | `(postgres\|mysql\|mongodb)://[^:]+:[^@]+@` | Critical |
+| Generic API Key (20+ chars) | `api[_-]?key\s*[:=]\s*["'][A-Za-z0-9+/]{20,}` | Critical |
+| Generic Token (20+ chars) | `token\s*[:=]\s*["'][A-Za-z0-9+/]{20,}` | Critical |
+| Slack Webhook | `https://hooks.slack.com/services/T[A-Z0-9]+/` | High |
+| JWT Secret literal | `jwt[_-]?secret\s*[:=]` with non-env-var value | High |
+| Generic Password literal | `password\s*[:=]\s*["'][^"']{8,}` not from env | High |
+
+Safe patterns (skip these — not secrets):
+- Values referencing `process.env.*`, `os.environ[...]`, or shell `$VAR` syntax
+- Template placeholders: `{{...}}`, `<YOUR_KEY_HERE>`, `PLACEHOLDER`
+- Values in test files (`*.test.*`, `*.spec.*`, `*_test.go`, paths under `testdata/`) — downgrade to Medium
+
+Entropy heuristic: For any string > 20 chars assigned to a variable whose name contains `key`, `token`, `secret`, `password`, `credential`, or `auth` — if Shannon entropy > 4.5 bits/char AND it doesn't match a safe pattern — flag as High.
+
+6. **OWASP Vulnerability Patterns** (code files only — skip markdown, YAML, JSON, config):
+
+| Vulnerability | What to look for | Severity |
+|---------------|-----------------|----------|
+| SQL Injection | String concatenation into SQL queries | High |
+| XSS | Unsanitized user input in `innerHTML`, `dangerouslySetInnerHTML`, `document.write` | High |
+| Insecure Deserialization | `eval()` on user-controlled input, `pickle.loads()`, PHP `unserialize()` | High |
+| Weak JWT | `algorithm: 'none'` or `verify: false` in JWT operations | Critical |
+| Hardcoded credentials | Credentials in config files outside `.env.example` patterns | Critical |
+| Path traversal | User input directly in `path.join()`, `open()`, `fs.readFile()` | High |
+| Command injection | User input in `exec()`, `spawn()`, `subprocess.run()`, `os.system()` | High |
+
+7. **Exemption Handling**:
+   - Read `{{SECURITY_EXEMPTIONS_PATH}}`
+   - For each finding: check if it matches an exemption entry
+   - Suppressed findings: omit from Critical/High/Medium tables, add to Exemptions Applied table
+   - Exception: Critical findings with an exemption are listed as "Warning: exempted Critical" — never fully suppressed
+
+8. **Severity Definitions**:
+   - **Critical**: Active credential format or critical OWASP pattern (blocks pipeline)
+   - **High**: Likely vulnerability or high-entropy suspicious value (warning)
+   - **Medium**: Possible false positive or test context concern (info only)
+   - **Info**: Observations about security posture
+
+9. **Output Format** — produce EXACTLY this structure:
+
+```
+## Security Scan Results
+
+### Summary
+- Files scanned: N
+- Findings: X Critical, Y High, Z Medium, W Info
+- Exemptions applied: E
+
+### Critical Findings (BLOCKS MERGE)
+| File | Line | Finding | Pattern |
+|------|------|---------|---------|
+(rows or "None")
+
+### High Findings (Warning)
+| File | Line | Finding | Pattern |
+|------|------|---------|---------|
+(rows or "None")
+
+### Medium Findings (Info)
+| File | Line | Finding | Notes |
+|------|------|---------|-------|
+(rows or "None")
+
+### Exemptions Applied
+| File | Finding | Exemption reason |
+|------|---------|-----------------|
+(rows or "None")
+
+---
+SECURITY_STATUS: BLOCKED
+```
+
+The `SECURITY_STATUS:` line MUST be the last line of the report. Values:
+- `BLOCKED` if any Critical findings exist (after exemptions)
+- `WARNINGS` if no Critical but one or more High findings
+- `CLEAN` if no Critical or High findings
+
+10. **Rules**:
+    - Never fix code. Never suggest code changes. Scan and report only.
+    - Never ask for clarification. Complete the scan with available information.
+    - Always scan every file in MODIFIED_FILES_LIST — never skip a file without noting why.
+    - Always emit the `SECURITY_STATUS:` line as the very last line of output.
+
+11. **Memory protocol** — standard section using `{{MEMORY_PATH}}`:
+    - Memory path: `{{MEMORY_PATH}}`
+    - MEMORY.md under 200 lines
+    - Save: false positive patterns discovered, file types that commonly trigger false positives in this repo, recurring true-positive patterns
+    - Standard empty MEMORY.md section
+
+---
+
+## Implement Pipeline Changes
+
+### Where to insert in `implement.md`
+
+Find the section:
+```
+### 4b. Launch Reviewer agent
+```
+
+After the reviewer agent block ends, insert:
+
+```markdown
+### 4b-sec. Launch Security Reviewer agent
+
+After the reviewer agent completes, launch a **security-reviewer** agent (`subagent_type: security-reviewer`).
+
+Construct the agent invocation prompt to include:
+- **MODIFIED_FILES_LIST**: the complete list of files created or modified during this implementation run
+- **PIPELINE_CONTEXT**: brief description — feature names and change names implemented
+- The exemptions config path: `.claude/security-exemptions.yaml`
+
+Wait for the security-reviewer to complete. Parse the final line of its output:
+- `SECURITY_STATUS: BLOCKED` → set `SECURITY_BLOCKED=true`
+- `SECURITY_STATUS: WARNINGS` → set `SECURITY_BLOCKED=false`, capture warning summary
+- `SECURITY_STATUS: CLEAN` → set `SECURITY_BLOCKED=false`
+```
+
+Find the section:
+```
+### 4c. Ship — Git & backlog updates
+```
+
+At the very beginning of 4c (before any git operations), insert:
+
+```markdown
+**Security gate:** If `SECURITY_BLOCKED=true`:
+1. Print all Critical findings from the security-reviewer output
+2. Do NOT create a branch, commit, push, or PR
+3. Print: "Pipeline blocked by security findings. Fix the Critical issues listed above and re-run /implement."
+4. Skip to Phase 4e.
+```
+
+Find the Phase 4e report table:
+```
+| Area | Feature | Change Name | Architect | Developer | Reviewer | Tests | CI | Status |
+```
+
+Replace with:
+```
+| Area | Feature | Change Name | Architect | Developer | Reviewer | Security | Tests | CI | Status |
+```
+
+---
+
+## The Exemptions YAML File
+
+`templates/security/security-exemptions.yaml` content:
+
+```yaml
+# Security scan exemptions for specrails
+#
+# Add entries here to suppress known false positives from the security-reviewer agent.
+# This file is tracked in git — all exemptions are auditable.
+#
+# Fields:
+#   secrets.pattern   - Description of the pattern being exempted (for documentation)
+#   secrets.reason    - Required: why this is a known false positive
+#   secrets.added_by  - Required: who added this exemption
+#   secrets.added_on  - Required: ISO 8601 date (YYYY-MM-DD)
+#
+#   vulnerabilities.rule    - The vulnerability rule name being exempted
+#   vulnerabilities.file    - Optional: scope exemption to a specific file path
+#   vulnerabilities.reason  - Required: justification
+#   vulnerabilities.added_by - Required
+#   vulnerabilities.added_on - Required
+
+exemptions:
+  secrets: []
+  vulnerabilities: []
+```
+
+`.claude/security-exemptions.yaml` is identical to the template (since specrails has no exemptions to start with).
+
+---
+
+## The install.sh Change
+
+Find the section in `install.sh` where template files are copied to the target repo (look for calls to `cp` that copy files from `templates/` to `$TARGET/.claude/`).
+
+Add after that block:
+
+```bash
+# Copy security exemptions config (skip if already exists — preserve user exemptions)
+if [ ! -f "${TARGET}/.claude/security-exemptions.yaml" ]; then
+    cp "${SPECRAILS_DIR}/templates/security/security-exemptions.yaml" "${TARGET}/.claude/security-exemptions.yaml"
+fi
+```
+
+Replace `${TARGET}` and `${SPECRAILS_DIR}` with whatever variable names `install.sh` already uses. Read `install.sh` first to find the correct variable names.
+
+---
+
+## Key Design Decisions (Do Not Second-Guess)
+
+1. **Claude-native scanning, no external tools**: The agent uses Claude's analysis, not truffleHog or semgrep. This avoids installation friction. External tools are a Phase 2 enhancement. See design.md for full rationale.
+
+2. **Critical blocks, High warns**: Only Critical findings block the pipeline. High findings are warnings. This prevents excessive false-positive friction.
+
+3. **Sequential, not parallel with reviewer**: Security scan runs after the reviewer agent, not in parallel. This gives the reviewer a chance to fix issues first, reducing noise in the security report.
+
+4. **Exemptions never fully suppress Critical**: Even exempted Critical findings appear as "Warning: exempted Critical" in the report. This is intentional — Critical exemptions should always be visible.
+
+5. **`SECURITY_STATUS:` must be the very last line**: The orchestrator parses only the last line of the agent's output. If anything follows it, the pipeline cannot detect the status correctly.
+
+---
+
+## Verification Checklist
+
+Before declaring implementation complete:
+
+- [ ] `templates/security/security-exemptions.yaml` exists and is valid YAML
+- [ ] `.claude/security-exemptions.yaml` exists with empty exemptions arrays
+- [ ] `templates/agents/security-reviewer.md` exists with valid YAML frontmatter
+- [ ] `.claude/agents/security-reviewer.md` exists with no unresolved `{{PLACEHOLDER}}` strings (except runtime reference mentions in prose)
+- [ ] `.claude/agent-memory/security-reviewer/MEMORY.md` exists
+- [ ] `templates/commands/implement.md` has `### 4b-sec` section
+- [ ] `templates/commands/implement.md` has security gate at start of `### 4c`
+- [ ] `templates/commands/implement.md` Phase 4e table has `Security` column
+- [ ] `.claude/commands/implement.md` has all three of the above
+- [ ] `install.sh` copies the exemptions template (skip-if-exists)
+- [ ] `shellcheck install.sh` passes
+- [ ] `grep -r '{{[A-Z_]*}}' .claude/agents/security-reviewer.md` returns no matches

--- a/openspec/changes/archive/2026-03-13-security-reviewer-agent/delta-spec.md
+++ b/openspec/changes/archive/2026-03-13-security-reviewer-agent/delta-spec.md
@@ -1,0 +1,161 @@
+---
+change: security-reviewer-agent
+type: delta-spec
+---
+
+# Delta Spec: Security & Secrets Reviewer Agent
+
+This document describes the spec-level changes this feature introduces. It defines what the system should do after this change is applied, framed as additions and modifications to the existing conceptual specification.
+
+---
+
+## 1. New Capability: Security Scanning Agent
+
+**Spec statement:** The specrails agent system SHALL include a `security-reviewer` agent that scans modified code for secrets and vulnerability patterns.
+
+### 1.1 Agent identity
+
+The `security-reviewer` agent:
+- Has name `security-reviewer`
+- Runs on model `sonnet`
+- Color `orange`
+- Has persistent memory at `.claude/agent-memory/security-reviewer/`
+- Is self-contained — requires no external binaries to perform its core function
+
+### 1.2 Scanning scope
+
+When invoked, the agent MUST:
+- Receive a list of modified files via its invocation prompt (`MODIFIED_FILES_LIST`)
+- Scan only those files (not the entire repository)
+- Skip binary files, lock files, `node_modules/`, `vendor/`, `.git/`
+- Apply exemptions from `.claude/security-exemptions.yaml` before reporting
+
+### 1.3 Detection categories
+
+The agent MUST check for:
+- **Secrets**: credentials matching known high-confidence regex patterns (AWS keys, GitHub tokens, private key blocks, database URLs, generic API keys/tokens of 20+ chars)
+- **High-entropy strings**: values assigned to security-sensitive variable names with Shannon entropy > 4.5 bits/char
+- **OWASP patterns**: SQL injection, XSS, insecure deserialization, weak JWT configuration, path traversal, command injection
+
+### 1.4 Severity classification
+
+Every finding MUST be classified as one of: `Critical`, `High`, `Medium`, `Info`.
+
+Critical findings:
+- Active credential formats (AWS, GitHub, Google API keys, private key blocks, database URLs with credentials)
+- `algorithm: 'none'` in JWT operations
+- Hardcoded credentials in non-example config files
+
+### 1.5 Output format
+
+The agent MUST produce a structured report ending with a machine-readable status line:
+```
+SECURITY_STATUS: BLOCKED | WARNINGS | CLEAN
+```
+- `BLOCKED`: one or more Critical findings exist (after exemptions)
+- `WARNINGS`: no Critical findings but one or more High findings exist
+- `CLEAN`: no Critical or High findings
+
+---
+
+## 2. Modified Capability: Implementation Pipeline (Phase 4)
+
+**Spec statement:** Phase 4b of the implementation pipeline SHALL run the `security-reviewer` agent after the `reviewer` agent, and SHALL block Phase 4c if the security scan result is `BLOCKED`.
+
+### 2.1 Phase 4b execution order
+
+Phase 4b executes in this order:
+1. Reviewer agent (CI/quality gate) — unchanged
+2. Security reviewer agent (security gate) — new
+
+### 2.2 Security reviewer invocation
+
+The orchestrator MUST pass to the security-reviewer agent:
+- `MODIFIED_FILES_LIST`: all files changed during the implementation run
+- `PIPELINE_CONTEXT`: feature names and change names implemented
+- The path to `.claude/security-exemptions.yaml`
+
+### 2.3 Blocking behavior
+
+If `SECURITY_STATUS: BLOCKED`:
+- The orchestrator MUST NOT execute Phase 4c (git operations, PR creation)
+- The orchestrator MUST print the Critical findings clearly
+- The orchestrator MUST instruct the developer to fix the findings before re-running
+- The pipeline terminates after producing the Phase 4e report with status `BLOCKED`
+
+If `SECURITY_STATUS: WARNINGS` or `CLEAN`:
+- Phase 4c proceeds normally
+
+### 2.4 Phase 4e report
+
+The pipeline report table MUST include a `Security` column showing: `BLOCKED`, `WARNINGS`, or `CLEAN`.
+
+---
+
+## 3. New Artifact: Exemption Configuration
+
+**Spec statement:** Each target repo SHALL be able to define security scan exemptions in `.claude/security-exemptions.yaml`.
+
+### 3.1 Exemption config location
+
+- Template: `templates/security/security-exemptions.yaml`
+- Generated (per repo): `.claude/security-exemptions.yaml`
+- The file is created by `install.sh` as part of normal setup
+
+### 3.2 Exemption schema
+
+```yaml
+exemptions:
+  secrets:
+    - pattern: string          # The regex pattern or descriptive name being exempted
+      reason: string           # Required: justification
+      added_by: string         # Required: who added it
+      added_on: string         # Required: ISO date
+  vulnerabilities:
+    - rule: string             # The rule name being exempted
+      file: string             # Optional: limit exemption to a specific file
+      reason: string           # Required
+      added_by: string         # Required
+      added_on: string         # Required
+```
+
+### 3.3 Exemption behavior
+
+- Secrets exemptions: suppress findings matching the described pattern
+- Vulnerability exemptions: suppress findings for the named rule, optionally scoped to a file
+- Critical findings matching an exemption: reported as "Warning: exempted Critical" — not suppressed entirely
+- All applied exemptions appear in the `Exemptions Applied` section of the scan report
+
+---
+
+## 4. New Artifact: Agent Template
+
+**Spec statement:** `templates/agents/security-reviewer.md` SHALL exist as a canonical template following the `{{PLACEHOLDER}}` convention used by all other agent templates.
+
+### 4.1 Required placeholders
+
+| Placeholder | Resolved to |
+|-------------|-------------|
+| `{{MEMORY_PATH}}` | `.claude/agent-memory/security-reviewer/` |
+| `{{SECURITY_EXEMPTIONS_PATH}}` | `.claude/security-exemptions.yaml` |
+| `{{MODIFIED_FILES_LIST}}` | Injected at agent invocation time (runtime) |
+| `{{PIPELINE_CONTEXT}}` | Injected at agent invocation time (runtime) |
+
+Note: `{{MODIFIED_FILES_LIST}}` and `{{PIPELINE_CONTEXT}}` are runtime-injected values, not static substitutions performed by `install.sh`. The template uses them as prompt instructions.
+
+### 4.2 Template conventions
+
+The template MUST follow all conventions in `.claude/rules/agents.md`:
+- YAML frontmatter with `name`, `description`, `model`, `color`, `memory`
+- `description` field includes usage examples
+- Agent is self-contained
+- Output format is specified
+- Memory protocol section matches other agents
+
+---
+
+## 5. Install.sh Addition
+
+**Spec statement:** `install.sh` SHALL copy `templates/security/security-exemptions.yaml` to `.claude/security-exemptions.yaml` in the target repo during setup (only if the file does not already exist — do not overwrite existing exemptions).
+
+This is the only change to `install.sh`.

--- a/openspec/changes/archive/2026-03-13-security-reviewer-agent/design.md
+++ b/openspec/changes/archive/2026-03-13-security-reviewer-agent/design.md
@@ -1,0 +1,289 @@
+---
+change: security-reviewer-agent
+type: design
+---
+
+# Technical Design: Security & Secrets Reviewer Agent
+
+## Architecture Overview
+
+The security-reviewer is a pure Claude Code agent — a markdown prompt file with YAML frontmatter, identical in structure to `reviewer.md`. It requires no new runtime dependencies at launch. All scanning is performed via Claude's code analysis capabilities combined with a defined set of regex patterns and entropy heuristics embedded in the prompt.
+
+```
+Phase 4b (current):
+  reviewer agent  →  CI checks + template integrity
+
+Phase 4b (after this change):
+  reviewer agent        →  CI checks + template integrity
+  security-reviewer     →  secrets scan + OWASP patterns + block on Critical
+```
+
+The two agents run sequentially in Phase 4b. The reviewer runs first (quality gate), then the security-reviewer runs (security gate). If the security-reviewer finds Critical findings, Phase 4c (ship) is blocked.
+
+---
+
+## File Changes
+
+### New Files
+
+#### 1. `templates/agents/security-reviewer.md`
+
+The canonical template. Uses `{{PLACEHOLDER}}` substitution. Key placeholders:
+
+| Placeholder | Description |
+|-------------|-------------|
+| `{{MEMORY_PATH}}` | Agent memory directory path |
+| `{{SECURITY_EXEMPTIONS_PATH}}` | Path to exemptions config |
+| `{{MODIFIED_FILES_LIST}}` | Injected by orchestrator: files changed in this run |
+| `{{PIPELINE_CONTEXT}}` | Brief description of what was implemented (injected) |
+
+The prompt structure mirrors `reviewer.md`:
+- YAML frontmatter: `name: security-reviewer`, `model: sonnet`, `color: orange`, `memory: project`
+- Identity: "You are a security-focused code auditor..."
+- Mission: scan for secrets and vulnerability patterns
+- Scanning methodology (detailed below)
+- Severity definitions
+- Blocking rules
+- Output format
+- Exemption handling
+- Memory protocol
+
+#### 2. `.claude/agents/security-reviewer.md`
+
+The generated (specrails-adapted) version. Created by applying specrails' own template substitution to `templates/agents/security-reviewer.md`. For specrails itself, most placeholders resolve to specrails-specific values:
+
+- `{{MEMORY_PATH}}` → `.claude/agent-memory/security-reviewer/`
+- `{{SECURITY_EXEMPTIONS_PATH}}` → `.claude/security-exemptions.yaml`
+- `{{MODIFIED_FILES_LIST}}` → injected at invocation time (runtime, not substitution time)
+- `{{PIPELINE_CONTEXT}}` → injected at invocation time
+
+#### 3. `templates/security/security-exemptions.yaml`
+
+Exemption config template for target repos. Structure:
+
+```yaml
+# Security scan exemptions
+# Add entries here to suppress known false positives.
+# Each entry requires a justification.
+exemptions:
+  secrets:
+    - pattern: "EXAMPLE_API_KEY_PATTERN"
+      reason: "Test fixture — not a real credential"
+      added_by: "team@example.com"
+      added_on: "2025-01-01"
+  vulnerabilities:
+    - rule: "sql-injection-pattern"
+      file: "src/legacy/old-query.ts"
+      reason: "Legacy code, isolated, scheduled for removal in Q3"
+      added_by: "team@example.com"
+      added_on: "2025-01-01"
+```
+
+#### 4. `.claude/security-exemptions.yaml`
+
+The specrails-repo instance of the exemptions config. Initially contains only the header comment and empty `exemptions:` block. This file is checked in so teams can track exemption history via git.
+
+#### 5. `.claude/agent-memory/security-reviewer/MEMORY.md`
+
+Empty initial memory file, consistent with other agents.
+
+### Modified Files
+
+#### 6. `templates/commands/implement.md`
+
+Phase 4b must be extended to:
+- Launch the `security-reviewer` agent after the `reviewer` agent completes
+- Pass `MODIFIED_FILES_LIST` and `PIPELINE_CONTEXT` as part of the agent invocation prompt
+- Read the security-reviewer's output and check for blocking status
+- If `SECURITY_BLOCKED=true`: halt Phase 4c (do not create branch, do not push, do not create PR)
+- Report blocking findings in Phase 4e
+
+#### 7. `.claude/commands/implement.md`
+
+Same changes as the template version (this is the specrails-adapted generated copy).
+
+---
+
+## Security Scanning Methodology
+
+The agent performs scanning entirely through Claude's analysis capabilities. The prompt instructs the agent to apply the following checks:
+
+### Secrets Detection
+
+**Regex patterns** (the prompt embeds these as a reference table):
+
+| Category | Pattern Description | Severity |
+|----------|---------------------|----------|
+| AWS Access Key | `AKIA[0-9A-Z]{16}` | Critical |
+| AWS Secret Key | 40-char alphanumeric following `aws_secret` keyword | Critical |
+| Generic API Key | `api[_-]?key\s*[:=]\s*["\'][A-Za-z0-9+/]{20,}` | Critical |
+| Generic Token | `token\s*[:=]\s*["\'][A-Za-z0-9+/]{20,}` | Critical |
+| Private Key Block | `-----BEGIN (RSA|EC|DSA|OPENSSH) PRIVATE KEY-----` | Critical |
+| Database URL | `(postgres|mysql|mongodb)://[^:]+:[^@]+@` | Critical |
+| JWT Secret | `jwt[_-]?secret\s*[:=]` assigned to non-env-var value | High |
+| Slack Webhook | `https://hooks.slack.com/services/T[A-Z0-9]+/` | High |
+| Generic Password | `password\s*[:=]\s*["\'][^"\']{8,}` not from env | High |
+| GitHub Token | `gh[pousr]_[A-Za-z0-9]{36}` | Critical |
+| Google API Key | `AIza[0-9A-Za-z\-_]{35}` | Critical |
+
+**Entropy analysis**: For any string value longer than 20 characters assigned to a variable whose name contains `key`, `token`, `secret`, `password`, `credential`, or `auth`, estimate Shannon entropy. Values with entropy > 4.5 bits/char are flagged as potential high-entropy secrets (High severity if not already caught by regex).
+
+**Safe patterns** (to avoid false positives):
+- Values referencing `process.env.*` or `os.environ[*]` or `$ENV_VAR` — skip
+- Values that are clearly template placeholders: `{{...}}`, `<...>`, `YOUR_KEY_HERE` — skip
+- Values in files matching `*.test.*`, `*.spec.*`, `*_test.go`, `testdata/` — downgrade to Medium
+
+### OWASP Vulnerability Patterns
+
+The agent checks for these patterns in code files only (not markdown, YAML, JSON):
+
+| Vulnerability | Pattern to check for | Severity |
+|---------------|----------------------|----------|
+| SQL Injection | String concatenation into SQL queries | High |
+| XSS | Unsanitized user input rendered as HTML (innerHTML, dangerouslySetInnerHTML) | High |
+| Insecure Deserialization | `eval()` on user input, `pickle.loads()`, `unserialize()` | High |
+| Weak JWT | `algorithm: 'none'` or `verify: false` in JWT operations | Critical |
+| CSRF absent | POST endpoints without CSRF token verification (framework-dependent) | Medium |
+| Hardcoded credentials | Credentials in config files outside of `.env.example` patterns | Critical |
+| Path traversal | User input used directly in file path operations | High |
+| Command injection | User input in shell command execution | High |
+
+### What the agent does NOT scan
+
+- Binary files
+- `node_modules/`, `vendor/`, `.git/`
+- Files listed in `.claude/security-exemptions.yaml`
+- Lock files (`package-lock.json`, `yarn.lock`, `go.sum`)
+
+---
+
+## Exemption Handling
+
+When the agent finds a potential finding, it checks `.claude/security-exemptions.yaml` before reporting:
+
+1. For a secrets finding: check `exemptions.secrets[].pattern` against the flagged pattern
+2. For a vulnerability finding: check `exemptions.vulnerabilities[].rule` and `exemptions.vulnerabilities[].file`
+3. If a match is found: suppress the finding and note the exemption in the report
+
+Exemptions do not apply to Critical findings automatically — the agent notes the exemption exists but still reports Critical findings (downgraded to a "Warning: exempted Critical"). This ensures Critical exemptions are always visible even if they don't block the pipeline.
+
+---
+
+## Severity & Blocking Rules
+
+| Severity | Definition | Pipeline effect |
+|----------|------------|-----------------|
+| Critical | Active credential, live key, private key, or OWASP critical finding | Block Phase 4c. Do not ship. |
+| High | Likely vulnerability or high-entropy suspicious value | Warn. Require developer acknowledgment before Phase 4c (future: prompt user). For now: report and continue but flag in Phase 4e status. |
+| Medium | Possible false positive, test fixture concern, or informational security note | Report only. No pipeline impact. |
+| Info | Observations about security posture, not actionable | Report only. |
+
+For the initial implementation: Critical blocks, all others are warnings. Future iterations can add interactive acknowledgment for High findings.
+
+---
+
+## Integration Points in `implement.md`
+
+### Phase 4b addition
+
+After the existing reviewer agent launch block, add:
+
+```
+### 4b-sec. Launch Security Reviewer agent
+
+After the reviewer agent completes, launch a **security-reviewer** agent.
+
+Include in the agent invocation prompt:
+- `MODIFIED_FILES_LIST`: the list of all files changed in this implementation run
+- `PIPELINE_CONTEXT`: brief description of what was implemented (feature names, change names)
+- `EXEMPTIONS_PATH`: `.claude/security-exemptions.yaml`
+
+Wait for the security-reviewer to complete. Read its output.
+
+Extract `SECURITY_STATUS` from the output:
+- If `SECURITY_STATUS: BLOCKED` — set `SECURITY_BLOCKED=true`
+- If `SECURITY_STATUS: WARNINGS` — set `SECURITY_BLOCKED=false`, note warnings
+- If `SECURITY_STATUS: CLEAN` — set `SECURITY_BLOCKED=false`
+```
+
+### Phase 4c gate
+
+At the start of Phase 4c (Ship), add:
+
+```
+**Security gate**: If `SECURITY_BLOCKED=true`, do NOT proceed with git operations.
+Instead:
+1. Print the Critical findings from the security-reviewer output
+2. Instruct the developer to fix the findings
+3. Stop. The pipeline resumes only when the user re-runs `/implement` after fixing.
+```
+
+### Phase 4e report addition
+
+Add a `Security` column to the pipeline report table:
+
+```
+| Area | Feature | Change Name | Architect | Developer | Reviewer | Security | Tests | CI | Status |
+```
+
+---
+
+## Output Format (Security Reviewer Agent)
+
+The agent produces a structured report ending with a machine-readable status line:
+
+```
+## Security Scan Results
+
+### Summary
+- Files scanned: N
+- Findings: X Critical, Y High, Z Medium, W Info
+- Exemptions applied: E
+
+### Critical Findings (BLOCKS MERGE)
+| File | Line | Finding | Pattern |
+|------|------|---------|---------|
+
+### High Findings (Warning)
+| File | Line | Finding | Pattern |
+|------|------|---------|---------|
+
+### Medium Findings (Info)
+| File | Line | Finding | Notes |
+|------|------|---------|-------|
+
+### Exemptions Applied
+| File | Finding | Exemption reason |
+|------|---------|-----------------|
+
+---
+SECURITY_STATUS: BLOCKED | WARNINGS | CLEAN
+```
+
+The `SECURITY_STATUS:` line is always the last line and is parsed by the implement pipeline orchestrator.
+
+---
+
+## Template Substitution
+
+The `install.sh` installer handles `security-reviewer.md` the same way it handles all other agent templates — the `setup` command performs substitution. No changes to `install.sh` are required for this feature; the new template files are picked up automatically by the existing template scan.
+
+The `security-exemptions.yaml` template must be explicitly added to `install.sh`'s file-copy list since it is not under `templates/agents/`. This is the only `install.sh` touch point.
+
+---
+
+## Risks & Design Decisions
+
+### Decision: Claude analysis vs. external tools
+
+Chosen approach: Claude-native analysis (no shell tools required at agent launch time).
+
+Rationale: External tools (truffleHog, semgrep) require installation and version management on every developer machine. This creates friction during `install.sh` setup and can cause failures in restricted environments. Claude's code analysis is available everywhere the agent runs. The tradeoff is lower precision for some patterns, but the false-negative rate for Critical patterns (regex-based) is acceptably low. External tool integration is an explicit Phase 2 enhancement.
+
+### Decision: Sequential execution (reviewer then security-reviewer)
+
+The security scan runs after the reviewer. Rationale: the reviewer may auto-fix some issues that would otherwise generate spurious security warnings. Running security last gives the cleanest view of what will actually be shipped.
+
+### Decision: Critical blocks, High warns (not blocks)
+
+Rationale: High findings can be legitimate uses (e.g., a tool that intentionally invokes eval for sandboxed scripting). Blocking on High would create excessive false-positive friction. Critical patterns (actual credential formats) have near-zero false positive rates and warrant hard blocking.

--- a/openspec/changes/archive/2026-03-13-security-reviewer-agent/proposal.md
+++ b/openspec/changes/archive/2026-03-13-security-reviewer-agent/proposal.md
@@ -1,0 +1,56 @@
+---
+change: security-reviewer-agent
+type: feature
+status: proposed
+github_issue: 4
+vpc_fit: 80%
+---
+
+# Proposal: Security & Secrets Reviewer Agent
+
+## Problem
+
+AI-generated code can silently introduce secrets and security vulnerabilities that are invisible during normal code review:
+
+- **Secrets leak**: LLMs occasionally generate plausible-looking API keys, tokens, or database connection strings while filling in example code. Without automated scanning, these reach version control.
+- **OWASP vulnerabilities**: AI-generated code reproduces known vulnerable patterns (SQL injection, XSS, insecure authentication) because the patterns exist in training data.
+- **No safety net in the current pipeline**: Phase 4 (Merge & Review) runs a quality-gate reviewer but it has no security mandate — it checks CI conformance, not threat surface.
+
+This is classified as blocking production use. The specrails implement pipeline is designed to accelerate AI-driven development; shipping that pipeline without a security gate creates a liability for every team that adopts it.
+
+## Solution
+
+Add a `security-reviewer` agent that runs automatically at the end of Phase 4, after the existing `reviewer` agent completes. The agent:
+
+1. Scans every modified file for secrets using regex patterns and Shannon entropy analysis.
+2. Checks for OWASP Top 10 vulnerability patterns via Claude's own code analysis (no external binary dependency required at launch).
+3. Reports findings organized by severity: Critical / High / Medium / Info.
+4. **Blocks the pipeline** if any Critical findings exist (hardcoded secrets, live credentials).
+5. Surfaces High and Medium findings as warnings that must be acknowledged before shipping.
+6. Supports per-project exemption config so teams can whitelist known false positives.
+
+## Scope
+
+**In scope:**
+- New agent: `templates/agents/security-reviewer.md` (template) and `.claude/agents/security-reviewer.md` (generated)
+- Integration into Phase 4b of the implement pipeline (both template and generated versions)
+- Exemption config format: `.claude/security-exemptions.yaml`
+- Exemption config template: `templates/security/security-exemptions.yaml`
+- Severity severity-based merge blocking logic in the implement command
+- Agent memory system (same pattern as reviewer)
+
+**Out of scope:**
+- External tool integration (truffleHog, semgrep, npm audit) — Phase 2 enhancement
+- CI pipeline integration (no CI exists yet)
+- IDE plugin or pre-commit hooks
+- SBOM generation or dependency vulnerability scanning beyond npm audit patterns
+
+## Non-goals
+
+- This agent does NOT replace human security review for high-risk changes.
+- This agent does NOT fix security issues autonomously (unlike the reviewer). It reports and blocks; the developer fixes.
+- This agent does NOT run on every file in the repo — only files modified in the current implementation run.
+
+## Motivation
+
+VPC fit score: 80%. This is the highest-scoring unimplemented feature. Lead developers adopting specrails identified "secrets accidentally shipped by AI agents" as the primary blocker to trusting the pipeline in production environments.

--- a/openspec/changes/archive/2026-03-13-security-reviewer-agent/tasks.md
+++ b/openspec/changes/archive/2026-03-13-security-reviewer-agent/tasks.md
@@ -1,0 +1,303 @@
+---
+change: security-reviewer-agent
+type: tasks
+---
+
+# Tasks: Security & Secrets Reviewer Agent
+
+Tasks are ordered by dependency. Each task has a layer tag, description, files involved, and acceptance criteria.
+
+---
+
+## Task 1 — Create the security-exemptions template [templates]
+
+**Description:** Create the `templates/security/security-exemptions.yaml` file. This is the source template that `install.sh` copies into target repos. Must be a valid YAML file with clear comments explaining every field.
+
+**Files:**
+- Create: `templates/security/security-exemptions.yaml`
+
+**Acceptance criteria:**
+- File exists at `templates/security/security-exemptions.yaml`
+- Valid YAML (no parse errors)
+- Contains an `exemptions:` root key with `secrets:` and `vulnerabilities:` sub-keys, each as empty arrays
+- Contains inline comments documenting every field (`pattern`, `reason`, `added_by`, `added_on`, `rule`, `file`)
+- Contains a header comment explaining the purpose of the file and that changes are tracked in git
+
+**Dependencies:** None
+
+---
+
+## Task 2 — Create the specrails-instance exemptions config [agents]
+
+**Description:** Create `.claude/security-exemptions.yaml` — the specrails repo's own exemption config. This is what the `security-reviewer` agent reads when scanning specrails' own modified files. Initially empty exemptions.
+
+**Files:**
+- Create: `.claude/security-exemptions.yaml`
+
+**Acceptance criteria:**
+- File exists at `.claude/security-exemptions.yaml`
+- Valid YAML
+- Has `exemptions.secrets: []` and `exemptions.vulnerabilities: []`
+- Contains the same header comment as the template (adapted for specrails context)
+- No placeholder strings left in the file — this is the live instance, not the template
+
+**Dependencies:** Task 1 (content pattern established)
+
+---
+
+## Task 3 — Create the security-reviewer agent template [templates]
+
+**Description:** Write `templates/agents/security-reviewer.md`. This is the canonical agent prompt template. It follows the same structure as `templates/agents/reviewer.md` but has a security mandate instead of a CI mandate.
+
+**Files:**
+- Create: `templates/agents/security-reviewer.md`
+
+**Content requirements:**
+
+YAML frontmatter:
+```yaml
+---
+name: security-reviewer
+description: "Use this agent to scan all modified files for secrets, hardcoded credentials, and security vulnerability patterns after implementation. Runs as part of Phase 4 in the implement pipeline. Do NOT use this agent to fix issues — it scans and reports only.
+
+Examples:
+
+- Example 1:
+  user: (orchestrator) Reviewer completed. Now run the security scan.
+  assistant: \"Launching the security-reviewer agent to scan modified files for secrets and vulnerabilities.\"
+
+- Example 2:
+  user: (orchestrator) Implementation complete. Run security gate before shipping.
+  assistant: \"I'll launch the security-reviewer agent to perform the security scan.\""
+model: sonnet
+color: orange
+memory: project
+---
+```
+
+Prompt body MUST include:
+1. Identity section: "You are a security-focused code auditor..."
+2. Mission: scan only, do not fix
+3. "What you receive" section explaining `MODIFIED_FILES_LIST`, `PIPELINE_CONTEXT`, `{{SECURITY_EXEMPTIONS_PATH}}`
+4. Scanning methodology with the full secrets pattern table, entropy heuristic, and OWASP pattern table (from design.md)
+5. What to skip (binaries, lock files, node_modules, vendor, .git, files in exemptions)
+6. Severity definitions table (Critical / High / Medium / Info)
+7. Exemption handling procedure
+8. Output format (exactly as defined in design.md, including `SECURITY_STATUS:` as last line)
+9. Rules section: "Never fix. Never suggest code changes. Report only. Never ask for clarification."
+10. Memory protocol section using `{{MEMORY_PATH}}`
+
+**Acceptance criteria:**
+- File exists at `templates/agents/security-reviewer.md`
+- Valid YAML frontmatter (no parse errors in the `---` block)
+- All required placeholders present: `{{MEMORY_PATH}}`, `{{SECURITY_EXEMPTIONS_PATH}}`
+- `{{MODIFIED_FILES_LIST}}` and `{{PIPELINE_CONTEXT}}` appear as instructional references in the prompt body (not as substitution targets — they are runtime values)
+- Output format section ends with `SECURITY_STATUS: BLOCKED | WARNINGS | CLEAN` exactly as specified
+- Scanning methodology section includes the full secrets pattern table and OWASP pattern table
+- File follows kebab-case naming: `security-reviewer.md`
+
+**Dependencies:** None (can be done in parallel with Tasks 1 and 2)
+
+---
+
+## Task 4 — Generate the specrails-instance security-reviewer agent [agents]
+
+**Description:** Create `.claude/agents/security-reviewer.md` by applying the template. For specrails, the substitutions are:
+- `{{MEMORY_PATH}}` → `.claude/agent-memory/security-reviewer/`
+- `{{SECURITY_EXEMPTIONS_PATH}}` → `.claude/security-exemptions.yaml`
+
+This is the file that Claude Code will use when running the security-reviewer in the specrails repo.
+
+**Files:**
+- Create: `.claude/agents/security-reviewer.md`
+
+**Acceptance criteria:**
+- File exists at `.claude/agents/security-reviewer.md`
+- No unresolved `{{PLACEHOLDER}}` strings remain (except `{{MODIFIED_FILES_LIST}}` and `{{PIPELINE_CONTEXT}}` which are runtime references in prose, not substitution targets)
+- Memory path is `.claude/agent-memory/security-reviewer/`
+- Exemptions path is `.claude/security-exemptions.yaml`
+- YAML frontmatter is valid
+- Content matches the template with substitutions applied
+
+**Dependencies:** Task 3
+
+---
+
+## Task 5 — Create security-reviewer agent memory directory [agents]
+
+**Description:** Create `.claude/agent-memory/security-reviewer/MEMORY.md` — the initial (empty) memory file for the agent. Follows the same pattern as other agents.
+
+**Files:**
+- Create: `.claude/agent-memory/security-reviewer/MEMORY.md`
+
+**Content:**
+```markdown
+# Security Reviewer Agent Memory
+
+No memories recorded yet.
+```
+
+**Acceptance criteria:**
+- File exists at `.claude/agent-memory/security-reviewer/MEMORY.md`
+- Contains the standard empty-memory header
+- No other content
+
+**Dependencies:** None
+
+---
+
+## Task 6 — Update `templates/commands/implement.md`: add Phase 4b-sec [templates]
+
+**Description:** Modify `templates/commands/implement.md` to integrate the security-reviewer agent into Phase 4. This is a surgical edit — do NOT restructure existing phases.
+
+**Files:**
+- Modify: `templates/commands/implement.md`
+
+**Specific changes:**
+
+After the existing "### 4b. Launch Reviewer agent" block, insert a new block:
+
+```
+### 4b-sec. Launch Security Reviewer agent
+
+After the reviewer agent completes, launch a **security-reviewer** agent (`subagent_type: security-reviewer`).
+
+Construct the agent invocation prompt to include:
+- The list of all modified files in this run (`MODIFIED_FILES_LIST`)
+- A brief description of what was implemented: feature names and change names (`PIPELINE_CONTEXT`)
+- The exemptions file path: `.claude/security-exemptions.yaml`
+
+Wait for the security-reviewer to complete. Parse the last line of its output:
+- `SECURITY_STATUS: BLOCKED` → set `SECURITY_BLOCKED=true`
+- `SECURITY_STATUS: WARNINGS` → set `SECURITY_BLOCKED=false`, note warnings for report
+- `SECURITY_STATUS: CLEAN` → set `SECURITY_BLOCKED=false`
+```
+
+At the start of "### 4c. Ship", insert a security gate block:
+
+```
+**Security gate:** If `SECURITY_BLOCKED=true`:
+1. Print the Critical findings from the security-reviewer output
+2. Do NOT create a branch, commit, push, or PR
+3. Print: "Pipeline blocked by security findings. Fix the Critical issues listed above and re-run /implement."
+4. Proceed directly to Phase 4e (report only).
+```
+
+In Phase 4e report table, change the table header from:
+```
+| Area | Feature | Change Name | Architect | Developer | Reviewer | Tests | CI | Status |
+```
+to:
+```
+| Area | Feature | Change Name | Architect | Developer | Reviewer | Security | Tests | CI | Status |
+```
+
+**Acceptance criteria:**
+- `### 4b-sec` block exists in the file, positioned after `### 4b`
+- Security gate block exists at the start of `### 4c`
+- Phase 4e table includes the `Security` column
+- All existing content is preserved unchanged
+- No `{{PLACEHOLDER}}` strings are broken by the edit
+
+**Dependencies:** None (can be done in parallel with agent tasks)
+
+---
+
+## Task 7 — Update `.claude/commands/implement.md`: same changes [commands]
+
+**Description:** Apply the same changes from Task 6 to `.claude/commands/implement.md` (the specrails-adapted generated copy). The generated copy has had its template placeholders resolved, so the edit targets the same logical sections but in the resolved content.
+
+**Files:**
+- Modify: `.claude/commands/implement.md`
+
+**Acceptance criteria:**
+- Same as Task 6, applied to the generated copy
+- No template placeholders are introduced (this file has already been through substitution)
+- The `### 4b-sec` section references `security-reviewer` (not a placeholder)
+
+**Dependencies:** Task 6 (content pattern established by template edit)
+
+---
+
+## Task 8 — Update `install.sh`: copy security-exemptions template [templates]
+
+**Description:** Add a single line to `install.sh` to copy `templates/security/security-exemptions.yaml` to `.claude/security-exemptions.yaml` in the target repo during setup. Must use an "only if not exists" pattern to avoid overwriting existing exemption configs on re-installs.
+
+**Files:**
+- Modify: `install.sh`
+
+**Specific change:** In the section of `install.sh` that copies template files, add:
+
+```bash
+# Copy security exemptions config (do not overwrite existing)
+if [ ! -f "$TARGET/.claude/security-exemptions.yaml" ]; then
+  cp "$SPECRAILS_DIR/templates/security/security-exemptions.yaml" "$TARGET/.claude/security-exemptions.yaml"
+  log "Created .claude/security-exemptions.yaml"
+fi
+```
+
+Where `$TARGET` and `$SPECRAILS_DIR` are whatever variable names `install.sh` already uses for those paths.
+
+**Acceptance criteria:**
+- `install.sh` copies `templates/security/security-exemptions.yaml` to `.claude/security-exemptions.yaml` in the target
+- Copy is skipped if `.claude/security-exemptions.yaml` already exists (idempotent)
+- `shellcheck install.sh` passes after the edit
+- The bash snippet uses `local` variables if inside a function, consistent with existing `install.sh` style
+- `set -euo pipefail` is not broken by the change
+
+**Dependencies:** Task 1
+
+---
+
+## Task 9 — Verify no broken placeholders [agents]
+
+**Description:** After all files are created, run the placeholder integrity check on the new agent files to ensure no unresolved `{{PLACEHOLDER}}` strings exist in `.claude/agents/security-reviewer.md`.
+
+**Files:** Read-only verification
+
+**Command:**
+```bash
+grep -r '{{[A-Z_]*}}' .claude/agents/security-reviewer.md 2>/dev/null || echo "OK: no broken placeholders"
+```
+
+Expected output: `OK: no broken placeholders`
+
+**Acceptance criteria:**
+- The grep command returns no matches (or echoes "OK")
+- If matches are found, fix them in `.claude/agents/security-reviewer.md` before considering this task done
+
+**Dependencies:** Task 4
+
+---
+
+## Task 10 — Verify shellcheck on install.sh [templates]
+
+**Description:** Run `shellcheck install.sh` after Task 8's edit to verify no shell script errors were introduced.
+
+**Command:**
+```bash
+shellcheck install.sh
+```
+
+**Acceptance criteria:**
+- `shellcheck install.sh` exits 0 (no errors)
+- If errors exist: fix them, then re-verify
+
+**Dependencies:** Task 8
+
+---
+
+## Execution Order
+
+```
+Task 1  ──┬──> Task 2 (instance config)
+           └──> Task 8 ──> Task 10 (install.sh)
+
+Task 3  ──> Task 4 ──> Task 9 (verification)
+
+Task 5  (independent)
+
+Task 6  ──> Task 7 (implement.md)
+```
+
+Tasks 1, 3, 5, and 6 can be started in parallel. Tasks 2 and 8 wait for Task 1. Task 4 and 9 follow Task 3. Task 7 follows Task 6. Task 10 follows Task 8.

--- a/openspec/specs/implement.md
+++ b/openspec/specs/implement.md
@@ -1,0 +1,128 @@
+# Spec: /implement Command
+
+The `/implement` command runs the full OpenSpec pipeline: product-manager explores, architect designs, developer implements, reviewer validates, and the result is shipped via git. This spec documents the command's flags, cache structure, and behavior matrix.
+
+---
+
+## Flags
+
+### `--dry-run` / `--preview`
+
+Activates preview mode. All pipeline phases run as normal, except:
+
+- Developer file output is redirected to `.claude/.dry-run/<feature-name>/` instead of real paths.
+- Phase 4a (merge) writes to the cache directory instead of the main repo.
+- Phase 4b (reviewer) reads from and writes to the cache directory.
+- Phase 4c (git, PR creation, backlog updates) is entirely skipped.
+- Phase 4e displays the Dry-Run Preview Report instead of the standard pipeline table.
+
+Both flags are equivalent aliases. Neither modifies git state, creates branches, pushes commits, opens PRs, or comments on backlog issues.
+
+### `--apply <feature-name>`
+
+Applies a previously cached dry-run to the real repo and then runs Phase 4c (git + backlog).
+
+Behavior:
+1. Reads `.cache-manifest.json` from `.claude/.dry-run/<feature-name>/`.
+2. Copies each `cached_path` to its `real_path`, creating parent directories as needed.
+3. Runs Phase 4c (branch creation, commits, push, PR, backlog updates) against the real files.
+4. On success: deletes the cache directory and prints `[apply] Cache cleaned up.`
+5. On failure: preserves the cache directory for re-run.
+
+Skips Phases 1 through 4b entirely — the cached artifacts from the prior dry-run are used directly.
+
+If no cache exists at `.claude/.dry-run/<feature-name>/`, the command stops with:
+```
+[apply] Error: no cached dry-run found at .claude/.dry-run/<feature-name>/
+```
+
+---
+
+## Behavior Matrix
+
+| Flag | Phases Run | Git ops | PR | Backlog | Output |
+|------|-----------|---------|----|---------|---------:|
+| (none) | All | Yes | Yes (if GH_AVAILABLE) | Yes (if BACKLOG_WRITE) | Standard pipeline table |
+| `--dry-run` | All | No | No | No | Dry-Run Preview Report |
+| `--preview` | All | No | No | No | Dry-Run Preview Report |
+| `--apply <name>` | 4c only | Yes | Yes (if GH_AVAILABLE) | Yes (if BACKLOG_WRITE) | Standard pipeline table |
+
+---
+
+## Cache Directory Structure
+
+```
+.claude/.dry-run/<feature-name>/
+├── .cache-manifest.json        # Manifest tracking all cached files and skipped operations
+└── <mirrored file paths>       # Developer output files at mirrored real paths
+    └── src/
+        └── utils/
+            └── parser.ts       # Example: mirrors real path src/utils/parser.ts
+```
+
+The cache directory is excluded from git via `.gitignore` (`.claude/.dry-run/`).
+
+---
+
+## `.cache-manifest.json` Schema
+
+```json
+{
+  "feature": "<feature-name>",
+  "created_at": "<ISO 8601 timestamp>",
+  "dry_run": true,
+  "files": [
+    {
+      "cached_path": ".claude/.dry-run/<feature-name>/src/utils/parser.ts",
+      "real_path": "src/utils/parser.ts",
+      "operation": "create | modify"
+    }
+  ],
+  "openspec_changes": "<feature-name>",
+  "skipped_operations": [
+    "git: branch creation (feat/<feature-name>)",
+    "git: commit",
+    "git: push",
+    "github: pr creation",
+    "github: issue comment #N"
+  ]
+}
+```
+
+### Field descriptions
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `feature` | string | Kebab-case feature name, matches directory name |
+| `created_at` | string | ISO 8601 timestamp of dry-run execution |
+| `dry_run` | boolean | Always `true` in cache manifests |
+| `files` | array | List of all files written by the developer agent |
+| `files[].cached_path` | string | Path where the file was written (under `.dry-run/`) |
+| `files[].real_path` | string | Path where the file would go in the real repo |
+| `files[].operation` | string | `"create"` for new files, `"modify"` for existing files |
+| `openspec_changes` | string | OpenSpec change name, matches `openspec/changes/<name>/` |
+| `skipped_operations` | array | List of git/GitHub/backlog operations that were skipped |
+
+---
+
+## Variable Reference
+
+Variables set during flag detection (Phase 0):
+
+| Variable | Type | Set when | Description |
+|----------|------|----------|-------------|
+| `DRY_RUN` | boolean | `--dry-run` or `--preview` present | Activates preview mode |
+| `APPLY_MODE` | boolean | `--apply` present | Activates apply-from-cache mode |
+| `APPLY_TARGET` | string | `APPLY_MODE=true` | Feature name argument following `--apply` |
+| `CACHE_DIR` | string | Either flag present | Absolute or relative path to the cache directory |
+
+`CACHE_DIR` for `--dry-run` is finalized after the feature name is derived from the remaining input. All phases from 3a onward can reference it.
+
+---
+
+## Edge Cases
+
+- **Stale cache on re-run**: Running `--dry-run` twice with the same feature name overwrites the prior cache. A warning is printed: `[dry-run] Overwriting existing cache at CACHE_DIR`.
+- **CI gap in dry-run**: The reviewer runs CI against the real repo (developer changes not yet applied). CI results may not reflect the final state. The reviewer prompt explicitly notes this caveat.
+- **Developer path discipline**: Dry-run correctness depends on the developer agent writing to the cache path. The developer prompt includes an explicit prohibition: "Do NOT write to real file paths."
+- **Apply after failure**: If `--apply` fails during Phase 4c, the cache is preserved so the user can retry without re-running the full pipeline.

--- a/templates/agents/product-manager.md
+++ b/templates/agents/product-manager.md
@@ -44,6 +44,7 @@ When invoked via `opsx:explore`, your job is to **explore, ideate, and strategiz
 You have {{PERSONA_COUNT}} primary personas defined in `.claude/agents/personas/`. **Always read these files** at the start of any exploration session:
 
 {{PERSONA_FILE_LIST}}
+{{MAINTAINER_PERSONA_LINE}}
 
 These personas include full Value Proposition Canvas profiles (jobs, pains, gains). Use them to ground every feature evaluation in real user needs.
 

--- a/templates/agents/security-reviewer.md
+++ b/templates/agents/security-reviewer.md
@@ -1,0 +1,178 @@
+---
+name: security-reviewer
+description: "Use this agent to scan all modified files for secrets, hardcoded credentials, and security vulnerability patterns after implementation. Runs as part of Phase 4 in the implement pipeline. Do NOT use this agent to fix issues — it scans and reports only.
+
+Examples:
+
+- Example 1:
+  user: (orchestrator) Reviewer completed. Now run the security scan.
+  assistant: \"Launching the security-reviewer agent to scan modified files for secrets and vulnerabilities.\"
+
+- Example 2:
+  user: (orchestrator) Implementation complete. Run security gate before shipping.
+  assistant: \"I'll launch the security-reviewer agent to perform the security scan.\""
+model: sonnet
+color: orange
+memory: project
+---
+
+You are a security-focused code auditor. You scan code for hardcoded secrets, credentials, and OWASP vulnerability patterns. You produce a structured findings report — you never fix code, never suggest changes, and never ask for clarification.
+
+## Your Mission
+
+- Scan every file in MODIFIED_FILES_LIST for secrets and vulnerabilities
+- Detect secrets using the patterns defined below
+- Detect OWASP vulnerability patterns in code files
+- Produce a structured report and set SECURITY_STATUS as the final line of your output
+
+## What You Receive
+
+The orchestrator injects three inputs into your invocation prompt:
+
+- **MODIFIED_FILES_LIST**: the complete list of files created or modified during this implementation run. Scan every file in this list (except those you are instructed to skip).
+- **PIPELINE_CONTEXT**: a brief description of what was implemented — feature names and change names. Use this for context when assessing findings.
+- The exemptions config at `{{SECURITY_EXEMPTIONS_PATH}}`: read this file before reporting to check whether any findings should be suppressed.
+
+## Files to Skip
+
+Do not scan:
+- Binary files (images, compiled artifacts, fonts, archives)
+- `node_modules/`, `vendor/`, `.git/`
+- Lock files: `package-lock.json`, `yarn.lock`, `go.sum`, `Cargo.lock`
+- Files listed under exemptions in `{{SECURITY_EXEMPTIONS_PATH}}`
+
+For every file you skip, note the reason briefly in your findings.
+
+## Secrets Detection
+
+Scan all non-skipped files for the following patterns:
+
+| Category | Pattern | Severity |
+|----------|---------|----------|
+| AWS Access Key ID | `AKIA[0-9A-Z]{16}` | Critical |
+| AWS Secret Access Key | 40-char alphanumeric after `aws_secret` keyword | Critical |
+| GitHub Token | `gh[pousr]_[A-Za-z0-9]{36}` | Critical |
+| Google API Key | `AIza[0-9A-Za-z\-_]{35}` | Critical |
+| Private Key Block | `-----BEGIN (RSA\|EC\|DSA\|OPENSSH) PRIVATE KEY-----` | Critical |
+| Database URL with credentials | `(postgres\|mysql\|mongodb)://[^:]+:[^@]+@` | Critical |
+| Generic API Key (20+ chars) | `api[_-]?key\s*[:=]\s*["'][A-Za-z0-9+/]{20,}` | Critical |
+| Generic Token (20+ chars) | `token\s*[:=]\s*["'][A-Za-z0-9+/]{20,}` | Critical |
+| Slack Webhook | `https://hooks.slack.com/services/T[A-Z0-9]+/` | High |
+| JWT Secret literal | `jwt[_-]?secret\s*[:=]` with non-env-var value | High |
+| Generic Password literal | `password\s*[:=]\s*["'][^"']{8,}` not from env | High |
+
+### Safe patterns — skip these, they are not secrets
+
+- Values referencing `process.env.*`, `os.environ[...]`, or shell `$VAR` syntax
+- Template placeholders: `{{...}}`, `<YOUR_KEY_HERE>`, `PLACEHOLDER`, `<...>`
+- Values in test files (`*.test.*`, `*.spec.*`, `*_test.go`, paths under `testdata/`) — if found, downgrade to Medium rather than skipping entirely
+
+### Entropy heuristic
+
+For any string longer than 20 characters assigned to a variable whose name contains `key`, `token`, `secret`, `password`, `credential`, or `auth`:
+- Estimate Shannon entropy
+- If entropy > 4.5 bits/char AND the value does not match a safe pattern above: flag as High severity
+
+## OWASP Vulnerability Patterns
+
+Apply these checks to code files only. Skip markdown, YAML, JSON, and config files.
+
+| Vulnerability | What to look for | Severity |
+|---------------|-----------------|----------|
+| SQL Injection | String concatenation into SQL queries | High |
+| XSS | Unsanitized user input in `innerHTML`, `dangerouslySetInnerHTML`, `document.write` | High |
+| Insecure Deserialization | `eval()` on user-controlled input, `pickle.loads()`, PHP `unserialize()` | High |
+| Weak JWT | `algorithm: 'none'` or `verify: false` in JWT operations | Critical |
+| Hardcoded credentials | Credentials in config files outside `.env.example` patterns | Critical |
+| Path traversal | User input directly in `path.join()`, `open()`, `fs.readFile()` without validation | High |
+| Command injection | User input in `exec()`, `spawn()`, `subprocess.run()`, `os.system()` | High |
+
+## Exemption Handling
+
+Before finalizing your report:
+
+1. Read `{{SECURITY_EXEMPTIONS_PATH}}`
+2. For each finding, check whether it matches an exemption entry:
+   - Secrets finding: check `exemptions.secrets[].pattern` against the flagged pattern
+   - Vulnerability finding: check `exemptions.vulnerabilities[].rule` and `exemptions.vulnerabilities[].file`
+3. If a match is found: remove the finding from the Critical/High/Medium tables and add a row to the Exemptions Applied table
+4. Exception: Critical findings with a matching exemption are NOT fully suppressed — list them as "Warning: exempted Critical" in the Critical table. Critical exemptions must always be visible.
+
+## Severity Definitions
+
+| Severity | Definition | Pipeline effect |
+|----------|------------|-----------------|
+| Critical | Active credential format, live key, private key block, or OWASP critical pattern | Blocks pipeline — sets SECURITY_STATUS: BLOCKED |
+| High | Likely vulnerability, high-entropy suspicious value, or OWASP high-severity pattern | Warning — sets SECURITY_STATUS: WARNINGS if no Critical |
+| Medium | Possible false positive, test-context concern, or downgraded pattern | Report only, no pipeline impact |
+| Info | Observations about security posture | Report only, no pipeline impact |
+
+## Output Format
+
+Produce exactly this report structure:
+
+```
+## Security Scan Results
+
+### Summary
+- Files scanned: N
+- Findings: X Critical, Y High, Z Medium, W Info
+- Exemptions applied: E
+
+### Critical Findings (BLOCKS MERGE)
+| File | Line | Finding | Pattern |
+|------|------|---------|---------|
+(rows or "None")
+
+### High Findings (Warning)
+| File | Line | Finding | Pattern |
+|------|------|---------|---------|
+(rows or "None")
+
+### Medium Findings (Info)
+| File | Line | Finding | Notes |
+|------|------|---------|-------|
+(rows or "None")
+
+### Exemptions Applied
+| File | Finding | Exemption reason |
+|------|---------|-----------------|
+(rows or "None")
+
+---
+SECURITY_STATUS: BLOCKED
+```
+
+Set the `SECURITY_STATUS:` value as follows:
+- `BLOCKED` — one or more Critical findings exist after exemptions
+- `WARNINGS` — no Critical findings, but one or more High findings exist
+- `CLEAN` — no Critical or High findings
+
+The `SECURITY_STATUS:` line MUST be the very last line of your output. Nothing may follow it.
+
+## Rules
+
+- Never fix code. Never suggest code changes. Scan and report only.
+- Never ask for clarification. Complete the scan with available information.
+- Always scan every file in MODIFIED_FILES_LIST — never skip a file without noting why in your output.
+- Always emit the `SECURITY_STATUS:` line as the very last line of output.
+
+# Persistent Agent Memory
+
+You have a persistent agent memory directory at `{{MEMORY_PATH}}`. Its contents persist across conversations.
+
+As you work, consult your memory files to build on previous experience.
+
+Guidelines:
+- `MEMORY.md` is always loaded — keep it under 200 lines
+- Create separate topic files for detailed notes and link to them from MEMORY.md
+- Update or remove memories that turn out to be wrong or outdated
+
+What to save:
+- False positive patterns you discovered in this repo (patterns that look like secrets but are not)
+- File types or directories that commonly trigger false positives in this repo
+- Recurring true-positive patterns that have been exempted (to watch for recurrences)
+
+## MEMORY.md
+
+Your MEMORY.md is currently empty.

--- a/templates/commands/implement.md
+++ b/templates/commands/implement.md
@@ -69,6 +69,31 @@ Print a setup report:
 
 ## Phase 0: Parse input and determine mode
 
+### Flag Detection
+
+Before parsing input, scan `$ARGUMENTS` for control flags:
+
+- If `--dry-run` or `--preview` is present in `$ARGUMENTS`:
+  - Set `DRY_RUN=true`
+  - Strip the flag from the arguments before further parsing
+  - Print: `[dry-run] Preview mode active — no git, PR, or backlog operations will run.`
+  - Set `CACHE_DIR=.claude/.dry-run/<kebab-case-feature-name>` (derive after parsing the remaining input)
+  - Note: if a cache already exists at `CACHE_DIR`, print `[dry-run] Overwriting existing cache at CACHE_DIR` before overwriting.
+
+- If `--apply <feature-name>` is present in `$ARGUMENTS`:
+  - Set `APPLY_MODE=true`
+  - Set `APPLY_TARGET=<feature-name>` (the argument immediately following `--apply`)
+  - Set `CACHE_DIR=.claude/.dry-run/<feature-name>`
+  - Verify `CACHE_DIR` exists. If it does not: print `[apply] Error: no cached dry-run found at CACHE_DIR` and stop.
+  - Skip Phases 1–4b. Go directly to Phase 4c (the apply path handles the rest).
+  - Strip `--apply` and the feature name before further parsing.
+
+If neither flag is present: `DRY_RUN=false`, `APPLY_MODE=false`. Pipeline runs as normal.
+
+Note: `CACHE_DIR` for `--dry-run` is finalized after the feature name is derived from the remaining input. All subsequent phases that reference `CACHE_DIR` have access to it.
+
+---
+
 **If the user passed a text description** (e.g. `"add feature X"`):
 - **Single-feature mode**. Derive a kebab-case change name.
 - Set `SINGLE_MODE = true`. No worktrees, no parallelism.
@@ -137,6 +162,23 @@ Before launching any developer agent, run a trivial Bash command to confirm Bash
 
 **Read reviewer learnings:** Check `.claude/agent-memory/reviewer/common-fixes.md` and include in developer prompts.
 
+#### Dry-Run: Redirect developer writes
+
+**If `DRY_RUN=true`**, include the following in every developer agent prompt:
+
+> IMPORTANT: This is a dry-run. Write all new or modified files under:
+>   .claude/.dry-run/\<feature-name\>/
+>
+> Mirror the real destination path within this directory. For example:
+>   Real path:   src/utils/parser.ts
+>   Write to:    .claude/.dry-run/\<feature-name\>/src/utils/parser.ts
+>
+> Do NOT write to real file paths. After writing each file, append an entry
+> to .claude/.dry-run/\<feature-name\>/.cache-manifest.json using this JSON format:
+>   {"cached_path": "...", "real_path": "...", "operation": "create|modify"}
+
+**If `DRY_RUN=false`**: developer agent instructions are unchanged.
+
 #### Choosing the right developer agent
 
 For each feature, analyze the tasks' layer tags:
@@ -156,7 +198,9 @@ Wait for all developers to complete.
 
 ### 4a. Merge worktree changes to main repo
 
-If `SINGLE_MODE`: skip. Otherwise copy feature-specific files, merge shared files manually, clean up worktrees.
+- If `SINGLE_MODE`: skip (no worktrees were used).
+- If `DRY_RUN=true`: merge worktree outputs to `CACHE_DIR` instead of the main repo. Apply the same merge logic (copy feature-specific files, handle shared files) but destination is `CACHE_DIR/<file-path>`.
+- Otherwise: merge to main repo working tree as normal (copy feature-specific files, merge shared files manually, clean up worktrees).
 
 ### 4b. Launch Reviewer agent
 
@@ -166,7 +210,59 @@ Launch a single **reviewer** agent to validate ALL merged changes. Include:
 - Record learnings to `common-fixes.md`
 - Archive completed changes via OpenSpec
 
+**If `DRY_RUN=true`**, add the following to the reviewer agent prompt:
+
+> Note: This is a dry-run review. Developer files are under .claude/.dry-run/\<feature-name\>/.
+> Read modified files from there. Write any reviewer fixes back to CACHE_DIR (not real paths).
+> CI commands may be run — they read the real repo, but be aware developer changes are not
+> yet applied to real paths.
+
+### 4b-sec. Launch Security Reviewer agent
+
+After the reviewer agent completes, launch a **security-reviewer** agent (`subagent_type: security-reviewer`).
+
+Construct the agent invocation prompt to include:
+- **MODIFIED_FILES_LIST**: the complete list of files created or modified during this implementation run
+- **PIPELINE_CONTEXT**: brief description — feature names and change names implemented
+- The exemptions config path: `.claude/security-exemptions.yaml`
+
+Wait for the security-reviewer to complete. Parse the final line of its output:
+- `SECURITY_STATUS: BLOCKED` → set `SECURITY_BLOCKED=true`
+- `SECURITY_STATUS: WARNINGS` → set `SECURITY_BLOCKED=false`, capture warning summary
+- `SECURITY_STATUS: CLEAN` → set `SECURITY_BLOCKED=false`
+
 ### 4c. Ship — Git & backlog updates
+
+**Security gate:** If `SECURITY_BLOCKED=true`:
+1. Print all Critical findings from the security-reviewer output
+2. Do NOT create a branch, commit, push, or PR
+3. Print: "Pipeline blocked by security findings. Fix the Critical issues listed above and re-run /implement."
+4. Skip to Phase 4e.
+
+### Dry-Run Gate
+
+**If `DRY_RUN=true`:**
+Print: `[dry-run] Skipping all git and backlog operations.`
+Record skipped operations to `.cache-manifest.json` under `skipped_operations`:
+- `"git: branch creation (feat/<name>)"`
+- `"git: commit"`
+- `"git: push"`
+- `"github: pr creation"` (if `GH_AVAILABLE=true`)
+- `"github: issue comment #N"` for each issue in scope (if `BACKLOG_WRITE=true`)
+
+Then skip the rest of Phase 4c and proceed directly to Phase 4e.
+
+**If `APPLY_MODE=true`:**
+1. Read `.cache-manifest.json` from `CACHE_DIR`.
+2. For each entry in `files`: copy `cached_path` to `real_path`, creating directories as needed.
+3. Print: `[apply] Copied N files from .claude/.dry-run/<feature-name>/ to real locations.`
+4. Then proceed with Phase 4c normally (GIT_AUTO logic, backlog updates) using the real files.
+5. On successful completion of Phase 4c: delete `CACHE_DIR` and print `[apply] Cache cleaned up.`
+   If Phase 4c fails: preserve `CACHE_DIR` for re-run.
+
+**Otherwise:** proceed as normal.
+
+---
 
 This phase respects the `GIT_AUTO` and `BACKLOG_WRITE` settings from configuration.
 
@@ -238,9 +334,50 @@ If `GIT_AUTO=false`: skip — the user will push and monitor CI themselves.
 
 ### 4e. Report
 
+**If `DRY_RUN=true`**, show this report instead of the standard pipeline table:
+
+---
+
+## Dry-Run Preview Report
+
+### Artifacts Generated
+
+| Type | Location |
+|------|----------|
+| OpenSpec proposal | openspec/changes/\<name\>/proposal.md |
+| OpenSpec design | openspec/changes/\<name\>/design.md |
+| OpenSpec tasks | openspec/changes/\<name\>/tasks.md |
+| OpenSpec context-bundle | openspec/changes/\<name\>/context-bundle.md |
+| Developer files | .claude/.dry-run/\<name\>/ (N files) |
+
+### What Would Change
+
+[For each file in `.cache-manifest.json` `files` array:]
+- `<real_path>` — [new file / modified] ([approximate line delta if available])
+
+### Operations Skipped
+
+[List items from `.cache-manifest.json` `skipped_operations` array]
+
+### Next Steps
+
+To apply these changes and ship:
 ```
-| Area | Feature | Change Name | Architect | Developer | Reviewer | Tests | CI | Status |
-|------|---------|-------------|-----------|-----------|----------|-------|----|--------|
+/implement --apply <feature-name>
+```
+
+To discard this dry run:
+```
+rm -rf .claude/.dry-run/<feature-name>/
+```
+
+---
+
+**Otherwise**, show the standard pipeline table:
+
+```
+| Area | Feature | Change Name | Architect | Developer | Reviewer | Security | Tests | CI | Status |
+|------|---------|-------------|-----------|-----------|----------|----------|-------|----|--------|
 ```
 
 Include the shipping mode in the report:

--- a/templates/personas/the-maintainer.md
+++ b/templates/personas/the-maintainer.md
@@ -1,0 +1,78 @@
+# Persona: The Maintainer
+
+> "I maintain this project in my spare time. Every hour I save on routine work is an hour I can spend on what actually matters."
+
+## Profile
+
+| Field | Value |
+|-------|-------|
+| **Name** | "Kai" — The Maintainer |
+| **Age** | 25-45 |
+| **Role** | Open-source maintainer, often solo or with 1-3 co-maintainers |
+| **Projects** | 1-5 active repos, ranging from 100 to 50k+ stars |
+| **Experience** | Deep expertise in their project's domain; variable breadth across stacks |
+| **Tools today** | GitHub (Issues, PRs, Actions), Dependabot, CodeQL, Claude Code or Copilot |
+| **Spending** | $0-20/month (OSS maintainers are cost-sensitive; many rely on free tiers/sponsorships) |
+| **Tech comfort** | Very high — but time-poor; optimizes for efficiency above all |
+
+## Behaviors
+
+- Reviews 5-50 PRs per week, most from contributors they've never met
+- Spends disproportionate time on triage — labeling issues, requesting info, closing duplicates
+- Deeply skeptical of AI-generated PRs and "drive-by" contributions
+- Values consistency and backwards compatibility over new features
+- Writes detailed contributing guides but contributors rarely read them
+- Burns out from the imbalance: contribution volume grows but maintainer capacity doesn't
+- Will adopt automation that reduces their review burden without sacrificing quality
+
+## Value Proposition Canvas
+
+### Customer Jobs
+
+| Type | Job |
+|------|-----|
+| Functional | Review and merge contributions efficiently without sacrificing quality |
+| Functional | Maintain coding standards across a growing contributor base |
+| Functional | Triage issues and PRs — separate signal from noise |
+| Functional | Keep CI/CD green and catch regressions early |
+| Social | Build a healthy community where contributors feel welcomed and guided |
+| Emotional | Avoid burnout from the growing volume of contributions and issues |
+| Emotional | Feel that their project is sustainable, not just surviving |
+
+### Pains
+
+| Severity | Pain |
+|----------|------|
+| Critical | "Eternal September" — AI lowers contribution friction, flooding maintainers with low-quality PRs |
+| Critical | Review burden scales with contributors but maintainer time doesn't |
+| High | AI-generated contributions that look plausible but miss project conventions or architectural intent |
+| High | No way to enforce project-specific coding standards automatically beyond basic linting |
+| Medium | Automated scanning tools (security, code quality) generate noise — hard to distinguish real issues |
+| Medium | Onboarding contributors to the project's specific patterns and conventions is time-consuming |
+| Medium | Feature requests pile up with no framework to evaluate which ones matter most to users |
+| Low | Sponsorship/funding doesn't scale with project popularity or maintenance burden |
+
+### Gains
+
+| Impact | Gain |
+|--------|------|
+| High | Automated review that enforces project-specific conventions, not just generic lint rules |
+| High | AI reviewer that knows the codebase deeply — catches architectural violations, not just style issues |
+| High | Reduced time spent on routine reviews, freeing time for design decisions and community |
+| Medium | Structured feature prioritization based on actual user needs (not loudest voices) |
+| Medium | Implementation pipeline that lets maintainers describe features and get convention-compliant PRs |
+| Medium | Institutional memory — the AI system remembers past decisions and enforces them consistently |
+| Low | Easy setup that works with existing GitHub-based workflows (Issues, Actions, PRs) |
+| Low | Free or very low cost for open-source projects |
+
+## Key Insight
+
+> Open-source maintainers are the most **time-constrained** users in the software ecosystem. They don't need more AI to *write* code — they need AI that *understands their project deeply enough* to review contributions, enforce conventions, and handle routine tasks so they can focus on architecture and community. The key unlock is project-specific intelligence, not generic coding ability.
+
+## Sources
+
+- [GitHub Blog — Welcome to the Eternal September of Open Source](https://github.blog/open-source/maintainers/welcome-to-the-eternal-september-of-open-source-heres-what-we-plan-to-do-for-maintainers/)
+- [st0012.dev — AI and Open Source: A Maintainer's Take (End of 2025)](https://st0012.dev/2025/12/30/ai-and-open-source-a-maintainers-take-end-of-2025/)
+- [The New Stack — Open Source: Inside 2025's 4 Biggest Trends](https://thenewstack.io/open-source-inside-2025s-4-biggest-trends/)
+- [Anthropic — 2026 Agentic Coding Trends Report](https://resources.anthropic.com/hubfs/2026%20Agentic%20Coding%20Trends%20Report.pdf)
+- [Augment Code — 6 Best Devin Alternatives for AI Agent Orchestration](https://www.augmentcode.com/tools/best-devin-alternatives)

--- a/templates/security/security-exemptions.yaml
+++ b/templates/security/security-exemptions.yaml
@@ -1,0 +1,20 @@
+# Security scan exemptions
+#
+# Add entries here to suppress known false positives from the security-reviewer agent.
+# All exemptions are tracked in git — every addition is auditable.
+#
+# Fields:
+#   secrets.pattern   - Description of the pattern being exempted (for documentation)
+#   secrets.reason    - Required: why this is a known false positive
+#   secrets.added_by  - Required: who added this exemption
+#   secrets.added_on  - Required: ISO 8601 date (YYYY-MM-DD)
+#
+#   vulnerabilities.rule    - The vulnerability rule name being exempted
+#   vulnerabilities.file    - Optional: scope exemption to a specific file path
+#   vulnerabilities.reason  - Required: justification
+#   vulnerabilities.added_by - Required
+#   vulnerabilities.added_on - Required
+
+exemptions:
+  secrets: []
+  vulnerabilities: []


### PR DESCRIPTION
## Summary

Implements the top 3 items from the product-driven backlog (Sprint 1):

- **#4 Security & Secrets Reviewer Agent** (12/15 VPC score) — New agent that scans for hardcoded secrets, API keys, and OWASP vulnerabilities as a Phase 4b-sec gate in the `/implement` pipeline. Blocks merge on Critical findings. Per-project exemptions via `.claude/security-exemptions.yaml`.
- **#18 Local Agent Dry-Run / Preview Mode** (10/15 VPC score) — Adds `--dry-run`/`--preview` flag to `/implement`. Runs the full pipeline without creating branches, PRs, or updating issues. Cached artifacts can be shipped later with `--apply`.
- **#13 Formalize OSS Maintainer Persona** (5/15 VPC score) — Auto-detects OSS projects during install (public repo + CI + CONTRIBUTING.md) and conditionally includes the Maintainer persona (Kai) in VPC scoring.

## Changes

### New files
- `templates/agents/security-reviewer.md` — Agent prompt template
- `.claude/agents/security-reviewer.md` — Generated agent (placeholders resolved)
- `templates/security/security-exemptions.yaml` — Exemptions config template
- `.claude/security-exemptions.yaml` — Instance config
- `.claude/agent-memory/security-reviewer/MEMORY.md` — Agent memory
- `templates/personas/the-maintainer.md` — Maintainer persona template
- `.gitignore` — Excludes `.claude/.dry-run/`
- `openspec/specs/implement.md` — Implement command spec (flags, cache, behavior matrix)
- `openspec/changes/archive/` — Archived change artifacts for all 3 features

### Modified files
- `templates/commands/implement.md` — Phase 4b-sec (security gate), dry-run flag detection, cache redirect, preview report
- `.claude/commands/implement.md` — Same changes (generated copy)
- `install.sh` — OSS detection (Phase 1.6), security exemptions copy
- `commands/setup.md` — OSS detection display, conditional Maintainer persona inclusion
- `templates/agents/product-manager.md` — `{{MAINTAINER_PERSONA_LINE}}` placeholder

## Test plan

- [ ] `grep -r '{{[A-Z_]*}}' .claude/agents/security-reviewer.md` returns no matches
- [ ] `shellcheck install.sh` passes
- [ ] Verify Phase 4b-sec block exists in both implement command files
- [ ] Verify security gate precedes dry-run gate in Phase 4c
- [ ] Verify `.gitignore` contains `.claude/.dry-run/`
- [ ] Verify `templates/personas/the-maintainer.md` matches `.claude/agents/personas/the-maintainer.md`
- [ ] Verify `{{MAINTAINER_PERSONA_LINE}}` appears in product-manager template

---
Implemented via `/implement` pipeline (architect → developer → reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)