### PR TITLE
feat: automated test writer agent

### DIFF
--- a/.claude/agent-memory/architect/MEMORY.md
+++ b/.claude/agent-memory/architect/MEMORY.md
@@ -5,3 +5,4 @@
 - [project_specrails_structure.md](project_specrails_structure.md) — repo layout, key files, self-hosting pattern
 - [project_implement_pipeline.md](project_implement_pipeline.md) — implement command phase structure and variable conventions
 - [setup_flow_and_personas.md](setup_flow_and_personas.md) — /setup phase map, persona system, install.sh→/setup handoff pattern
+- [openspec_artifact_conventions.md](openspec_artifact_conventions.md) — OpenSpec artifact format, frontmatter schema, cross-file consistency patterns

--- a/.claude/agent-memory/architect/openspec_artifact_conventions.md
+++ b/.claude/agent-memory/architect/openspec_artifact_conventions.md
@@ -1,0 +1,68 @@
+---
+name: openspec_artifact_conventions
+description: Conventions for OpenSpec change artifacts — frontmatter schemas, cross-file consistency rules, and patterns discovered across multiple change sets
+type: project
+---
+
+# OpenSpec Artifact Conventions
+
+## Frontmatter Schema (all 5 artifact types)
+
+Each artifact has a YAML frontmatter block:
+
+```yaml
+---
+change: <kebab-case-change-name>      # same across all 5 files
+type: feature | design | delta-spec | tasks | context-bundle
+status: proposed                      # proposal.md only
+github_issue: <number>               # proposal.md only
+vpc_fit: <percent>%                  # proposal.md only
+---
+```
+
+## The 5 Required Artifacts
+
+| File | Type value | Purpose |
+|------|-----------|---------|
+| `proposal.md` | `feature` | Problem, solution, scope, acceptance criteria, motivation |
+| `design.md` | `design` | Technical architecture, file changes, design decisions, edge cases |
+| `delta-spec.md` | `delta-spec` | Spec-level statements ("SHALL", "MUST") — what the system does after the change |
+| `tasks.md` | `tasks` | Ordered atomic tasks with layer tags, files, acceptance criteria, dependencies |
+| `context-bundle.md` | `context-bundle` | Self-contained developer briefing — no other file needed |
+
+## Cross-file Consistency Rules
+
+1. **Report table**: The Phase 4e report table in `templates/commands/implement.md` is the single source of truth for pipeline status columns. When designing a new phase, verify the current table column order before specifying "before/after" — columns may have been added by prior changes.
+
+2. **Agent colors**: Maintain a registry of assigned colors to avoid collision:
+   - `green` — architect
+   - `purple` — developer (and layer variants)
+   - `red` — reviewer
+   - `orange` — security-reviewer
+   - `cyan` — test-writer (assigned 2026-03-13)
+
+3. **Placeholder naming**: Use `{{UPPER_SNAKE_CASE}}` only for static substitutions by install.sh. Runtime-injected values (like `IMPLEMENTED_FILES_LIST`) appear in the prompt body as plain text references, never as `{{...}}`.
+
+4. **Always-on vs. flagged agents**: The pattern is always-on with graceful degradation (SKIPPED status) rather than opt-out flags. See security-reviewer and test-writer as examples.
+
+5. **Non-blocking failure pattern**: New agents should be non-blocking by default. If an agent fails, the pipeline logs FAILED in the report column and continues. Only security Critical findings block Phase 4c.
+
+## Phase Numbering in implement.md
+
+Current phase map as of 2026-03-13:
+- Phase -1: Environment Setup
+- Phase 0: Parse input and determine mode
+- Phase 1: Explore (parallel)
+- Phase 2: Select
+- Phase 3a: Architect
+- Phase 3b: Implement (developer)
+- Phase 3c: Write Tests (test-writer) — added by automated-test-writer change
+- Phase 4: Merge & Review
+  - 4a: Merge worktrees
+  - 4b: Reviewer
+  - 4b-sec: Security Reviewer
+  - 4c: Ship
+  - 4d: Monitor CI
+  - 4e: Report
+
+**Why:** Always check the current implement.md before assigning a new phase number — phases have been inserted between existing ones (3b → 3c) and between sub-phases (4b → 4b-sec).

--- a/.claude/agent-memory/developer/MEMORY.md
+++ b/.claude/agent-memory/developer/MEMORY.md
@@ -1,3 +1,4 @@
 # Developer Agent Memory
 
-No memories recorded yet.
+- [Agent template pattern](agent-template-pattern.md) — how to create new agent templates and generated instances
+- [Implement command structure](implement-command-structure.md) — phase ordering and insertion points in the pipeline command

--- a/.claude/agent-memory/developer/agent-template-pattern.md
+++ b/.claude/agent-memory/developer/agent-template-pattern.md
@@ -1,0 +1,52 @@
+---
+name: agent-template-pattern
+description: How to create new agent template files and their generated instances in specrails
+type: project
+---
+
+Every new agent requires two files plus a memory directory:
+
+1. `templates/agents/<name>.md` — canonical template with `{{PLACEHOLDER}}` syntax
+2. `.claude/agents/<name>.md` — generated instance with all placeholders resolved
+3. `.claude/agent-memory/<name>/MEMORY.md` — initial empty memory file
+
+**Why:** templates are copied by install.sh into target repos; the .claude/ copy is used by specrails itself.
+
+**How to apply:** When adding any new agent, always create all three. Never leave a .claude/ agent file with unresolved `{{...}}` strings.
+
+### YAML frontmatter required fields
+
+```yaml
+---
+name: <kebab-case-name>
+description: "Multi-line string with usage examples"
+model: sonnet
+color: <color-name>
+memory: project
+---
+```
+
+### Assigned colors (do not reuse)
+- `green` — architect
+- `purple` — developer
+- `red` — reviewer
+- `orange` — security-reviewer
+- `cyan` — test-writer
+
+### Placeholders used by agent templates
+- `{{TECH_EXPERTISE}}` — polyglot stack description (resolved from .claude/agents/developer.md)
+- `{{LAYER_CLAUDE_MD_PATHS}}` — e.g. `.claude/rules/*.md`
+- `{{MEMORY_PATH}}` — e.g. `.claude/agent-memory/<name>/`
+- `{{SECURITY_EXEMPTIONS_PATH}}` — security-reviewer specific
+
+### Memory file initial content
+```markdown
+# <Title Case Name> Agent Memory
+
+No memories recorded yet.
+```
+
+### Verification after creating
+```bash
+grep -r '{{[A-Z_]*}}' .claude/agents/<name>.md 2>/dev/null || echo "OK: no broken placeholders"
+```

--- a/.claude/agent-memory/developer/implement-command-structure.md
+++ b/.claude/agent-memory/developer/implement-command-structure.md
@@ -1,0 +1,43 @@
+---
+name: implement-command-structure
+description: Phase ordering and key insertion points in the implement pipeline command
+type: project
+---
+
+The implement pipeline lives in two files that must always be kept in sync:
+- `templates/commands/implement.md` — the template (has `{{PLACEHOLDER}}` strings)
+- `.claude/commands/implement.md` — the generated specrails instance (no placeholders)
+
+**Why:** The template is installed into target repos. The .claude/ copy drives the pipeline when using specrails itself.
+
+### Phase order (as of automated-test-writer change)
+
+```
+Phase -1: Environment Setup
+Phase 0:  Parse input and determine mode
+Phase 1:  Explore (parallel)
+Phase 2:  Select
+Phase 3a: Architect (parallel, in main repo)
+Phase 3b: Implement
+Phase 3c: Write Tests   ← NEW (after 3b "Wait for all developers to complete.")
+Phase 4:  Merge & Review
+  4a. Merge worktree changes
+  4b. Launch Reviewer agent
+  4b-sec. Launch Security Reviewer agent
+  4c. Ship
+  4d. Monitor CI
+  4e. Report
+```
+
+### Phase 4e report table column order
+
+```
+| Area | Feature | Change Name | Architect | Developer | Tests | Reviewer | Security | CI | Status |
+```
+
+Tests column is between Developer and Reviewer, reflecting pipeline execution order.
+
+### Key insertion anchor lines
+
+- Phase 3c is inserted AFTER: "Wait for all developers to complete."
+- Phase 3c is inserted BEFORE: "## Phase 4: Merge & Review"

--- a/.claude/agent-memory/reviewer/MEMORY.md
+++ b/.claude/agent-memory/reviewer/MEMORY.md
@@ -1,3 +1,5 @@
 # Reviewer Agent Memory
 
-No memories recorded yet.
+## Index
+
+- [common-fixes.md](common-fixes.md) — Recurring CI failure patterns and fixes: placeholder grep false positives, template vs instance placeholder count, shellcheck availability

--- a/.claude/agent-memory/reviewer/common-fixes.md
+++ b/.claude/agent-memory/reviewer/common-fixes.md
@@ -1,0 +1,35 @@
+---
+name: common-fixes
+description: Recurring CI failure patterns and their fixes found during code reviews
+type: project
+---
+
+# Common Fixes
+
+## Placeholder grep false positives
+
+**Pattern:** `grep -r '{{[A-Z_]*}}' .claude/agents/` flags existing agent files (reviewer.md, architect.md, developer.md, rules/templates.md) that contain `{{PLACEHOLDER}}` in documentation prose — not as unresolved substitutions.
+
+**Why:** These files use the `{{...}}` notation to document the convention itself ("use `{{UPPER_SNAKE_CASE}}` for placeholders"). They are not broken.
+
+**How to apply:** When the placeholder check flags hits in existing (non-newly-generated) files, confirm the match is in a documentation context (backtick-quoted or descriptive sentence) rather than a bare value. Only flag bare `{{WORD}}` usages outside of documentation/example prose.
+
+---
+
+## Template vs instance placeholder count
+
+**Pattern:** Template agent files should contain exactly the documented placeholders (e.g., `{{TECH_EXPERTISE}}`, `{{LAYER_CLAUDE_MD_PATHS}}`, `{{MEMORY_PATH}}`). The generated instance must contain zero `{{...}}` strings.
+
+**Verification command:**
+```bash
+grep -c '{{' templates/agents/<name>.md   # should equal expected count
+grep -c '{{' .claude/agents/<name>.md     # must be 0
+```
+
+---
+
+## shellcheck not installed
+
+**Pattern:** `shellcheck` is not in PATH on this machine. The check exits with "command not found" but is treated as non-fatal (`|| true`).
+
+**How to apply:** Until shellcheck is installed, the shell validation check is advisory only. Manual review of `set -euo pipefail`, quoted variables, and `local` usage in shell scripts is required.

--- a/.claude/agent-memory/test-writer/MEMORY.md
+++ b/.claude/agent-memory/test-writer/MEMORY.md
@@ -1,0 +1,3 @@
+# Test Writer Agent Memory
+
+No memories recorded yet.

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -1,0 +1,167 @@
+---
+name: test-writer
+description: "Use this agent after a developer agent completes implementation, to generate comprehensive tests for the implemented code. Runs as Phase 3c in the implement pipeline, before the reviewer.
+
+Examples:
+
+- Example 1:
+  user: (orchestrator) Developer agent completed. Write tests for the implemented files.
+  assistant: \"Launching the test-writer agent to generate tests for the implemented code.\"
+
+- Example 2:
+  user: (orchestrator) Implementation done. Run test writer before review.
+  assistant: \"I'll use the test-writer agent to write tests following the project's test patterns.\""
+model: sonnet
+color: cyan
+memory: project
+---
+
+You are a specialist test engineer. Your only job is to write tests — you never modify implementation files.
+
+## Your Identity & Expertise
+
+You are a polyglot test engineer with deep knowledge of testing patterns across the full stack:
+- **Shell scripting**: Bash, POSIX sh, installers, CLI tools
+- **TypeScript/JavaScript**: Node.js, CLI frameworks (commander, oclif, yargs), npm packaging
+- **Template systems**: Markdown templates with placeholder substitution, code generation
+- **Developer tooling**: CI/CD pipelines, GitHub Actions, package distribution
+- **AI prompt engineering**: Claude Code agents, structured prompts, multi-agent orchestration
+
+You write tests that are meaningful, maintainable, and maximize coverage of the code under test.
+
+## Your Mission
+
+Generate comprehensive tests for newly implemented code, targeting >80% coverage of all files in IMPLEMENTED_FILES_LIST. You write unit tests, integration tests, edge case tests, and error handling tests. You never run tests — running is the reviewer's job.
+
+## What You Receive
+
+The orchestrator injects these inputs into your invocation prompt:
+
+- **IMPLEMENTED_FILES_LIST**: the complete list of files the developer created or modified for this feature. Write tests for every file in this list (except those you are instructed to skip).
+- **TASK_DESCRIPTION**: the original task or feature description that drove the implementation. Use this to understand intent when generating edge cases.
+- Layer conventions at `.claude/rules/*.md`: read these before generating tests to understand project-specific patterns.
+
+## Framework Detection Protocol
+
+Detect the test framework by reading manifest files in this order. Stop at the first match.
+
+| Manifest File | Condition | Framework | Test runner |
+|---------------|-----------|-----------|-------------|
+| `package.json` | `jest` in scripts or devDependencies | Jest | `npx jest` / `npm test` |
+| `package.json` | `vitest` in scripts or devDependencies | Vitest | `npx vitest` |
+| `package.json` | `mocha` in scripts or devDependencies | Mocha | `npx mocha` |
+| `requirements.txt` or `pyproject.toml` | file exists | pytest | `pytest` |
+| `Gemfile` | contains `rspec` | RSpec | `bundle exec rspec` |
+| `go.mod` | file exists | Go test | `go test ./...` |
+| `Cargo.toml` | file exists | cargo test | `cargo test` |
+| `composer.json` | contains `phpunit` | PHPUnit | `./vendor/bin/phpunit` |
+
+If no framework is detected: output `TEST_WRITER_STATUS: SKIPPED` with reason "no test framework detected" and stop. Do not attempt to write tests.
+
+## Pattern Learning Protocol
+
+Before writing any tests, read up to 3 representative existing test files from the project to learn:
+1. **Naming convention** — how test files are named relative to source files (e.g., `foo.test.ts` vs `foo_test.go` vs `spec/foo_spec.rb`)
+2. **Directory structure** — where tests live (alongside source, in a `test/` root, in `__tests__/`, etc.)
+3. **Import style** — how the module under test is imported or required
+4. **Assertion library** — which assertion style is used (e.g., `expect`, `assert`, `should`)
+5. **Test block structure** — `describe`/`it`, `test()`, `def test_`, `func Test`, `RSpec.describe`, etc.
+6. **Mock patterns** — how dependencies are mocked or stubbed (jest.mock, unittest.mock, testify mocks, etc.)
+
+Apply every learned pattern exactly when writing new tests.
+
+## Test Generation Mandate
+
+For each file in IMPLEMENTED_FILES_LIST (that is not skipped), write:
+
+- **Unit tests**: test each exported function or method in isolation
+- **Integration tests**: test interactions between components where applicable
+- **Edge case tests**: test boundary values, empty inputs, maximum inputs, type coercions
+- **Error handling tests**: test that errors are thrown/returned correctly for invalid inputs and failure paths
+
+Target >80% coverage of new code. Prioritize branches, error paths, and exported API surface.
+
+## Test Writing Rules
+
+1. **Never modify implementation files.** If you determine that an implementation file is untestable as written, write a best-effort test and prepend the test file with a comment: `# UNTESTABLE: <reason>` (use the comment syntax of the target language).
+2. **Follow exact naming and structure of existing tests.** Do not invent a new convention.
+3. **One test file per implementation file** unless the project convention clearly differs (e.g., a single `spec/` directory with grouped specs).
+4. **Do not add test dependencies** that are not already present in the project's manifest.
+5. **Do not import test utilities** that do not exist in the project.
+
+## Files to Skip
+
+Do not write tests for:
+- Auto-generated files: database migrations, type declaration stubs (`.d.ts`), scaffold output, generated GraphQL types
+- Binary files: images, compiled artifacts, fonts, archives
+- Configuration files with no logic: `.env.example`, `tsconfig.json`, `jest.config.js`, `Cargo.toml`, `go.mod`
+- Lock files: `package-lock.json`, `yarn.lock`, `go.sum`, `Cargo.lock`
+
+For every file you skip, note the reason in your output.
+
+## Output Format
+
+After writing all test files, produce this report:
+
+```
+## Test Writer Results
+
+### Framework
+- Detected: <framework name>
+- Test runner: <command>
+
+### Patterns Learned
+- Naming: <pattern>
+- Directory: <location>
+- Assertion style: <style>
+- Mock style: <style>
+
+### Tests Written
+| Implementation File | Test File | Coverage Description |
+|--------------------|-----------|---------------------|
+| <file> | <test file path> | <brief description of what is tested> |
+
+### Files Skipped
+| File | Reason |
+|------|--------|
+(rows or "None")
+
+---
+TEST_WRITER_STATUS: DONE
+```
+
+Set `TEST_WRITER_STATUS:` as follows:
+- `DONE` — one or more test files written successfully
+- `SKIPPED` — no test framework detected or all files were in the skip list
+- `FAILED` — an unrecoverable error occurred
+
+The `TEST_WRITER_STATUS:` line MUST be the very last line of your output. Nothing may follow it.
+
+## Rules
+
+- Never modify implementation files. Generate test files only.
+- Never run tests. Writing only — execution is the reviewer's responsibility.
+- Never ask for clarification. Complete test generation with available information.
+- Always emit the `TEST_WRITER_STATUS:` line as the very last line of output.
+- If framework detection fails: output `TEST_WRITER_STATUS: SKIPPED` immediately. Do not guess or invent a framework.
+
+# Persistent Agent Memory
+
+You have a persistent agent memory directory at `.claude/agent-memory/test-writer/`. Its contents persist across conversations.
+
+As you work, consult your memory files to build on previous experience.
+
+Guidelines:
+- `MEMORY.md` is always loaded — keep it under 200 lines
+- Create separate topic files for detailed notes and link to them from MEMORY.md
+- Update or remove memories that turn out to be wrong or outdated
+
+What to save:
+- Test framework and runner confirmed for this repo
+- Test directory structure and naming conventions discovered
+- Patterns for mocking dependencies in this codebase
+- Files or directories that are always in the skip list for this repo
+
+## MEMORY.md
+
+Your MEMORY.md is currently empty.

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -196,6 +196,38 @@ All tasks currently route to the full-stack **developer** agent since the projec
 
 Wait for all developers to complete.
 
+## Phase 3c: Write Tests
+
+Launch a **test-writer** agent for each feature immediately after its developer completes.
+
+Construct the agent invocation prompt to include:
+- **IMPLEMENTED_FILES_LIST**: the complete list of files the developer created or modified for this feature
+- **TASK_DESCRIPTION**: the original task or feature description that drove the implementation
+
+### Launch modes
+
+**If `SINGLE_MODE`**: Launch a single test-writer agent in the foreground (`run_in_background: false`). Wait for it to complete before proceeding to Phase 4.
+
+**If multiple features (worktrees)**: Launch one test-writer agent per feature, each in its corresponding worktree (`isolation: worktree`, `run_in_background: true`). Wait for all test-writer agents to complete before proceeding to Phase 4.
+
+### Dry-run behavior
+
+**If `DRY_RUN=true`**, include in every test-writer agent prompt:
+
+> IMPORTANT: This is a dry-run. Write all new or modified test files under:
+>   .claude/.dry-run/\<feature-name\>/
+>
+> Mirror the real destination path within this directory. After writing each file, append an entry
+> to .claude/.dry-run/\<feature-name\>/.cache-manifest.json using:
+>   {"cached_path": "...", "real_path": "...", "operation": "create"}
+
+### Failure handling
+
+If a test-writer agent fails or times out:
+- Record `Tests: FAILED` for that feature in the Phase 4e report
+- Continue to Phase 4 — the test-writer failure is non-blocking
+- Include in the reviewer agent prompt: "Note: the test-writer failed for this feature. Check for coverage gaps."
+
 ## Phase 4: Merge & Review
 
 **This phase is fully autonomous.**
@@ -356,8 +388,8 @@ rm -rf .claude/.dry-run/<feature-name>/
 **Otherwise**, show the standard pipeline table:
 
 ```
-| Area | Feature | Change Name | Architect | Developer | Reviewer | Security | Tests | CI | Status |
-|------|---------|-------------|-----------|-----------|----------|----------|-------|----|--------|
+| Area | Feature | Change Name | Architect | Developer | Tests | Reviewer | Security | CI | Status |
+|------|---------|-------------|-----------|-----------|-------|----------|----------|----|--------|
 ```
 
 Include PR URL, CI status, and backlog updates made.

--- a/openspec/changes/archive/2026-03-13-automated-test-writer/context-bundle.md
+++ b/openspec/changes/archive/2026-03-13-automated-test-writer/context-bundle.md
@@ -1,0 +1,233 @@
+---
+change: automated-test-writer
+type: context-bundle
+---
+
+# Context Bundle: Automated Test Writer Agent
+
+This document contains everything a developer needs to implement this change without reading any other file. It bundles key context from the design, delta-spec, and codebase exploration.
+
+---
+
+## What You Are Building
+
+A new Claude Code agent called `test-writer` that:
+1. Detects the target repo's test framework from standard manifest files
+2. Reads existing test files to learn the project's test patterns
+3. Generates unit tests, integration tests, edge case tests, and error handling tests for newly implemented code
+4. Targets >80% coverage of new code
+5. Integrates into the implement pipeline as **Phase 3c**, running after the developer (Phase 3b) and before the reviewer (Phase 4)
+6. Is non-blocking on failure — if the agent fails, the pipeline continues
+
+The agent is a **markdown prompt file** — no shell scripts, no external tool dependencies. All test generation happens through Claude's code analysis.
+
+---
+
+## Codebase Patterns to Follow
+
+### Agent file structure
+
+All agents follow this pattern. Study `templates/agents/security-reviewer.md` for a clean recent example of the template, and `.claude/agents/security-reviewer.md` for the generated instance.
+
+**Template file** (`templates/agents/*.md`): Uses `{{PLACEHOLDER}}` for values that vary per target repo.
+
+**Generated file** (`.claude/agents/*.md`): Same content with placeholders substituted.
+
+YAML frontmatter required fields:
+```yaml
+---
+name: <kebab-case-name>
+description: "Multi-line string with usage examples"
+model: sonnet
+color: <color-name>
+memory: project
+---
+```
+
+Color `cyan` is assigned to the test-writer. It is not used by any existing agent:
+- `green` — architect
+- `purple` — developer
+- `red` — reviewer
+- `orange` — security-reviewer
+- `cyan` — test-writer (new)
+
+### Placeholders in templates
+
+Templates use `{{UPPER_SNAKE_CASE}}` for static substitution by `install.sh`. The specrails-instance values for the test-writer are:
+
+| Placeholder | Resolved value |
+|-------------|---------------|
+| `{{TECH_EXPERTISE}}` | (see below) |
+| `{{LAYER_CLAUDE_MD_PATHS}}` | `.claude/rules/*.md` |
+| `{{MEMORY_PATH}}` | `.claude/agent-memory/test-writer/` |
+
+For `{{TECH_EXPERTISE}}`, match what `.claude/agents/developer.md` uses:
+```
+- **Shell scripting**: Bash, POSIX sh, installers, CLI tools
+- **TypeScript/JavaScript**: Node.js, CLI frameworks (commander, oclif, yargs), npm packaging
+- **Template systems**: Markdown templates with placeholder substitution, code generation
+- **Developer tooling**: CI/CD pipelines, GitHub Actions, package distribution
+- **AI prompt engineering**: Claude Code agents, structured prompts, multi-agent orchestration
+```
+
+**Runtime-injected values** — these are NOT substitution targets. They appear in the prompt body as instructional references (plain text, not `{{...}}`):
+- `IMPLEMENTED_FILES_LIST` — injected by the orchestrator at invocation time
+- `TASK_DESCRIPTION` — injected by the orchestrator at invocation time
+
+### Memory pattern
+
+Every agent has a memory directory with an initial `MEMORY.md` file:
+```
+.claude/agent-memory/<agent-name>/MEMORY.md
+```
+
+Header content:
+```markdown
+# Test Writer Agent Memory
+
+No memories recorded yet.
+```
+
+### Implement command structure
+
+`templates/commands/implement.md` is a long Markdown document describing the pipeline phases. The existing phase structure:
+
+```
+Phase -1: Environment Setup
+Phase 0:  Parse input and determine mode
+Phase 1:  Explore (parallel)
+Phase 2:  Select
+Phase 3a: Architect (parallel, in main repo)
+Phase 3b: Implement
+           ← INSERT Phase 3c: Write Tests HERE
+Phase 4:  Merge & Review
+  4a. Merge worktree changes
+  4b. Launch Reviewer agent
+  4b-sec. Launch Security Reviewer agent
+  4c. Ship
+  4d. Monitor CI
+  4e. Report
+```
+
+Phase 3c is inserted between the final line of Phase 3b ("Wait for all developers to complete.") and the `## Phase 4: Merge & Review` heading.
+
+The Phase 4e report table already has both `Security` and `Tests` columns (stubs added by prior changes). The table currently reads:
+```
+| Area | Feature | Change Name | Architect | Developer | Reviewer | Security | Tests | CI | Status |
+```
+
+After this change it should read:
+```
+| Area | Feature | Change Name | Architect | Developer | Tests | Reviewer | Security | CI | Status |
+```
+
+This is a **column reorder**, not an addition. `Tests` moves from after `Security` to between `Developer` and `Reviewer`, to reflect execution order in the pipeline.
+
+---
+
+## Files to Create or Modify
+
+### Create (new files)
+
+| Path | Description |
+|------|-------------|
+| `templates/agents/test-writer.md` | Canonical agent template with `{{PLACEHOLDER}}` syntax |
+| `.claude/agents/test-writer.md` | Generated specrails instance with placeholders resolved |
+| `.claude/agent-memory/test-writer/MEMORY.md` | Initial empty memory file |
+
+### Modify (existing files)
+
+| Path | Change |
+|------|--------|
+| `templates/commands/implement.md` | Insert Phase 3c after Phase 3b; update Phase 4e table |
+| `.claude/commands/implement.md` | Same changes applied to generated copy |
+
+---
+
+## Phase 3c Content to Insert
+
+Insert the following Markdown block into both `templates/commands/implement.md` and `.claude/commands/implement.md`, immediately after the "Wait for all developers to complete." line of Phase 3b:
+
+```markdown
+## Phase 3c: Write Tests
+
+Launch a **test-writer** agent for each feature immediately after its developer completes.
+
+Construct the agent invocation prompt to include:
+- **IMPLEMENTED_FILES_LIST**: the complete list of files the developer created or modified for this feature
+- **TASK_DESCRIPTION**: the original task or feature description that drove the implementation
+
+### Launch modes
+
+**If `SINGLE_MODE`**: Launch a single test-writer agent in the foreground (`run_in_background: false`). Wait for it to complete before proceeding to Phase 4.
+
+**If multiple features (worktrees)**: Launch one test-writer agent per feature, each in its corresponding worktree (`isolation: worktree`, `run_in_background: true`). Wait for all test-writer agents to complete before proceeding to Phase 4.
+
+### Dry-run behavior
+
+**If `DRY_RUN=true`**, include in every test-writer agent prompt:
+
+> IMPORTANT: This is a dry-run. Write all new or modified test files under:
+>   .claude/.dry-run/\<feature-name\>/
+>
+> Mirror the real destination path within this directory. After writing each file, append an entry
+> to .claude/.dry-run/\<feature-name\>/.cache-manifest.json using:
+>   {"cached_path": "...", "real_path": "...", "operation": "create"}
+
+### Failure handling
+
+If a test-writer agent fails or times out:
+- Record `Tests: FAILED` for that feature in the Phase 4e report
+- Continue to Phase 4 — the test-writer failure is non-blocking
+- Include in the reviewer agent prompt: "Note: the test-writer failed for this feature. Check for coverage gaps."
+```
+
+---
+
+## Framework Detection Table (for agent prompt)
+
+The agent prompt must include this detection logic:
+
+| Manifest File | Framework | Test runner |
+|---------------|-----------|-------------|
+| `package.json` — `jest` in scripts/devDeps | Jest | `npx jest` / `npm test` |
+| `package.json` — `vitest` in scripts/devDeps | Vitest | `npx vitest` |
+| `package.json` — `mocha` in scripts/devDeps | Mocha | `npx mocha` |
+| `requirements.txt` or `pyproject.toml` present | pytest | `pytest` |
+| `Gemfile` with `rspec` | RSpec | `bundle exec rspec` |
+| `go.mod` present | Go test | `go test ./...` |
+| `Cargo.toml` present | cargo test | `cargo test` |
+| `composer.json` with `phpunit` | PHPUnit | `./vendor/bin/phpunit` |
+
+Detection is sequential: stop at first match.
+
+---
+
+## Key Design Decisions (Do Not Deviate)
+
+1. **Test-writer is always-on** — no flag to disable it. If framework detection fails, the agent outputs `SKIPPED` and continues. Do not add a `--skip-tests` flag.
+
+2. **Test-writer does NOT run tests** — writing only. Running tests is the reviewer's job via CI checks.
+
+3. **Test-writer does NOT modify implementation files** — generating untestable code is flagged, not fixed.
+
+4. **One test-writer per feature in multi-feature mode** — scoped to its own worktree, not a single agent over all features.
+
+5. **Non-blocking failure** — if the agent fails, Phase 4 continues. The reviewer notes the gap.
+
+6. **Color is `cyan`** — do not change this to an already-used color.
+
+---
+
+## Verification Checklist
+
+Before considering this change complete:
+
+- [ ] `templates/agents/test-writer.md` exists and has valid YAML frontmatter
+- [ ] `templates/agents/test-writer.md` contains exactly these placeholders: `{{TECH_EXPERTISE}}`, `{{LAYER_CLAUDE_MD_PATHS}}`, `{{MEMORY_PATH}}`
+- [ ] `.claude/agents/test-writer.md` exists with no unresolved `{{...}}` strings
+- [ ] `.claude/agent-memory/test-writer/MEMORY.md` exists
+- [ ] `templates/commands/implement.md` has a `## Phase 3c: Write Tests` section positioned between Phase 3b and Phase 4
+- [ ] `.claude/commands/implement.md` has the same Phase 3c section
+- [ ] Phase 4e report table in both implement files includes `Tests` column between `Developer` and `Reviewer`
+- [ ] `grep -r '{{[A-Z_]*}}' .claude/agents/test-writer.md` returns no output

--- a/openspec/changes/archive/2026-03-13-automated-test-writer/delta-spec.md
+++ b/openspec/changes/archive/2026-03-13-automated-test-writer/delta-spec.md
@@ -1,0 +1,165 @@
+---
+change: automated-test-writer
+type: delta-spec
+---
+
+# Delta Spec: Automated Test Writer Agent
+
+This document describes the spec-level changes this feature introduces. It defines what the system should do after this change is applied, framed as additions and modifications to the existing conceptual specification.
+
+---
+
+## 1. New Capability: Test Writing Agent
+
+**Spec statement:** The specrails agent system SHALL include a `test-writer` agent that generates comprehensive tests for code implemented by developer agents.
+
+### 1.1 Agent identity
+
+The `test-writer` agent:
+- Has name `test-writer`
+- Runs on model `sonnet`
+- Color `cyan`
+- Has persistent memory at `.claude/agent-memory/test-writer/`
+- Is self-contained — requires no external binaries to perform its core function
+
+### 1.2 Test writing scope
+
+When invoked, the agent MUST:
+- Receive a list of implemented files (`IMPLEMENTED_FILES_LIST`) via its invocation prompt
+- Receive the task description (`TASK_DESCRIPTION`) for context on intended behavior
+- Read existing test files to learn project test patterns before generating any tests
+- Detect the test framework from standard manifest files
+- Write test files only — never modify implementation files
+- Target >80% coverage for all newly implemented code
+
+### 1.3 Framework detection
+
+The agent MUST detect the test framework by reading manifest files in this order of priority:
+1. `package.json` — detect `jest`, `vitest`, or `mocha` in scripts or devDependencies
+2. `requirements.txt` or `pyproject.toml` — infer pytest
+3. `Gemfile` — detect `rspec`
+4. `go.mod` — infer Go test
+5. `Cargo.toml` — infer cargo test
+6. `composer.json` — detect `phpunit`
+
+If no framework is detected, the agent MUST output a `TEST_FRAMEWORK_UNKNOWN.md` file with an explanation and set its report status to `SKIPPED`. This MUST NOT block the pipeline.
+
+### 1.4 Pattern learning
+
+Before generating any tests, the agent MUST:
+- Identify existing test files related to the layer being tested
+- Read up to 3 representative existing test files
+- Extract: file naming convention, directory structure, import style, assertion library, test block structure, fixture/mock patterns
+- Apply those patterns to all generated tests
+
+### 1.5 Test categories
+
+For each implemented file, the agent MUST attempt to generate:
+- Unit tests for all public functions and methods
+- Integration tests for interactions between modules (where applicable)
+- Edge case tests: null/empty inputs, boundary values, type coercion
+- Error handling tests: expected exceptions, failure modes, invalid inputs
+
+### 1.6 Untestable code handling
+
+If an implemented file cannot be meaningfully unit-tested (global state, no dependency injection, etc.), the agent MUST:
+- Write the best-effort test file
+- Add a comment at the top of the test file: `# UNTESTABLE: <reason>`
+- This file still counts as "written" in the output report
+
+### 1.7 Output format
+
+The agent MUST produce a summary listing:
+- Each test file written and the path it was written to
+- The framework detected
+- The test patterns learned from existing files
+- Any files skipped and the reason
+
+---
+
+## 2. Modified Capability: Implementation Pipeline (Phase 3)
+
+**Spec statement:** Phase 3 of the implementation pipeline SHALL include a test-writing step (Phase 3c) that runs after developer implementation and before the merge and review phase.
+
+### 2.1 Phase 3c execution
+
+Phase 3 executes in this order:
+1. Phase 3a: Architect — unchanged
+2. Phase 3b: Implement (developer) — unchanged
+3. Phase 3c: Write Tests — new
+
+### 2.2 Test-writer invocation
+
+The orchestrator MUST pass to the test-writer agent:
+- `IMPLEMENTED_FILES_LIST`: all files created or modified by the developer in this feature
+- `TASK_DESCRIPTION`: the original task/feature description that drove the implementation
+
+### 2.3 Failure handling
+
+If the test-writer agent fails or times out:
+- The failure MUST be logged in the Phase 4e report under `Tests` as `FAILED`
+- The pipeline MUST continue to Phase 4 (merge and review) — the test-writer failure is non-blocking
+- The reviewer agent MUST note the missing test coverage in its review
+
+### 2.4 Dry-run behavior
+
+When `DRY_RUN=true`, the test-writer MUST:
+- Write all test files under `.claude/.dry-run/<feature-name>/` mirroring real paths
+- Append each written test file to `.cache-manifest.json` with `operation: "create"`
+
+### 2.5 Multi-feature mode
+
+In multi-feature mode (worktrees):
+- One test-writer agent MUST be launched per feature, in its corresponding worktree
+- Each test-writer operates on the files for its own feature only
+- All test-writers run in background (`run_in_background: true`)
+- Phase 4 begins only after all test-writers complete (or time out)
+
+---
+
+## 3. Modified Capability: Phase 4e Report
+
+**Spec statement:** The Phase 4e pipeline report table SHALL include a `Tests` column showing the outcome of the test-writer phase.
+
+### 3.1 Report table schema
+
+The Phase 4e report table:
+
+```
+| Area | Feature | Change Name | Architect | Developer | Tests | Reviewer | Security | CI | Status |
+```
+
+### 3.2 Tests column values
+
+| Value | Meaning |
+|-------|---------|
+| `ok` | Test-writer completed, test files written |
+| `FAILED` | Test-writer agent failed or timed out |
+| `SKIPPED` | No test framework detected |
+
+---
+
+## 4. New Artifact: Test Writer Agent Template
+
+**Spec statement:** `templates/agents/test-writer.md` SHALL exist as a canonical template following the `{{PLACEHOLDER}}` convention used by all other agent templates.
+
+### 4.1 Required placeholders
+
+| Placeholder | Resolved to (specrails) |
+|-------------|-------------------------|
+| `{{TECH_EXPERTISE}}` | Specrails' full stack description |
+| `{{LAYER_CLAUDE_MD_PATHS}}` | `.claude/rules/*.md` |
+| `{{MEMORY_PATH}}` | `.claude/agent-memory/test-writer/` |
+
+Runtime-injected values (not static substitution targets — appear as instructional references in the prompt body):
+- `IMPLEMENTED_FILES_LIST`
+- `TASK_DESCRIPTION`
+
+### 4.2 Template conventions
+
+The template MUST follow all conventions in `.claude/rules/agents.md`:
+- YAML frontmatter with `name`, `description`, `model`, `color`, `memory`
+- `description` field includes usage examples
+- Agent is self-contained
+- Output format is specified
+- Memory protocol section matches other agents

--- a/openspec/changes/archive/2026-03-13-automated-test-writer/design.md
+++ b/openspec/changes/archive/2026-03-13-automated-test-writer/design.md
@@ -1,0 +1,206 @@
+---
+change: automated-test-writer
+type: design
+---
+
+# Technical Design: Automated Test Writer Agent
+
+## Architecture Overview
+
+The test-writer is a Claude Code agent — a markdown prompt file with YAML frontmatter, identical in structure to `developer.md` and `reviewer.md`. No new runtime dependencies are required.
+
+The agent runs as a new **Phase 3c** in the implement pipeline, inserted between the existing Phase 3b (developer implementation) and Phase 4 (merge and review).
+
+```
+Current pipeline:
+  Phase 3b: Developer  →  Phase 4: Merge & Review
+
+After this change:
+  Phase 3b: Developer  →  Phase 3c: Test Writer  →  Phase 4: Merge & Review
+```
+
+The test-writer receives the implementation output as context (list of files created/modified), reads existing tests for pattern matching, detects the framework, and writes new test files. It never modifies implementation files.
+
+---
+
+## Framework Detection
+
+Framework detection is performed by the agent at the start of its run. It reads standard manifest files and infers the test runner and conventions:
+
+| Manifest File | Detected Framework | Test Runner Command |
+|---------------|-------------------|---------------------|
+| `package.json` (has `jest` in devDeps or scripts) | Jest | `npx jest` / `npm test` |
+| `package.json` (has `vitest` in devDeps or scripts) | Vitest | `npx vitest` |
+| `package.json` (has `mocha`) | Mocha | `npx mocha` |
+| `requirements.txt` or `pyproject.toml` | pytest | `pytest` |
+| `Gemfile` (has `rspec`) | RSpec | `bundle exec rspec` |
+| `go.mod` | Go test | `go test ./...` |
+| `Cargo.toml` | Rust/cargo | `cargo test` |
+| `composer.json` (has `phpunit`) | PHPUnit | `./vendor/bin/phpunit` |
+
+Detection is sequential: the agent reads files top-to-bottom from this table and stops on the first match. If no manifest file is found or no framework is identified, the agent writes a `TEST_FRAMEWORK_UNKNOWN.md` note and stops gracefully without blocking the pipeline.
+
+### Pattern Learning
+
+Before generating any tests, the agent reads existing test files to understand:
+- File naming convention (`*.test.ts`, `*_test.go`, `test_*.py`, `*_spec.rb`)
+- Directory structure (co-located vs. dedicated `tests/` directory)
+- Import style and assertion library (`expect`, `assert`, `should`)
+- Test block structure (`describe`/`it`, `test`, `func Test*`, `context`/`it`)
+- Fixture and mock patterns
+
+The agent reads up to 3 representative existing test files as pattern examples. It selects files that are closest in layer to the newly implemented code.
+
+---
+
+## Agent Prompt Structure
+
+### File: `templates/agents/test-writer.md`
+
+YAML frontmatter:
+```yaml
+---
+name: test-writer
+description: "..."
+model: sonnet
+color: cyan
+memory: project
+---
+```
+
+Color choice: `cyan` — distinguishes the test-writer from the developer (purple) and reviewer (red) while maintaining visual coherence in the pipeline.
+
+### Placeholders
+
+| Placeholder | Description | Resolved to (specrails) |
+|-------------|-------------|-------------------------|
+| `{{TECH_EXPERTISE}}` | Tech expertise list | specrails' own language list |
+| `{{LAYER_CLAUDE_MD_PATHS}}` | Layer-specific CLAUDE.md paths | `.claude/rules/*.md` |
+| `{{MEMORY_PATH}}` | Agent memory directory | `.claude/agent-memory/test-writer/` |
+
+Note: `{{IMPLEMENTED_FILES_LIST}}` and `{{TASK_DESCRIPTION}}` appear in the prompt as instructional references (runtime-injected by the orchestrator) — they are not static substitution targets.
+
+### Prompt Sections
+
+1. **Identity**: "You are a specialist test engineer. Your only job is to write tests..."
+2. **What you receive**: Implemented files list, task description, existing test patterns
+3. **Framework detection protocol**: Ordered manifest-reading procedure
+4. **Pattern learning protocol**: How to read existing tests before writing new ones
+5. **Test generation mandate**: Unit, integration, edge case, error handling. Target: >80% coverage of new code
+6. **Test writing rules**: Never modify implementation files. One test file per implementation file (or follow project convention). Follow exact naming and structure of existing tests.
+7. **Untestable code protocol**: If code structure prevents unit testing (no dependency injection, global state, etc.), write an `# UNTESTABLE: <reason>` comment at the top of what you would have written, then write the best-effort test.
+8. **Output format**: List of test files written with brief description of what each covers
+9. **Memory protocol**: Using `{{MEMORY_PATH}}`
+
+---
+
+## Pipeline Integration
+
+### Phase 3c: Test Writing
+
+The new phase is inserted in `templates/commands/implement.md` after Phase 3b (Implement) and before Phase 4 (Merge & Review).
+
+#### Positioning
+
+```
+## Phase 3b: Implement
+[...existing content unchanged...]
+
+## Phase 3c: Write Tests     ← NEW
+
+## Phase 4: Merge & Review
+[...existing content unchanged...]
+```
+
+#### Phase 3c Behavior
+
+**Single-feature mode (`SINGLE_MODE=true`):**
+- After the developer agent completes in Phase 3b, launch a single `test-writer` agent in the foreground.
+- Pass to the agent:
+  - `IMPLEMENTED_FILES_LIST`: the list of files the developer created or modified
+  - `TASK_DESCRIPTION`: the original task description / feature spec
+- Wait for the test-writer to complete before proceeding to Phase 4.
+
+**Multi-feature mode (worktrees):**
+- After all developer worktrees complete (Phase 3b), launch one `test-writer` agent per feature, each in its corresponding worktree (`isolation: worktree`, `run_in_background: true`).
+- Each agent receives the `IMPLEMENTED_FILES_LIST` for its own feature only.
+- Wait for all test-writer agents to complete before proceeding to Phase 4.
+
+**Dry-run mode (`DRY_RUN=true`):**
+Apply the same dry-run redirect as the developer:
+> IMPORTANT: This is a dry-run. Write all new or modified test files under `.claude/.dry-run/<feature-name>/`. Mirror the real destination path within this directory. Append each file to `.cache-manifest.json`.
+
+**If test-writer fails or times out:**
+- Log the failure in the Phase 4e report under the `Tests` column as `FAILED`.
+- Do NOT block Phase 4 (merge and review). Proceed without tests.
+- Rationale: A missing test pass is preferable to blocking a valid implementation. The reviewer will note the coverage gap.
+
+#### Report Table Update
+
+The Phase 4e report table already contains a `Tests` column stub (after `Security`). This change **reorders** it to appear between `Developer` and `Reviewer`, reflecting the actual pipeline execution order:
+
+**Current:**
+```
+| Area | Feature | Change Name | Architect | Developer | Reviewer | Security | Tests | CI | Status |
+```
+
+**After:**
+```
+| Area | Feature | Change Name | Architect | Developer | Tests | Reviewer | Security | CI | Status |
+```
+
+`Tests` column values: `ok` (test files written), `FAILED` (agent failed or timed out), `SKIPPED` (no test framework detected).
+
+---
+
+## File Changes Summary
+
+### New Files
+
+| File | Description |
+|------|-------------|
+| `templates/agents/test-writer.md` | Canonical test-writer agent template |
+| `.claude/agents/test-writer.md` | Generated specrails instance |
+| `.claude/agent-memory/test-writer/MEMORY.md` | Initial empty memory file |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `templates/commands/implement.md` | Add Phase 3c, update Phase 4e table |
+| `.claude/commands/implement.md` | Same changes applied to generated copy |
+
+---
+
+## Design Decisions and Rationale
+
+### Always-on vs. optional flag
+
+The test-writer runs unconditionally — no `--skip-tests` flag is provided. Rationale:
+
+1. Making it optional creates a habit of opting out. The pipeline's value proposition is that it handles the full development lifecycle.
+2. The fail-graceful behavior (if agent fails, pipeline continues) already handles the edge case where tests can't be generated.
+3. If a project has no test framework at all, the agent detects this and outputs `SKIPPED` — zero disruption.
+
+If a specific case arises requiring opt-out, that is a Phase 2 enhancement.
+
+### Test-writer runs after each developer, not after all developers
+
+In multi-feature mode, each test-writer is scoped to its own worktree and its own feature's implemented files. Running a single test-writer over all features at once would require merging context that isn't yet merged, producing cross-feature confusion. The worktree-local approach mirrors how the developer works.
+
+### Test-writer does not run tests
+
+The agent writes test files. The reviewer runs the test suite via CI checks. This separation keeps the test-writer focused on generation quality and keeps the reviewer as the authoritative quality gate. Running tests inside the test-writer would require the agent to know the full CI invocation, handle failures, and potentially modify both tests and implementation — collapsing two distinct concerns.
+
+### Framework detection is agent-side, not orchestrator-side
+
+The orchestrator does not detect the framework and pass it in. The agent reads the manifest files itself. Rationale: the agent needs to read existing test patterns anyway (which requires file I/O), so combining detection with pattern learning in a single reading phase is more efficient. It also keeps the orchestrator prompt simpler.
+
+---
+
+## Edge Cases
+
+- **No existing test files**: Agent uses framework defaults (standard describe/it blocks, standard import style). It cannot learn from examples that don't exist, so it notes "No existing test files found — using framework defaults."
+- **Mixed frameworks** (e.g., Jest for frontend, pytest for backend): Agent detects both based on the layer of the files it's testing and writes tests in the appropriate framework per file.
+- **Generated/scaffold files**: If an implemented file is auto-generated (e.g., a migration file, a type declaration file), the agent skips it and notes the skip in its output.
+- **Dry-run + test-writer**: Test files land in the dry-run cache alongside developer files. The `.cache-manifest.json` receives entries for test files just like implementation files.

--- a/openspec/changes/archive/2026-03-13-automated-test-writer/proposal.md
+++ b/openspec/changes/archive/2026-03-13-automated-test-writer/proposal.md
@@ -1,0 +1,75 @@
+---
+change: automated-test-writer
+type: feature
+status: proposed
+github_issue: 6
+vpc_fit: 70%
+---
+
+# Proposal: Automated Test Writer Agent
+
+## Problem
+
+Test coverage is a consistent trailing indicator in AI-driven development pipelines. The current specrails implement pipeline (architect → developer → reviewer) produces working implementations but leaves test authorship to the developer agent — and developers, AI or otherwise, tend to deprioritize tests under time pressure.
+
+The symptoms are predictable:
+- **Coverage gaps ship**: The reviewer validates CI conformance but has no mandate to enforce test coverage thresholds.
+- **Test writing is interruption-heavy**: When a developer does write tests, context-switching between implementation and test authorship degrades the quality of both.
+- **Pattern inconsistency**: Without a dedicated pass, test style diverges from the project's existing test patterns — wrong naming conventions, wrong assertion library imports, missing edge cases.
+
+The net result: test coverage becomes a reviewer concern after the fact, requiring fix cycles, or worse, a permanent gap that accumulates sprint over sprint.
+
+## Solution
+
+Add a `test-writer` agent that runs as a dedicated pipeline phase between the developer and reviewer. The agent:
+
+1. Reads the implemented code and the task description that produced it.
+2. Reads the project's existing test patterns to match style, structure, and framework.
+3. Detects the target repo's test framework automatically (Jest, pytest, RSpec, Go test, etc.) from standard manifest files.
+4. Generates unit tests, integration tests, edge case tests, and error handling tests.
+5. Targets >80% coverage for new code.
+6. Writes test files following the project's naming and co-location conventions.
+
+Claude already excels at test generation. This agent is primarily orchestration — giving test writing a dedicated phase with the right context and the right mandate.
+
+## Scope
+
+**In scope:**
+- New agent template: `templates/agents/test-writer.md`
+- Generated specrails instance: `.claude/agents/test-writer.md`
+- New pipeline phase: Phase 3c (Test Writing) inserted between Phase 3b (Implement) and Phase 4 (Merge & Review)
+- Framework detection: reads `package.json`, `requirements.txt`, `Gemfile`, `go.mod`, `Cargo.toml` to identify test runner and conventions
+- Agent memory directory: `.claude/agent-memory/test-writer/MEMORY.md`
+- Updates to `templates/commands/implement.md` and `.claude/commands/implement.md`
+- Updates to Phase 4e report table (add `Tests` column)
+
+**Out of scope:**
+- Mutation testing or coverage instrumentation tools
+- Snapshot testing generation
+- Load or performance test generation
+- End-to-end/browser test generation (UI layer only)
+- CI enforcement of coverage thresholds (no CI exists yet)
+- Auto-fix of tests that fail post-generation (that is the reviewer's mandate)
+
+## Non-goals
+
+- The test-writer does NOT run or verify test output. It writes tests; the reviewer runs them.
+- The test-writer does NOT replace the developer's judgment on what needs testing. It supplements.
+- The test-writer does NOT modify implementation code to make it more testable. If code is untestable as written, it flags that as a note in its output.
+
+## Acceptance Criteria
+
+1. `templates/agents/test-writer.md` exists with correct `{{PLACEHOLDER}}` syntax and YAML frontmatter.
+2. `.claude/agents/test-writer.md` exists with all placeholders resolved for the specrails repo.
+3. Phase 3c is present in `templates/commands/implement.md` and `.claude/commands/implement.md`, positioned after Phase 3b and before Phase 4.
+4. The test-writer agent launches after each developer agent completes (or after all developers complete in multi-feature mode).
+5. Framework detection logic covers: Jest/Vitest, pytest, RSpec, Go test, Rust (cargo test), PHPUnit.
+6. The agent reads existing test files to match patterns before generating new ones.
+7. The Phase 4e report table includes a `Tests` column.
+8. The `test-writer` is always-on (not a flag). Rationale: skipping tests defeats the purpose of the agent; it should always run.
+
+## Motivation
+
+VPC fit score: 70%. Alex (Lead Dev, 4/5) and Kai (DevOps/Platform, 4/5) both rate this highly. The feature directly addresses the trust gap between "AI generated this code" and "this code is safe to ship" — coverage evidence is the bridge.
+
+Sara (Product Owner, 1/5) gives it low weight, which is expected: test coverage is an engineering concern, not a product discovery concern. The agent adds pipeline phases that the product owner does not see.

--- a/openspec/changes/archive/2026-03-13-automated-test-writer/tasks.md
+++ b/openspec/changes/archive/2026-03-13-automated-test-writer/tasks.md
@@ -1,0 +1,245 @@
+---
+change: automated-test-writer
+type: tasks
+---
+
+# Tasks: Automated Test Writer Agent
+
+Tasks are ordered by dependency. Each task has a layer tag, description, files involved, and acceptance criteria.
+
+---
+
+## Task 1 — Create the test-writer agent template [templates]
+
+**Description:** Write `templates/agents/test-writer.md`. This is the canonical template that `install.sh` copies into target repos and that drives all generated instances. Follow the exact same structure as `templates/agents/developer.md` and `templates/agents/security-reviewer.md`.
+
+**Files:**
+- Create: `templates/agents/test-writer.md`
+
+**YAML frontmatter:**
+```yaml
+---
+name: test-writer
+description: "Use this agent after a developer agent completes implementation, to generate comprehensive tests for the implemented code. Runs as Phase 3c in the implement pipeline, before the reviewer.
+
+Examples:
+
+- Example 1:
+  user: (orchestrator) Developer agent completed. Write tests for the implemented files.
+  assistant: \"Launching the test-writer agent to generate tests for the implemented code.\"
+
+- Example 2:
+  user: (orchestrator) Implementation done. Run test writer before review.
+  assistant: \"I'll use the test-writer agent to write tests following the project's test patterns.\""
+model: sonnet
+color: cyan
+memory: project
+---
+```
+
+**Prompt body MUST include (in order):**
+1. Identity: "You are a specialist test engineer. Your only job is to write tests — you never modify implementation files."
+2. Mission: generate comprehensive tests targeting >80% coverage of newly implemented code
+3. "What you receive" section explaining `IMPLEMENTED_FILES_LIST`, `TASK_DESCRIPTION`, layer CLAUDE.md paths (`{{LAYER_CLAUDE_MD_PATHS}}`)
+4. Framework detection protocol: ordered manifest-reading procedure (package.json → requirements.txt/pyproject.toml → Gemfile → go.mod → Cargo.toml → composer.json)
+5. Pattern learning protocol: read up to 3 representative existing test files, extract naming convention, directory structure, import style, assertion library, test block structure, mock patterns
+6. Test generation mandate: unit tests, integration tests, edge case tests, error handling tests
+7. Test writing rules: never modify implementation files; follow exact naming and structure of existing tests; one test file per implementation file unless project convention differs
+8. Untestable code protocol: write best-effort test, prepend `# UNTESTABLE: <reason>` comment
+9. Files to skip: auto-generated files (migrations, type declaration stubs, scaffold output), binary files
+10. Output format: list of test files written with brief coverage description per file, framework detected, patterns learned, files skipped
+11. Memory protocol section using `{{MEMORY_PATH}}`
+
+**Placeholders to include:**
+- `{{TECH_EXPERTISE}}`
+- `{{LAYER_CLAUDE_MD_PATHS}}`
+- `{{MEMORY_PATH}}`
+
+**Acceptance criteria:**
+- File exists at `templates/agents/test-writer.md`
+- Valid YAML frontmatter
+- All three placeholders (`{{TECH_EXPERTISE}}`, `{{LAYER_CLAUDE_MD_PATHS}}`, `{{MEMORY_PATH}}`) present exactly once in the body
+- `IMPLEMENTED_FILES_LIST` and `TASK_DESCRIPTION` appear as instructional references in the prompt body (not as `{{...}}` substitution targets)
+- Framework detection table covers at minimum: Jest/Vitest/Mocha, pytest, RSpec, Go test, cargo test, PHPUnit
+- Output format section describes what "done" looks like for the orchestrator to parse
+- File follows kebab-case naming: `test-writer.md`
+
+**Dependencies:** None (can start immediately)
+
+---
+
+## Task 2 — Generate the specrails-instance test-writer agent [templates]
+
+**Description:** Create `.claude/agents/test-writer.md` by applying the template. This is what Claude Code uses when running the test-writer in the specrails repo itself. Substitutions:
+- `{{TECH_EXPERTISE}}` → specrails full stack description (match what `.claude/agents/developer.md` uses)
+- `{{LAYER_CLAUDE_MD_PATHS}}` → `.claude/rules/*.md`
+- `{{MEMORY_PATH}}` → `.claude/agent-memory/test-writer/`
+
+**Files:**
+- Create: `.claude/agents/test-writer.md`
+
+**Acceptance criteria:**
+- File exists at `.claude/agents/test-writer.md`
+- No unresolved `{{PLACEHOLDER}}` strings remain (except `IMPLEMENTED_FILES_LIST` and `TASK_DESCRIPTION` which are runtime references in prose)
+- Memory path resolves to `.claude/agent-memory/test-writer/`
+- YAML frontmatter is valid
+- Content matches the template with substitutions applied consistently with other `.claude/agents/*.md` files
+
+**Dependencies:** Task 1
+
+---
+
+## Task 3 — Create test-writer agent memory directory [templates]
+
+**Description:** Create `.claude/agent-memory/test-writer/MEMORY.md` — the initial (empty) memory file. Follows the same pattern as reviewer and security-reviewer agents.
+
+**Files:**
+- Create: `.claude/agent-memory/test-writer/MEMORY.md`
+
+**Content:**
+```markdown
+# Test Writer Agent Memory
+
+No memories recorded yet.
+```
+
+**Acceptance criteria:**
+- File exists at `.claude/agent-memory/test-writer/MEMORY.md`
+- Contains only the standard empty-memory header
+- No other content
+
+**Dependencies:** None (can run in parallel with Tasks 1 and 4)
+
+---
+
+## Task 4 — Update `templates/commands/implement.md`: add Phase 3c [templates]
+
+**Description:** Modify `templates/commands/implement.md` to add Phase 3c (Write Tests) between Phase 3b (Implement) and Phase 4 (Merge & Review). This is a surgical insertion — do NOT restructure any existing phases.
+
+**Files:**
+- Modify: `templates/commands/implement.md`
+
+**Specific changes:**
+
+**Change 1 — Insert Phase 3c after Phase 3b.**
+
+After the final line of the `## Phase 3b: Implement` section (the "Wait for all developers to complete." line), insert:
+
+```markdown
+## Phase 3c: Write Tests
+
+Launch a **test-writer** agent for each feature immediately after its developer completes.
+
+Construct the agent invocation prompt to include:
+- **IMPLEMENTED_FILES_LIST**: the complete list of files the developer created or modified for this feature
+- **TASK_DESCRIPTION**: the original task or feature description that drove the implementation
+
+### Launch modes
+
+**If `SINGLE_MODE`**: Launch a single test-writer agent in the foreground (`run_in_background: false`). Wait for it to complete before proceeding to Phase 4.
+
+**If multiple features (worktrees)**: Launch one test-writer agent per feature, each in its corresponding worktree (`isolation: worktree`, `run_in_background: true`). Wait for all test-writer agents to complete before proceeding to Phase 4.
+
+### Dry-run behavior
+
+**If `DRY_RUN=true`**, include in every test-writer agent prompt:
+
+> IMPORTANT: This is a dry-run. Write all new or modified test files under:
+>   .claude/.dry-run/\<feature-name\>/
+>
+> Mirror the real destination path within this directory. After writing each file, append an entry
+> to .claude/.dry-run/\<feature-name\>/.cache-manifest.json using:
+>   {"cached_path": "...", "real_path": "...", "operation": "create"}
+
+### Failure handling
+
+If a test-writer agent fails or times out:
+- Record `Tests: FAILED` for that feature in the Phase 4e report
+- Continue to Phase 4 — the test-writer failure is non-blocking
+- Include in the reviewer agent prompt: "Note: the test-writer failed for this feature. Check for coverage gaps."
+```
+
+**Change 2 — Update the Phase 4e report table header.**
+
+Find the line:
+```
+| Area | Feature | Change Name | Architect | Developer | Reviewer | Security | Tests | CI | Status |
+```
+
+Replace with:
+```
+| Area | Feature | Change Name | Architect | Developer | Tests | Reviewer | Security | CI | Status |
+```
+
+(This reorders `Tests` to appear between `Developer` and `Reviewer`, matching execution order.)
+
+**Acceptance criteria:**
+- `## Phase 3c: Write Tests` section exists, positioned after `## Phase 3b: Implement` and before `## Phase 4: Merge & Review`
+- Section describes single-mode and multi-feature launch behavior
+- Section describes dry-run behavior for test files
+- Section describes non-blocking failure handling
+- Phase 4e report table includes `Tests` column between `Developer` and `Reviewer`
+- All existing content is preserved unchanged
+- No `{{PLACEHOLDER}}` strings are broken by the edit
+
+**Dependencies:** None (can run in parallel with agent tasks)
+
+---
+
+## Task 5 — Update `.claude/commands/implement.md`: same changes [commands]
+
+**Description:** Apply the same changes from Task 4 to `.claude/commands/implement.md` (the specrails-adapted generated copy). The generated copy has had its template placeholders resolved; apply the same logical sections but in the resolved content.
+
+**Files:**
+- Modify: `.claude/commands/implement.md`
+
+**Specific changes:**
+- Same Phase 3c insertion as Task 4, positioned after the existing `## Phase 3b: Implement` section
+- Same Phase 4e report table update as Task 4
+
+**Acceptance criteria:**
+- Same as Task 4, applied to the generated copy
+- No template placeholders (`{{...}}`) are introduced into this file — it is a fully resolved instance
+- The `## Phase 3c` section references `test-writer` (not a placeholder)
+- The Phase 4e table column order matches the template: `Developer | Tests | Reviewer | Security | CI | Status`
+
+**Dependencies:** Task 4 (content pattern established by template edit)
+
+---
+
+## Task 6 — Verify no broken placeholders [templates]
+
+**Description:** After Tasks 1 and 2 are complete, run the placeholder integrity check on the generated agent file to ensure no unresolved `{{PLACEHOLDER}}` strings exist.
+
+**Files:** Read-only verification
+
+**Command:**
+```bash
+grep -r '{{[A-Z_]*}}' /path/to/repo/.claude/agents/test-writer.md 2>/dev/null || echo "OK: no broken placeholders"
+```
+
+Expected output: `OK: no broken placeholders`
+
+**Acceptance criteria:**
+- The grep command returns no matches (or echoes "OK")
+- If matches are found: fix them in `.claude/agents/test-writer.md` before considering this task done
+
+**Dependencies:** Task 2
+
+---
+
+## Execution Order
+
+```
+Task 1 (template)  ──> Task 2 (generated instance)  ──> Task 6 (verify)
+
+Task 3 (memory)  — independent, run any time
+
+Task 4 (template implement.md)  ──> Task 5 (generated implement.md)
+```
+
+Tasks 1, 3, and 4 can all start in parallel. Task 2 depends on Task 1. Task 5 depends on Task 4. Task 6 is the final verification and depends on Task 2.
+
+### Minimum critical path
+
+Task 1 → Task 2 → Task 6 (plus Task 4 → Task 5 in parallel)

--- a/templates/agents/test-writer.md
+++ b/templates/agents/test-writer.md
@@ -1,0 +1,163 @@
+---
+name: test-writer
+description: "Use this agent after a developer agent completes implementation, to generate comprehensive tests for the implemented code. Runs as Phase 3c in the implement pipeline, before the reviewer.
+
+Examples:
+
+- Example 1:
+  user: (orchestrator) Developer agent completed. Write tests for the implemented files.
+  assistant: \"Launching the test-writer agent to generate tests for the implemented code.\"
+
+- Example 2:
+  user: (orchestrator) Implementation done. Run test writer before review.
+  assistant: \"I'll use the test-writer agent to write tests following the project's test patterns.\""
+model: sonnet
+color: cyan
+memory: project
+---
+
+You are a specialist test engineer. Your only job is to write tests — you never modify implementation files.
+
+## Your Identity & Expertise
+
+You are a polyglot test engineer with deep knowledge of testing patterns across the full stack:
+{{TECH_EXPERTISE}}
+
+You write tests that are meaningful, maintainable, and maximize coverage of the code under test.
+
+## Your Mission
+
+Generate comprehensive tests for newly implemented code, targeting >80% coverage of all files in IMPLEMENTED_FILES_LIST. You write unit tests, integration tests, edge case tests, and error handling tests. You never run tests — running is the reviewer's job.
+
+## What You Receive
+
+The orchestrator injects these inputs into your invocation prompt:
+
+- **IMPLEMENTED_FILES_LIST**: the complete list of files the developer created or modified for this feature. Write tests for every file in this list (except those you are instructed to skip).
+- **TASK_DESCRIPTION**: the original task or feature description that drove the implementation. Use this to understand intent when generating edge cases.
+- Layer conventions at `{{LAYER_CLAUDE_MD_PATHS}}`: read these before generating tests to understand project-specific patterns.
+
+## Framework Detection Protocol
+
+Detect the test framework by reading manifest files in this order. Stop at the first match.
+
+| Manifest File | Condition | Framework | Test runner |
+|---------------|-----------|-----------|-------------|
+| `package.json` | `jest` in scripts or devDependencies | Jest | `npx jest` / `npm test` |
+| `package.json` | `vitest` in scripts or devDependencies | Vitest | `npx vitest` |
+| `package.json` | `mocha` in scripts or devDependencies | Mocha | `npx mocha` |
+| `requirements.txt` or `pyproject.toml` | file exists | pytest | `pytest` |
+| `Gemfile` | contains `rspec` | RSpec | `bundle exec rspec` |
+| `go.mod` | file exists | Go test | `go test ./...` |
+| `Cargo.toml` | file exists | cargo test | `cargo test` |
+| `composer.json` | contains `phpunit` | PHPUnit | `./vendor/bin/phpunit` |
+
+If no framework is detected: output `TEST_WRITER_STATUS: SKIPPED` with reason "no test framework detected" and stop. Do not attempt to write tests.
+
+## Pattern Learning Protocol
+
+Before writing any tests, read up to 3 representative existing test files from the project to learn:
+1. **Naming convention** — how test files are named relative to source files (e.g., `foo.test.ts` vs `foo_test.go` vs `spec/foo_spec.rb`)
+2. **Directory structure** — where tests live (alongside source, in a `test/` root, in `__tests__/`, etc.)
+3. **Import style** — how the module under test is imported or required
+4. **Assertion library** — which assertion style is used (e.g., `expect`, `assert`, `should`)
+5. **Test block structure** — `describe`/`it`, `test()`, `def test_`, `func Test`, `RSpec.describe`, etc.
+6. **Mock patterns** — how dependencies are mocked or stubbed (jest.mock, unittest.mock, testify mocks, etc.)
+
+Apply every learned pattern exactly when writing new tests.
+
+## Test Generation Mandate
+
+For each file in IMPLEMENTED_FILES_LIST (that is not skipped), write:
+
+- **Unit tests**: test each exported function or method in isolation
+- **Integration tests**: test interactions between components where applicable
+- **Edge case tests**: test boundary values, empty inputs, maximum inputs, type coercions
+- **Error handling tests**: test that errors are thrown/returned correctly for invalid inputs and failure paths
+
+Target >80% coverage of new code. Prioritize branches, error paths, and exported API surface.
+
+## Test Writing Rules
+
+1. **Never modify implementation files.** If you determine that an implementation file is untestable as written, write a best-effort test and prepend the test file with a comment: `# UNTESTABLE: <reason>` (use the comment syntax of the target language).
+2. **Follow exact naming and structure of existing tests.** Do not invent a new convention.
+3. **One test file per implementation file** unless the project convention clearly differs (e.g., a single `spec/` directory with grouped specs).
+4. **Do not add test dependencies** that are not already present in the project's manifest.
+5. **Do not import test utilities** that do not exist in the project.
+
+## Files to Skip
+
+Do not write tests for:
+- Auto-generated files: database migrations, type declaration stubs (`.d.ts`), scaffold output, generated GraphQL types
+- Binary files: images, compiled artifacts, fonts, archives
+- Configuration files with no logic: `.env.example`, `tsconfig.json`, `jest.config.js`, `Cargo.toml`, `go.mod`
+- Lock files: `package-lock.json`, `yarn.lock`, `go.sum`, `Cargo.lock`
+
+For every file you skip, note the reason in your output.
+
+## Output Format
+
+After writing all test files, produce this report:
+
+```
+## Test Writer Results
+
+### Framework
+- Detected: <framework name>
+- Test runner: <command>
+
+### Patterns Learned
+- Naming: <pattern>
+- Directory: <location>
+- Assertion style: <style>
+- Mock style: <style>
+
+### Tests Written
+| Implementation File | Test File | Coverage Description |
+|--------------------|-----------|---------------------|
+| <file> | <test file path> | <brief description of what is tested> |
+
+### Files Skipped
+| File | Reason |
+|------|--------|
+(rows or "None")
+
+---
+TEST_WRITER_STATUS: DONE
+```
+
+Set `TEST_WRITER_STATUS:` as follows:
+- `DONE` — one or more test files written successfully
+- `SKIPPED` — no test framework detected or all files were in the skip list
+- `FAILED` — an unrecoverable error occurred
+
+The `TEST_WRITER_STATUS:` line MUST be the very last line of your output. Nothing may follow it.
+
+## Rules
+
+- Never modify implementation files. Generate test files only.
+- Never run tests. Writing only — execution is the reviewer's responsibility.
+- Never ask for clarification. Complete test generation with available information.
+- Always emit the `TEST_WRITER_STATUS:` line as the very last line of output.
+- If framework detection fails: output `TEST_WRITER_STATUS: SKIPPED` immediately. Do not guess or invent a framework.
+
+# Persistent Agent Memory
+
+You have a persistent agent memory directory at `{{MEMORY_PATH}}`. Its contents persist across conversations.
+
+As you work, consult your memory files to build on previous experience.
+
+Guidelines:
+- `MEMORY.md` is always loaded — keep it under 200 lines
+- Create separate topic files for detailed notes and link to them from MEMORY.md
+- Update or remove memories that turn out to be wrong or outdated
+
+What to save:
+- Test framework and runner confirmed for this repo
+- Test directory structure and naming conventions discovered
+- Patterns for mocking dependencies in this codebase
+- Files or directories that are always in the skip list for this repo
+
+## MEMORY.md
+
+Your MEMORY.md is currently empty.

--- a/templates/commands/implement.md
+++ b/templates/commands/implement.md
@@ -192,6 +192,38 @@ For each feature, analyze the tasks' layer tags:
 
 Wait for all developers to complete.
 
+## Phase 3c: Write Tests
+
+Launch a **test-writer** agent for each feature immediately after its developer completes.
+
+Construct the agent invocation prompt to include:
+- **IMPLEMENTED_FILES_LIST**: the complete list of files the developer created or modified for this feature
+- **TASK_DESCRIPTION**: the original task or feature description that drove the implementation
+
+### Launch modes
+
+**If `SINGLE_MODE`**: Launch a single test-writer agent in the foreground (`run_in_background: false`). Wait for it to complete before proceeding to Phase 4.
+
+**If multiple features (worktrees)**: Launch one test-writer agent per feature, each in its corresponding worktree (`isolation: worktree`, `run_in_background: true`). Wait for all test-writer agents to complete before proceeding to Phase 4.
+
+### Dry-run behavior
+
+**If `DRY_RUN=true`**, include in every test-writer agent prompt:
+
+> IMPORTANT: This is a dry-run. Write all new or modified test files under:
+>   .claude/.dry-run/\<feature-name\>/
+>
+> Mirror the real destination path within this directory. After writing each file, append an entry
+> to .claude/.dry-run/\<feature-name\>/.cache-manifest.json using:
+>   {"cached_path": "...", "real_path": "...", "operation": "create"}
+
+### Failure handling
+
+If a test-writer agent fails or times out:
+- Record `Tests: FAILED` for that feature in the Phase 4e report
+- Continue to Phase 4 — the test-writer failure is non-blocking
+- Include in the reviewer agent prompt: "Note: the test-writer failed for this feature. Check for coverage gaps."
+
 ## Phase 4: Merge & Review
 
 **This phase is fully autonomous.**
@@ -378,8 +410,8 @@ rm -rf .claude/.dry-run/<feature-name>/
 **Otherwise**, show the standard pipeline table:
 
 ```
-| Area | Feature | Change Name | Architect | Developer | Reviewer | Security | Tests | CI | Status |
-|------|---------|-------------|-----------|-----------|----------|----------|-------|----|--------|
+| Area | Feature | Change Name | Architect | Developer | Tests | Reviewer | Security | CI | Status |
+|------|---------|-------------|-----------|-----------|-------|----------|----------|----|--------|
 ```
 
 Include the shipping mode in the report:


### PR DESCRIPTION
## Summary

- New **test-writer** agent that runs as Phase 3c in the implement pipeline (after developer, before reviewer)
- Detects target repo's test framework (Jest, Vitest, Mocha, pytest, RSpec, Go test, cargo test, PHPUnit)
- Learns existing test patterns before generating tests targeting >80% coverage
- Non-blocking failure — pipeline continues if test writing fails

## Changes

**New files:**
- `templates/agents/test-writer.md` — canonical agent template
- `.claude/agents/test-writer.md` — specrails instance
- `.claude/agent-memory/test-writer/MEMORY.md` — agent memory

**Modified files:**
- `templates/commands/implement.md` — Phase 3c insertion, Phase 4e table reorder
- `.claude/commands/implement.md` — same changes in generated copy

**Archived:**
- `openspec/changes/archive/2026-03-13-automated-test-writer/` — full OpenSpec artifacts

## Test plan

- [x] `grep -r '{{[A-Z_]*}}' .claude/agents/test-writer.md` returns no matches
- [x] Phase 3c positioned between Phase 3b and Phase 4 in both implement files
- [x] Phase 4e table column order: Developer | Tests | Reviewer | Security
- [x] Framework detection covers 8 frameworks
- [x] Security review: CLEAN

---
Implemented via `/implement` pipeline (architect → developer → reviewer)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)