### PR TITLE
feat: smart merge conflict resolver for multi-feature pipelines

### DIFF
--- a/.claude/agent-memory/architect/project_implement_pipeline.md
+++ b/.claude/agent-memory/architect/project_implement_pipeline.md
@@ -32,6 +32,9 @@ Error Handling
 - `GIT_AUTO` — controls automatic git ops in 4c
 - `BACKLOG_WRITE` — controls issue commenting in 4c
 - `GH_AVAILABLE` — set in Phase -1 from gh auth status
+- `SHARED_FILES` — map of `{path: {features, risk}}`, set by Phase 3a.1 in multi-feature mode
+- `MERGE_ORDER` — ordered feature list for Phase 4a, derived in Phase 3a.1
+- `MERGE_REPORT` — merge outcome accumulator: `cleanly_merged`, `auto_resolved`, `requires_resolution`
 
 **Architect output:** always goes to `openspec/changes/<name>/` (not cached in dry-run)
 **Developer output:** written to working tree (or cache in dry-run mode)

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -148,7 +148,51 @@ Each agent's prompt should include:
 
 ### 3a.1 Identify shared file conflicts
 
-Before launching developers, scan all tasks.md files to identify **shared files** that multiple features will modify.
+**Only runs in multi-feature mode** (more than one feature). Skip entirely if `SINGLE_MODE=true`.
+
+After all architect agents complete, before launching any developer agent:
+
+#### Step 1: Extract file references
+
+For each `openspec/changes/<name>/tasks.md`, extract all paths listed under `**Files:**` entries (both `Create:` and `Modify:` lines). Normalize paths: strip leading `./`.
+
+#### Step 2: Build the shared-file registry
+
+Group file paths across all features. Any path appearing in two or more features' task lists is a **shared file**. Store as `SHARED_FILES` map: `{path: {features: [...], risk: ""}}`.
+
+#### Step 3: Classify risk
+
+For each shared file, classify risk based on file type and which regions each feature modifies (consult each feature's context-bundle.md "Exact Changes" section):
+
+| Risk | Condition |
+|------|-----------|
+| `low` | Both features only append new named sections not present in the other feature's changes |
+| `medium` | Both features modify structurally distinct regions (different `##` sections or different top-level YAML keys) |
+| `high` | Both features modify the same region (same `##` section, same YAML key subtree, or any region in shell scripts) |
+
+Shell scripts (`.sh`, `.bash`): always `high`.
+Non-existent files that two features both create: always `high`.
+
+#### Step 4: Derive MERGE_ORDER
+
+Sort features so that for any pair sharing a `high`-risk file, one appears before the other. Use topological sort; break ties alphabetically. Set `MERGE_ORDER` = sorted feature list.
+
+#### Step 5: Print pre-flight report
+
+```
+## Shared File Analysis
+
+| File | Features | Risk |
+|------|----------|------|
+| <path> | <feature-a>, <feature-b> | <risk> |
+
+Merge order: <feature-a> → <feature-b> → <feature-c>
+
+High-risk files detected. These files will be merged sequentially.
+Developers will still run in parallel — merge order applies at Phase 4a only.
+```
+
+If no shared files: print `No shared files detected. All features modify independent files.`
 
 ### 3a.2 Pre-validate architect output
 
@@ -234,9 +278,102 @@ If a test-writer agent fails or times out:
 
 ### 4a. Merge worktree changes to main repo
 
-- If `SINGLE_MODE`: skip (no worktrees were used).
-- If `DRY_RUN=true`: merge worktree outputs to `CACHE_DIR` instead of the main repo. Apply the same merge logic (copy feature-specific files, handle shared files) but destination is `CACHE_DIR/<file-path>`.
-- Otherwise: merge to main repo working tree as normal (copy feature-specific files, merge shared files manually, clean up worktrees).
+- If `SINGLE_MODE`: skip (no worktrees were used). Proceed to Phase 4b.
+- If `DRY_RUN=true`: apply the merge algorithm below, writing all outputs to `CACHE_DIR/<file-path>` instead of the main repo working tree. Do NOT clean up worktrees in dry-run mode.
+- Otherwise: apply the merge algorithm below, writing outputs to the main repo working tree. Clean up worktrees at the end.
+
+#### Merge Algorithm
+
+Process features in `MERGE_ORDER` sequence. For each feature:
+
+**Step 1: Identify changed files**
+
+```bash
+git -C <worktree-path> diff main --name-only
+```
+
+Split into `exclusive_files` (only this feature modifies them) and `shared_files_for_this_feature` (also modified by another feature in MERGE_ORDER).
+
+**Step 2: Merge exclusive files**
+
+Copy directly from worktree to target:
+```bash
+cp <worktree-path>/<file> <target>/<file>
+```
+Log: `Copied (exclusive): <file>`
+
+**Step 3: Merge shared files**
+
+For each shared file, choose strategy by file type:
+
+**Strategy A — Markdown section-aware merge** (`.md` files):
+1. Read base: current content of `<target>/<file>`.
+2. Read incoming: `<worktree-path>/<file>`.
+3. Parse both into sections using `##` heading boundaries (heading line + all content until next `##` or EOF).
+4. Build section maps: `{heading_text: content}` for base and incoming.
+5. Merge:
+   - Section in base only: keep.
+   - Section in incoming only: append to merged output.
+   - Section in both, content identical: keep base.
+   - Section in both, content differs: insert conflict markers:
+     ```
+     <<<<<<< <feature-name>
+     <incoming section content>
+     =======
+     <base section content>
+     >>>>>>> base
+     ```
+     Log: `CONFLICT: <file> — section "<heading>" requires manual resolution.`
+6. Write merged result to `<target>/<file>`.
+
+**Strategy B — Unified diff sequential apply** (all other file types):
+1. Generate incoming diff against original `main`:
+   ```bash
+   git -C <worktree-path> diff main -- <file>
+   ```
+2. Apply to current target:
+   ```bash
+   patch --forward --fuzz=3 <target>/<file> < <diff>
+   ```
+3. If `patch` succeeds: log `Merged (diff-apply): <file>`.
+4. If `patch` fails: insert conflict markers around rejected hunks. Log: `CONFLICT: <file> — N hunks rejected.`
+
+If `patch` is not available (detected in Phase -1): use Strategy A for all file types and print: `[warn] patch not available — using section-aware fallback for all shared files.`
+
+**Step 4: Record outcomes**
+
+Maintain `MERGE_REPORT`:
+- `cleanly_merged`: exclusive files + shared files with no conflicts
+- `auto_resolved`: shared files merged without conflict markers
+- `requires_resolution`: `{file, feature, regions}` for files with conflict markers
+
+**Step 5: Emit merge report**
+
+After all features are processed:
+
+```
+## Phase 4a Merge Report
+
+### Cleanly Merged
+- <file> (exclusive to <feature>)
+
+### Auto-Resolved
+- <file> (features: <a>, <b> — distinct sections)
+
+### Requires Manual Resolution
+- <file> (features: <a>, <b> — conflicting section: "<heading>")
+  Search for `<<<<<<< <feature-name>` to locate conflict markers.
+
+Pipeline will continue. Fix conflicts above before the reviewer runs CI.
+```
+
+**Step 6: Clean up worktrees** (skip if `DRY_RUN=true`)
+
+```bash
+git worktree remove <worktree-path> --force
+```
+
+Pass `MERGE_REPORT` to the Phase 4b reviewer agent prompt, listing any files in `requires_resolution`.
 
 ### 4b. Launch Reviewer agent
 
@@ -390,6 +527,18 @@ rm -rf .claude/.dry-run/<feature-name>/
 ```
 | Area | Feature | Change Name | Architect | Developer | Tests | Reviewer | Security | CI | Status |
 |------|---------|-------------|-----------|-----------|-------|----------|----------|----|--------|
+```
+
+If `MERGE_REPORT.requires_resolution` is non-empty, print an additional section:
+
+```
+### Merge Conflicts Requiring Resolution
+
+| File | Features | Conflicting Region |
+|------|----------|-------------------|
+| <file> | <feature-a>, <feature-b> | <section heading or hunk description> |
+
+Fix these conflicts (search for `<<<<<<<` in each file), then commit the resolved files.
 ```
 
 Include PR URL, CI status, and backlog updates made.

--- a/openspec/changes/archive/2026-03-13-smart-merge-conflict-resolver/context-bundle.md
+++ b/openspec/changes/archive/2026-03-13-smart-merge-conflict-resolver/context-bundle.md
@@ -1,0 +1,400 @@
+---
+change: smart-merge-conflict-resolver
+type: context-bundle
+---
+
+# Context Bundle: Smart Merge Conflict Resolver
+
+This document is a self-contained developer briefing. You do not need to read any other file to execute these tasks.
+
+---
+
+## What You Are Building
+
+You are adding a concrete merge algorithm to the `/implement` pipeline. Currently, when multiple features are implemented in parallel using git worktrees, Phase 4a says "merge shared files manually" — which is undefined and causes silent data loss (last-writer-wins). You will:
+
+1. Replace the Phase 3a.1 stub with a full shared-file analysis that classifies each shared file by conflict risk and derives a merge order.
+2. Replace the Phase 4a stub with a concrete, ordered merge algorithm (section-aware for Markdown, diff/patch for everything else).
+3. Add merge conflict reporting to the Phase 4e summary.
+4. Mirror all changes to the generated command file.
+5. Update the spec with normative documentation.
+
+**This is exclusively an edit to two command files and one spec file. No new agents, no new templates, no new directories.**
+
+---
+
+## Files to Change
+
+| File | Change Type | Notes |
+|------|-------------|-------|
+| `templates/commands/implement.md` | Modify | Primary target — contains the pipeline definition with `{{PLACEHOLDER}}` syntax |
+| `.claude/commands/implement.md` | Modify | Generated copy — same changes but placeholders already resolved; do NOT introduce `{{...}}` |
+| `openspec/specs/implement.md` | Modify | Spec — add "Merge Behavior" section and three variable rows |
+
+**Do NOT modify:**
+- Any file in `templates/agents/` or `.claude/agents/`
+- `install.sh`
+- Any other command file
+- Any OpenSpec change artifact file (proposal.md, design.md, delta-spec.md, tasks.md — the files you are reading right now)
+
+---
+
+## Current State
+
+### `templates/commands/implement.md` — Phase 3a.1 (the stub, lines ~143–147)
+
+```markdown
+### 3a.1 Identify shared file conflicts
+
+Before launching developers, scan all tasks.md files to identify **shared files** that multiple features will modify.
+```
+
+This is three lines. It says nothing about how to scan, what risk levels to assign, or what to do with the result.
+
+### `templates/commands/implement.md` — Phase 4a (the stub, lines ~233–239)
+
+```markdown
+### 4a. Merge worktree changes to main repo
+
+- If `SINGLE_MODE`: skip (no worktrees were used).
+- If `DRY_RUN=true`: merge worktree outputs to `CACHE_DIR` instead of the main repo. Apply the same merge logic (copy feature-specific files, handle shared files) but destination is `CACHE_DIR/<file-path>`.
+- Otherwise: merge to main repo working tree as normal (copy feature-specific files, merge shared files manually, clean up worktrees).
+```
+
+The word "manually" is the problem. There is no algorithm.
+
+### `openspec/specs/implement.md` — Variable Reference table (lines ~110–119)
+
+The table has four rows: `DRY_RUN`, `APPLY_MODE`, `APPLY_TARGET`, `CACHE_DIR`. Three new rows must be added: `SHARED_FILES`, `MERGE_ORDER`, `MERGE_REPORT`.
+
+### `.claude/commands/implement.md`
+
+Identical structure to the template but with `{{PLACEHOLDER}}` strings resolved. Phase 3a.1 and Phase 4a have the same stub content. The generated file does not have placeholders in these sections — the Phase 3a.1 and Phase 4a sections are plain prose.
+
+---
+
+## Exact Changes
+
+### Change 1 — Replace Phase 3a.1 stub in `templates/commands/implement.md`
+
+**Location:** The section starting with `### 3a.1 Identify shared file conflicts` and ending before `### 3a.2 Pre-validate architect output`.
+
+**Replace this exact block:**
+
+```markdown
+### 3a.1 Identify shared file conflicts
+
+Before launching developers, scan all tasks.md files to identify **shared files** that multiple features will modify.
+```
+
+**With this block:**
+
+```markdown
+### 3a.1 Identify shared file conflicts
+
+**Only runs in multi-feature mode** (more than one feature). Skip entirely if `SINGLE_MODE=true`.
+
+After all architect agents complete, before launching any developer agent:
+
+#### Step 1: Extract file references
+
+For each `openspec/changes/<name>/tasks.md`, extract all paths listed under `**Files:**` entries (both `Create:` and `Modify:` lines). Normalize paths: strip leading `./`.
+
+#### Step 2: Build the shared-file registry
+
+Group file paths across all features. Any path appearing in two or more features' task lists is a **shared file**. Store as `SHARED_FILES` map: `{path: {features: [...], risk: ""}}`.
+
+#### Step 3: Classify risk
+
+For each shared file, classify risk based on file type and which regions each feature modifies (consult each feature's context-bundle.md "Exact Changes" section):
+
+| Risk | Condition |
+|------|-----------|
+| `low` | Both features only append new named sections not present in the other feature's changes |
+| `medium` | Both features modify structurally distinct regions (different `##` sections or different top-level YAML keys) |
+| `high` | Both features modify the same region (same `##` section, same YAML key subtree, or any region in shell scripts) |
+
+Shell scripts (`.sh`, `.bash`): always `high`.
+Net-new files that two features both create: always `high`.
+
+#### Step 4: Derive MERGE_ORDER
+
+Sort features so that for any pair sharing a `high`-risk file, one appears before the other. Use topological sort; break ties alphabetically. Set `MERGE_ORDER` = sorted feature list.
+
+#### Step 5: Print pre-flight report
+
+```
+## Shared File Analysis
+
+| File | Features | Risk |
+|------|----------|------|
+| <path> | <feature-a>, <feature-b> | <risk> |
+
+Merge order: <feature-a> → <feature-b> → <feature-c>
+
+High-risk files detected. These files will be merged sequentially.
+Developers will still run in parallel — merge order applies at Phase 4a only.
+```
+
+If no shared files: print `No shared files detected. All features modify independent files.`
+```
+
+---
+
+### Change 2 — Replace Phase 4a body in `templates/commands/implement.md`
+
+**Location:** The section starting with `### 4a. Merge worktree changes to main repo` and ending before `### 4b. Launch Reviewer agent`.
+
+**Replace this exact block:**
+
+```markdown
+### 4a. Merge worktree changes to main repo
+
+- If `SINGLE_MODE`: skip (no worktrees were used).
+- If `DRY_RUN=true`: merge worktree outputs to `CACHE_DIR` instead of the main repo. Apply the same merge logic (copy feature-specific files, handle shared files) but destination is `CACHE_DIR/<file-path>`.
+- Otherwise: merge to main repo working tree as normal (copy feature-specific files, merge shared files manually, clean up worktrees).
+```
+
+**With this block:**
+
+```markdown
+### 4a. Merge worktree changes to main repo
+
+- If `SINGLE_MODE`: skip (no worktrees were used). Proceed to Phase 4b.
+- If `DRY_RUN=true`: apply the merge algorithm below, writing all outputs to `CACHE_DIR/<file-path>` instead of the main repo working tree. Do NOT clean up worktrees in dry-run mode.
+- Otherwise: apply the merge algorithm below, writing outputs to the main repo working tree. Clean up worktrees at the end.
+
+#### Merge Algorithm
+
+Process features in `MERGE_ORDER` sequence. For each feature:
+
+**Step 1: Identify changed files**
+
+```bash
+git -C <worktree-path> diff main --name-only
+```
+
+Split into `exclusive_files` (only this feature modifies them) and `shared_files_for_this_feature` (also modified by another feature in MERGE_ORDER).
+
+**Step 2: Merge exclusive files**
+
+Copy directly from worktree to target:
+```bash
+cp <worktree-path>/<file> <target>/<file>
+```
+Log: `Copied (exclusive): <file>`
+
+**Step 3: Merge shared files**
+
+For each shared file, choose strategy by file type:
+
+**Strategy A — Markdown section-aware merge** (`.md` files):
+1. Read base: current content of `<target>/<file>`.
+2. Read incoming: `<worktree-path>/<file>`.
+3. Parse both into sections using `##` heading boundaries (heading line + all content until next `##` or EOF).
+4. Build section maps: `{heading_text: content}` for base and incoming.
+5. Merge:
+   - Section in base only: keep.
+   - Section in incoming only: append to merged output.
+   - Section in both, content identical: keep base.
+   - Section in both, content differs: insert conflict markers:
+     ```
+     <<<<<<< <feature-name>
+     <incoming section content>
+     =======
+     <base section content>
+     >>>>>>> base
+     ```
+     Log: `CONFLICT: <file> — section "<heading>" requires manual resolution.`
+6. Write merged result to `<target>/<file>`.
+
+**Strategy B — Unified diff sequential apply** (all other file types):
+1. Generate incoming diff against original `main`:
+   ```bash
+   git -C <worktree-path> diff main -- <file>
+   ```
+2. Apply to current target:
+   ```bash
+   patch --forward --fuzz=3 <target>/<file> < <diff>
+   ```
+3. If `patch` succeeds: log `Merged (diff-apply): <file>`.
+4. If `patch` fails: insert conflict markers around rejected hunks. Log: `CONFLICT: <file> — N hunks rejected.`
+
+If `patch` is not available (detected in Phase -1): use Strategy A for all file types and print: `[warn] patch not available — using section-aware fallback for all shared files.`
+
+**Step 4: Record outcomes**
+
+Maintain `MERGE_REPORT`:
+- `cleanly_merged`: exclusive files + shared files with no conflict markers
+- `auto_resolved`: shared files merged without conflict markers
+- `requires_resolution`: `{file, feature, regions}` for files with conflict markers
+
+**Step 5: Emit merge report**
+
+After all features are processed:
+
+```
+## Phase 4a Merge Report
+
+### Cleanly Merged
+- <file> (exclusive to <feature>)
+
+### Auto-Resolved
+- <file> (features: <a>, <b> — distinct sections)
+
+### Requires Manual Resolution
+- <file> (features: <a>, <b> — conflicting section: "<heading>")
+  Search for `<<<<<<< <feature-name>` to locate conflict markers.
+
+Pipeline will continue. Fix conflicts above before the reviewer runs CI.
+```
+
+**Step 6: Clean up worktrees** (skip if `DRY_RUN=true`)
+
+```bash
+git worktree remove <worktree-path> --force
+```
+
+Pass `MERGE_REPORT` to the Phase 4b reviewer agent prompt, listing any files in `requires_resolution`.
+```
+
+---
+
+### Change 3 — Add conflict table to Phase 4e in `templates/commands/implement.md`
+
+**Location:** In the Phase 4e "Otherwise" (non-dry-run) report section. After the pipeline status table code block, insert:
+
+```markdown
+If `MERGE_REPORT.requires_resolution` is non-empty, print an additional section:
+
+```
+### Merge Conflicts Requiring Resolution
+
+| File | Features | Conflicting Region |
+|------|----------|-------------------|
+| <file> | <feature-a>, <feature-b> | <section heading or hunk description> |
+
+Fix these conflicts (search for `<<<<<<<` in each file), then commit the resolved files.
+```
+```
+
+**Location anchor:** After the closing ` ``` ` of the pipeline status table (the table with `Area | Feature | Change Name | ...`), before the "Include the shipping mode in the report" line.
+
+---
+
+### Change 4 — Apply the same changes to `.claude/commands/implement.md`
+
+Apply Changes 1, 2, and 3 to `.claude/commands/implement.md`. The content is identical — this file has no placeholders in the Phase 3a.1 or Phase 4a sections, so no placeholder resolution is needed.
+
+Verify: after editing, run:
+```bash
+grep -n 'manually' /Users/javi/repos/specrails/.claude/commands/implement.md
+```
+Expected: no matches in Phase 4a (the word "manually" must be gone from the merge section).
+
+---
+
+### Change 5 — Add "Merge Behavior" section to `openspec/specs/implement.md`
+
+**Location:** After the "Edge Cases" section (currently the last section in the file).
+
+**Insert this section:**
+
+```markdown
+---
+
+## Merge Behavior
+
+### Shared File Analysis (Phase 3a.1)
+
+**When multi-feature mode is active** (more than one feature is being implemented), the pipeline SHALL run a shared file analysis before launching any developer agent.
+
+The analysis MUST:
+1. Extract all file paths listed in `**Files:**` entries within each feature's `tasks.md`.
+2. Identify paths that appear in two or more features' file lists as **shared files**.
+3. Classify each shared file with a risk level: `low`, `medium`, or `high`.
+4. Derive `MERGE_ORDER`: an ordered sequence of feature names such that features with `high`-risk shared files are processed sequentially.
+5. Print a pre-flight shared file report before developer agents launch.
+
+The analysis SHALL NOT block developer agent launch.
+
+**Risk Classification Rules:**
+
+| Risk | Condition |
+|------|-----------|
+| `low` | Both features append new, named sections that do not exist in the other feature's changes |
+| `medium` | Both features modify structurally distinct regions of the same file |
+| `high` | Both features modify overlapping regions; or the file is a shell script; or both features create the same net-new file |
+
+### Merge Algorithm (Phase 4a)
+
+**When multi-feature mode is active**, Phase 4a MUST process features in `MERGE_ORDER` sequence.
+
+**For exclusive files**: copy directly from worktree to merge target.
+
+**For shared Markdown files** (`.md`): apply section-aware merging using `##` heading boundaries. Non-overlapping sections are combined additively. Overlapping sections receive conflict markers (`<<<<<<< / ======= / >>>>>>>`).
+
+**For shared non-Markdown files**: apply unified diff sequential merging using `patch --forward --fuzz=3`. Failed hunks receive conflict markers.
+
+**If `patch` is unavailable**: fall back to section-aware merge for all file types with a warning.
+
+### Merge Report
+
+Phase 4a MUST emit a merge report listing: Cleanly Merged, Auto-Resolved, and Requires Manual Resolution. Files in "Requires Manual Resolution" MUST appear in the Phase 4e final report. The reviewer agent prompt MUST include the conflict file list.
+
+### Dry-Run Compatibility
+
+When `DRY_RUN=true`, Phase 4a MUST apply the identical merge algorithm writing to `CACHE_DIR`. Merge report MUST be written to `.cache-manifest.json` under `merge_report`. Worktrees SHALL NOT be cleaned up.
+
+### Constraints
+
+- `SINGLE_MODE=true` MUST bypass Phase 3a.1 and Phase 4a smart merge entirely.
+- The merge algorithm MUST NOT create git commits, branches, or pushes.
+- Pre-existing conflict markers in a file MUST NOT be nested with new conflict markers — log a warning instead.
+```
+
+**Extend the Variable Reference table** with three new rows (insert after the `CACHE_DIR` row):
+
+```markdown
+| `SHARED_FILES` | map | After Phase 3a.1, multi-feature only | Registry mapping file paths to `{features: [...], risk: "low"\|"medium"\|"high"}` |
+| `MERGE_ORDER` | list | After Phase 3a.1, multi-feature only | Ordered sequence of feature names for Phase 4a processing |
+| `MERGE_REPORT` | map | During Phase 4a, multi-feature only | Accumulates merge outcomes: `cleanly_merged`, `auto_resolved`, `requires_resolution` |
+```
+
+---
+
+## Existing Patterns to Follow
+
+- **Phase section structure**: Each phase has a `##` heading, optional subsections with `###`, and numbered steps within code blocks or bold-prefixed paragraphs. Follow exactly.
+- **Condition guards**: Use the pattern `**If `FLAG=true`:**` followed by bullet points. See Phase 3b "Dry-Run: Redirect developer writes" for the canonical example.
+- **Code blocks in pipeline instructions**: Use triple-backtick blocks with the `bash` language tag for shell commands, no tag for output format examples.
+- **Conflict markers**: The canonical format is `<<<<<<< <feature-name>` (not `<<<<<<< HEAD` or `<<<<<<< THEIRS` — feature name is more readable for the reviewer).
+- **Non-breaking changes**: Always preserve existing content verbatim. The only removals in this change set are the two stubs being replaced.
+
+---
+
+## Conventions Checklist
+
+Before marking any task done:
+
+- [ ] No `{{PLACEHOLDER}}` strings introduced into `.claude/commands/implement.md`
+- [ ] No `{{PLACEHOLDER}}` strings broken in `templates/commands/implement.md` (the sections being edited have none, but verify with surrounding context)
+- [ ] The word "manually" does not appear in the new Phase 4a text
+- [ ] `SINGLE_MODE=true` skip guard is present in Phase 3a.1 AND Phase 4a
+- [ ] Dry-run path (`DRY_RUN=true`) is explicitly handled in both Phase 3a.1 (N/A — no change) and Phase 4a (CACHE_DIR target)
+- [ ] Conflict marker format exactly: `<<<<<<< <feature-name>` / `=======` / `>>>>>>> base`
+- [ ] `MERGE_ORDER`, `SHARED_FILES`, `MERGE_REPORT` variable names are spelled consistently across all three files
+- [ ] Phase 4e conflict table is conditional (only printed when `requires_resolution` is non-empty)
+- [ ] Spec additions use SHALL/MUST/SHOULD normative language
+
+---
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Phase 4a edit accidentally truncates Phase 4b content | Medium | Read from `### 4a.` to `### 4b.` to identify the exact replacement boundary before editing |
+| `MERGE_ORDER` variable referenced in Phase 4a but defined in Phase 3a.1 — ordering in the reader's mind may be confused | Low | Phase 3a.1 runs before developer launch; Phase 4a runs after all agents complete. The timeline is clear from the phase numbers. |
+| Section-aware merge breaks on files that use `###` as top-level sections (non-standard) | Low | specrails files consistently use `##` for top-level logical sections. Document the `##` assumption in the algorithm text. |
+| `patch` not available in some environments (Docker, minimal shells) | Low | Phase -1 fallback guard handles this. The context-bundle already includes the detection note. |
+| Task 4 (generated file) diverges from template if editor applies slightly different phrasing | Medium | Developer should copy content directly from the modified template, not rewrite from scratch. The tasks.md says this explicitly. |

--- a/openspec/changes/archive/2026-03-13-smart-merge-conflict-resolver/delta-spec.md
+++ b/openspec/changes/archive/2026-03-13-smart-merge-conflict-resolver/delta-spec.md
@@ -1,0 +1,106 @@
+---
+change: smart-merge-conflict-resolver
+type: delta-spec
+---
+
+# Delta Spec: Smart Merge Conflict Resolver
+
+This document describes the changes to `openspec/specs/implement.md` required by this feature. It uses SHALL/MUST/SHOULD language to define normative behavior.
+
+---
+
+## Changes to `openspec/specs/implement.md`
+
+### Add: "Merge Behavior" section
+
+Insert the following section after the "Variable Reference" section (currently the last section) in `openspec/specs/implement.md`:
+
+---
+
+## Merge Behavior
+
+### Shared File Analysis (Phase 3a.1)
+
+**When multi-feature mode is active** (more than one feature is being implemented), the pipeline SHALL run a shared file analysis before launching any developer agent.
+
+The analysis MUST:
+1. Extract all file paths listed in `**Files:**` entries within each feature's `tasks.md`.
+2. Identify paths that appear in two or more features' file lists as **shared files**.
+3. Classify each shared file with a risk level: `low`, `medium`, or `high` (see risk classification rules below).
+4. Derive `MERGE_ORDER`: an ordered sequence of feature names such that features with `high`-risk shared files are processed sequentially.
+5. Print a pre-flight shared file report before developer agents launch.
+
+The analysis SHALL NOT block developer agent launch. Regardless of risk classification, all developer agents launch in parallel after Phase 3a.1 completes.
+
+**Risk Classification Rules:**
+
+| Risk | Condition |
+|------|-----------|
+| `low` | Both features append new, named sections (`##` headings for Markdown; new top-level keys for YAML/JSON) that do not exist in the other feature's changes |
+| `medium` | Both features modify structurally distinct regions of the same file (different `##` sections; different top-level YAML keys) |
+| `high` | Both features modify overlapping regions of the same file (same `##` section; same YAML/JSON key subtree; any region in shell scripts) |
+
+### Merge Algorithm (Phase 4a)
+
+**When multi-feature mode is active**, Phase 4a MUST process features in `MERGE_ORDER` sequence (not arbitrary order).
+
+**For exclusive files** (modified by only one feature): the pipeline SHALL copy the file directly from the worktree to the merge target.
+
+**For shared Markdown files** (`.md` extension): the pipeline SHALL apply section-aware merging:
+- Parse files into sections using `##` heading boundaries.
+- Sections present in only one version SHALL be added to the merged output.
+- Sections present in both versions with identical content SHALL be kept as-is (the base version is authoritative).
+- Sections present in both versions with differing content SHALL be marked as conflicts using the following format:
+  ```
+  <<<<<<< <feature-name>
+  <incoming section content>
+  =======
+  <base section content>
+  >>>>>>> base
+  ```
+
+**For shared non-Markdown files** (`.yaml`, `.yml`, `.json`, `.sh`, `.bash`, and all other types): the pipeline SHALL apply unified diff sequential merging:
+- Generate the incoming diff against the original `main` version.
+- Apply the diff to the current target file using `patch --forward --fuzz=3`.
+- If `patch` succeeds: the file is cleanly merged.
+- If `patch` rejects one or more hunks: the rejected regions SHALL be marked with conflict markers as above.
+
+**If `patch` is not available** in the environment: the pipeline SHALL fall back to section-aware merge for all file types and MUST print a warning noting the fallback.
+
+### Merge Report
+
+Phase 4a MUST emit a merge report after all features are processed. The report SHALL include:
+
+- **Cleanly Merged**: files copied exclusively (no conflict possible)
+- **Auto-Resolved**: shared files merged without conflicts
+- **Requires Manual Resolution**: shared files where conflict markers were inserted, with the feature name and conflicting section or hunk
+
+Files listed under "Requires Manual Resolution" MUST also appear in the Phase 4e final report.
+
+The reviewer agent prompt MUST include the list of conflicting files (if any) so the reviewer can attempt auto-resolution.
+
+### Dry-Run Compatibility
+
+When `DRY_RUN=true`, Phase 4a MUST apply the identical merge algorithm, writing all results to `CACHE_DIR` instead of the main repo working tree.
+
+The merge report MUST be written to `.cache-manifest.json` under a `merge_report` key.
+
+Worktrees SHALL NOT be cleaned up in dry-run mode.
+
+### Constraints
+
+- `SINGLE_MODE=true` MUST bypass Phase 3a.1 and Phase 4a smart merge entirely. No shared file analysis, no MERGE_ORDER, no section-aware merge.
+- The merge algorithm MUST NOT make any git commits, branch operations, or push operations. It operates exclusively on the working tree.
+- If a file already contains conflict markers from a prior failed run, the pipeline MUST log a warning and MUST NOT insert nested conflict markers.
+
+---
+
+### Add: New variables to "Variable Reference" section
+
+Append the following rows to the Variable Reference table in `openspec/specs/implement.md`:
+
+| Variable | Type | Set when | Description |
+|----------|------|----------|-------------|
+| `SHARED_FILES` | map | After Phase 3a.1, multi-feature only | Registry mapping file paths to `{features: [...], risk: "low"|"medium"|"high"}` |
+| `MERGE_ORDER` | list | After Phase 3a.1, multi-feature only | Ordered sequence of feature names for Phase 4a processing |
+| `MERGE_REPORT` | map | During Phase 4a, multi-feature only | Accumulates merge outcomes: `cleanly_merged`, `auto_resolved`, `requires_resolution` |

--- a/openspec/changes/archive/2026-03-13-smart-merge-conflict-resolver/design.md
+++ b/openspec/changes/archive/2026-03-13-smart-merge-conflict-resolver/design.md
@@ -1,0 +1,314 @@
+---
+change: smart-merge-conflict-resolver
+type: design
+---
+
+# Design: Smart Merge Conflict Resolver
+
+## Architecture Overview
+
+This feature is entirely contained within the orchestrator's inline logic — no new agents, no new files outside of `implement.md` edits. The two affected phases are:
+
+- **Phase 3a.1**: shared file detection and risk classification (currently a one-line stub)
+- **Phase 4a**: merge algorithm (currently a vague instruction to "merge shared files manually")
+
+Both changes live in the same file (`templates/commands/implement.md`), mirrored to `.claude/commands/implement.md`. The spec (`openspec/specs/implement.md`) gains a new "Merge Behavior" section.
+
+---
+
+## Phase 3a.1 Redesign: Shared File Analysis
+
+### Current state
+
+```markdown
+### 3a.1 Identify shared file conflicts
+
+Before launching developers, scan all tasks.md files to identify **shared files** that multiple features will modify.
+```
+
+This is a stub. It says what to scan but not how, what output to produce, or what to do with the result.
+
+### New design
+
+Phase 3a.1 executes immediately after all architect agents complete, before any developer agent launches.
+
+#### Step 1: Extract file references from tasks.md
+
+For each `openspec/changes/<name>/tasks.md`, extract all file paths listed under "Files:" or "**Files:**" entries. These are the files each feature intends to modify or create.
+
+Normalization rules:
+- Strip leading `./` from paths
+- Treat `Create:` and `Modify:` entries identically — a creation conflict is still a conflict
+- Ignore paths that don't exist in the repo (they're net-new files; two features creating the same net-new path IS a conflict)
+
+#### Step 2: Build the shared-file registry
+
+Group file paths across all features. Any path appearing in two or more features' task lists is a **shared file**.
+
+Data structure (in-memory for the orchestrator):
+```
+shared_files = {
+  "path/to/file": {
+    features: ["feature-a", "feature-b"],
+    risk: "low" | "medium" | "high"
+  }
+}
+```
+
+#### Step 3: Risk classification heuristic
+
+Classify each shared file by risk:
+
+| Risk | Criteria | Examples |
+|------|----------|---------|
+| `low` | Only one feature modifies the file's content; the other only creates it (net-new additions don't collide) | Feature A adds a new section at EOF; Feature B does not touch that file at all in its actual diff |
+| `low` | Both features append to distinct, named sections that don't overlap | Two features each add a new `##` section with different headings |
+| `medium` | Both features modify the same file but in structurally distinct regions (different `##` sections, different top-level YAML keys) | Feature A adds to `Phase 3b`, Feature B adds to `Phase 4` |
+| `high` | Both features modify the same region of the file (same `##` section, same YAML block, same function body) | Both modify the Phase 4e report table header |
+
+**Classification algorithm for Markdown files:**
+1. For each feature, identify which `##` sections they modify (by reading context-bundle.md "Exact Changes" section).
+2. If the section sets are disjoint: `medium` risk.
+3. If the section sets overlap: `high` risk.
+4. If one feature only appends a new `##` section not present in any other feature's changes: downgrade to `low` risk.
+
+**Classification for non-Markdown files:**
+- YAML/JSON with distinct top-level keys: `medium`
+- YAML/JSON with overlapping keys: `high`
+- Shell scripts: always `high` (line-level edits are hard to region-classify without execution context)
+
+#### Step 4: Derive MERGE_ORDER
+
+For features with `high`-risk shared files, serialized merge order reduces the risk of conflicts by making one feature's output the base for the next:
+
+1. Build a dependency graph: if Feature A and Feature B share a `high`-risk file, one must come before the other in merge order.
+2. Use topological sort. If there are no ordering constraints between two features (they share no `high`-risk files), their relative order is arbitrary.
+3. Set `MERGE_ORDER` = the sorted feature list.
+
+Note: `MERGE_ORDER` is the sequence in which Phase 4a processes features, not the sequence in which developer agents run. Developer agents still run in parallel.
+
+#### Step 5: Print pre-flight report
+
+```
+## Shared File Analysis
+
+| File | Features | Risk |
+|------|----------|------|
+| templates/commands/implement.md | feature-a, feature-b | high |
+| .claude/commands/implement.md | feature-a, feature-b | high |
+| openspec/specs/implement.md | feature-b, feature-c | medium |
+
+Merge order: feature-a → feature-b → feature-c
+
+High-risk files detected. These files will be merged sequentially in the order above.
+Developers will still run in parallel — merge order applies at Phase 4a only.
+```
+
+If no shared files exist, print: `No shared files detected. All features modify independent files.`
+
+---
+
+## Phase 4a Redesign: Smart Merge Algorithm
+
+### Current state
+
+```markdown
+### 4a. Merge worktree changes to main repo
+
+- If `SINGLE_MODE`: skip (no worktrees were used).
+- If `DRY_RUN=true`: merge worktree outputs to `CACHE_DIR` instead of the main repo.
+- Otherwise: merge to main repo working tree as normal (copy feature-specific files, merge shared files manually, clean up worktrees).
+```
+
+"Manually" is undefined. This design replaces it with a concrete, ordered algorithm.
+
+### New design
+
+Phase 4a processes features in `MERGE_ORDER` sequence.
+
+#### For each feature in MERGE_ORDER:
+
+**Step 1: Identify this feature's changed files**
+
+Read the feature's worktree diff against main:
+```bash
+git -C <worktree-path> diff main --name-only
+```
+
+Split the file list into:
+- `exclusive_files`: files only this feature modifies
+- `shared_files_for_this_feature`: files also modified by another feature
+
+**Step 2: Merge exclusive files**
+
+For exclusive files: direct copy from worktree to target (main repo working tree, or `CACHE_DIR` in dry-run mode).
+
+```bash
+cp <worktree-path>/<file> <target>/<file>
+```
+
+No conflict possible. Log: `Copied (exclusive): <file>`
+
+**Step 3: Merge shared files**
+
+For each shared file, apply the appropriate merge strategy based on file type and risk.
+
+##### Strategy A: Markdown section-aware merge
+
+Applies when: file extension is `.md`
+
+Algorithm:
+1. Read the **base** version: current content of `<target>/<file>` (which may already have a previous feature's changes applied if this is not the first feature in MERGE_ORDER).
+2. Read the **incoming** version: `<worktree-path>/<file>`.
+3. Parse both into sections using `##` heading boundaries. A section is: the heading line + all content until the next `##` heading or EOF.
+4. Build a section map: `{heading_text: content}` for both base and incoming.
+5. Merge:
+   - Sections present only in base: keep as-is.
+   - Sections present only in incoming: append after the last base section (or in position order if the incoming file has a clear structure to follow).
+   - Sections present in both:
+     - If content is identical: keep base version (no-op).
+     - If content differs: this is a **conflict region**. Insert conflict markers:
+       ```
+       <<<<<<< <feature-name>
+       <incoming section content>
+       =======
+       <base section content>
+       >>>>>>> base
+       ```
+     - Log: `CONFLICT: <file> — section "<heading>" requires manual resolution.`
+
+6. Write the merged result to `<target>/<file>`.
+7. Log outcome: `Merged (section-aware): <file>` or `Merged with conflicts: <file> (N sections need resolution)`
+
+##### Strategy B: Unified diff sequential apply
+
+Applies when: file extension is `.yaml`, `.yml`, `.json`, `.sh`, `.bash`, or any non-Markdown type
+
+Algorithm:
+1. Generate a diff of the incoming changes against the original `main` version:
+   ```bash
+   git -C <worktree-path> diff main -- <file>
+   ```
+2. Attempt to apply the diff to the current target file (which may already have changes from a prior feature):
+   ```bash
+   patch --forward --fuzz=3 <target>/<file> < <diff>
+   ```
+3. If `patch` succeeds: log `Merged (diff-apply): <file>`
+4. If `patch` fails (hunk rejection): fall back to conflict markers. Write the conflicting hunks as:
+   ```
+   <<<<<<< <feature-name>
+   <incoming hunk>
+   =======
+   <current base content at that location>
+   >>>>>>> base
+   ```
+   Log: `CONFLICT: <file> — N hunks rejected, manual resolution required.`
+
+Note: `patch` is POSIX standard and available in all target environments. This avoids any dependency on language-specific tooling.
+
+#### Step 4: Record merge outcomes
+
+Maintain a `MERGE_REPORT` accumulator:
+```
+merge_report = {
+  cleanly_merged: ["file-a", "file-b"],
+  auto_resolved: ["file-c"],   # section-aware merge with no conflicts
+  requires_resolution: [
+    {file: "file-d", feature: "feature-b", sections: ["## Phase 4a"]},
+  ]
+}
+```
+
+#### Step 5: Emit merge report
+
+After all features are processed:
+
+```
+## Phase 4a Merge Report
+
+### Cleanly Merged (exclusive files)
+- templates/commands/implement.md ... (exclusive to feature-a)
+- src/utils/parser.ts ... (exclusive to feature-b)
+
+### Auto-Resolved (section-aware merge, no conflicts)
+- openspec/specs/implement.md (features: feature-a, feature-b — distinct sections)
+
+### Requires Manual Resolution
+- templates/agents/developer.md (features: feature-a, feature-b — conflicting section: "## Identity")
+  Search for `<<<<<<< feature-a` to find conflict markers.
+
+Pipeline will continue. Fix the conflicts above before the reviewer runs CI.
+```
+
+If `requires_resolution` is non-empty: the reviewer agent prompt must include the list of conflicting files so the reviewer can attempt auto-resolution or flag them clearly.
+
+#### Step 6: Clean up worktrees
+
+After all merges are complete, remove worktree directories:
+```bash
+git worktree remove <worktree-path> --force
+```
+
+---
+
+## Dry-Run Compatibility
+
+When `DRY_RUN=true`:
+- Target directory is `CACHE_DIR` instead of the main repo working tree.
+- All copy, merge, and patch operations write to `CACHE_DIR/<real-path>`.
+- The merge report is appended to `.cache-manifest.json` under a `merge_report` key.
+- Worktrees are NOT cleaned up in dry-run mode (they may be needed for inspection).
+
+---
+
+## Variable Reference
+
+New variables introduced by this feature:
+
+| Variable | Type | Set when | Description |
+|----------|------|----------|-------------|
+| `SHARED_FILES` | map | After Phase 3a.1 | Registry of shared files with feature lists and risk classification |
+| `MERGE_ORDER` | list | After Phase 3a.1 | Ordered sequence of feature names for Phase 4a processing |
+| `MERGE_REPORT` | map | During Phase 4a | Accumulates merge outcomes (clean, auto-resolved, conflicts) |
+
+---
+
+## Design Decisions
+
+### Why no new agent?
+
+The merge logic is a sequential, deterministic algorithm operating on files already present in the repo. It does not require the creativity or broad reasoning of an AI agent — it is closer to a script. Embedding it as orchestrator logic keeps the pipeline simpler, keeps latency low (no agent launch overhead), and avoids the ambiguity of an agent making freeform decisions about conflict resolution.
+
+If future iterations require AST-aware merging across multiple compiled languages, a specialized `merge-coordinator` agent would be the right approach at that point.
+
+### Why Markdown-section-aware merging?
+
+specrails' file corpus is overwhelmingly Markdown. The `templates/commands/implement.md` and `.claude/agents/*.md` files — the most frequently modified files in the repo — are Markdown. Section-aware merging using `##` boundaries handles the dominant case correctly with no external dependencies.
+
+`##` (H2) is the right boundary level because specrails Markdown files use H1 for the document title and H2 for logical sections. Smaller boundaries (H3, H4) would over-split sections and miss that a `###` heading belongs to its parent `##` section's scope.
+
+### Why `patch` for non-Markdown?
+
+`patch` is universally available in POSIX environments and is the established tool for applying unified diffs. It handles context lines, fuzz matching, and partial failure gracefully. The alternative (manual line-by-line diff application) would be significantly more complex to specify and execute reliably in an orchestrator prompt.
+
+### Why not `git merge`?
+
+`git merge` operates on branches and commits, not on working tree files. The worktrees in this pipeline are git repos, but merging them back into main via `git merge` would require rebasing or creating merge commits on the main branch — which conflicts with the pipeline's design of producing a single clean branch per feature group. The working-tree approach (copy + patch) is simpler and more predictable for the orchestrator.
+
+### Why not serialize developer agents for high-risk files?
+
+Serializing developers would eliminate conflicts at the source, but at the cost of removing the parallelism that makes multi-feature mode valuable. The correct trade-off: keep developers parallel (speed), handle conflicts at merge time (correctness). For truly irreconcilable conflicts, the pipeline surfaces them clearly rather than silently failing.
+
+---
+
+## Edge Cases
+
+| Scenario | Handling |
+|----------|----------|
+| Three features all modify the same Markdown section | Each is merged in MERGE_ORDER. First two may auto-resolve; if all three conflict, the final file has conflict markers showing the last-applied incoming vs. the accumulated base. The reviewer resolves. |
+| A feature creates a file that another feature also creates (net-new collision) | Treated as `high`-risk shared file. Section-aware merge or diff-apply will surface the conflict. |
+| `patch` binary not available | Detect at Phase -1 (environment setup). If missing, fall back to section-aware merge for all file types with a warning. |
+| Single feature in MERGE_ORDER has no shared files | Processes normally. MERGE_ORDER degenerates to a single-feature list. |
+| `SINGLE_MODE=true` | Phase 3a.1 and Phase 4a smart merge are entirely skipped. No behavioral change from current implementation. |
+| Worktree diff against main returns empty (no changes) | Feature is skipped in MERGE_ORDER. Log: `No changes detected in worktree for <feature>`. |
+| Conflict markers already present in a file (from a prior failed run) | The diff-apply strategy will detect this as a pre-existing conflict and log a warning rather than adding nested markers. |

--- a/openspec/changes/archive/2026-03-13-smart-merge-conflict-resolver/proposal.md
+++ b/openspec/changes/archive/2026-03-13-smart-merge-conflict-resolver/proposal.md
@@ -1,0 +1,84 @@
+---
+change: smart-merge-conflict-resolver
+type: feature
+status: proposed
+github_issue: 3
+vpc_fit: 75%
+---
+
+# Proposal: Smart Merge Conflict Resolver
+
+## Problem
+
+The `/implement` pipeline supports parallel multi-feature implementation via git worktrees. Each feature gets an isolated worktree where a developer agent works uninterrupted. At Phase 4a, the pipeline merges all worktrees back into the main repo working tree.
+
+The current merge logic in Phase 4a is a stub: it says "copy feature-specific files, merge shared files manually, clean up worktrees." The word "manually" is load-bearing — there is no actual merge strategy specified. When two features touch the same file (e.g., `templates/commands/implement.md`), the pipeline produces undefined behavior: the last feature's copy silently wins, or the orchestrator is left with no guidance on how to combine them.
+
+For a Lead Dev running 5+ features in parallel, this is a serious reliability failure. The benefit of parallel implementation evaporates if Phase 4a requires hours of manual conflict resolution. Worse, silent last-writer-wins overwrites mean the problem is not even surfaced — the pipeline reports success while losing one feature's changes.
+
+The symptoms:
+- **Silent overwrites**: shared file modifications from earlier-merged features are replaced by later ones, with no warning.
+- **No pre-flight awareness**: the orchestrator learns about shared files only at merge time, after all developer agents have finished.
+- **No merge strategy**: the pipeline provides no guidance on how to combine non-conflicting changes in the same file (e.g., two features each appending a different section).
+- **No ordered execution option**: there is no mechanism to serialize developer agents on shared files when full parallelism would cause irreconcilable conflicts.
+
+## Solution
+
+Enhance Phase 3a.1 (shared file identification, already exists as a stub) and Phase 4a (merge) with a practical, heuristic-based Smart Merge Conflict Resolver:
+
+**Phase 3a.1 — Shared File Analysis (pre-flight):**
+Scan all `tasks.md` files extracted from architect output. For each file referenced in multiple tasks.md files, classify it by merge risk: `low` (append-only sections), `medium` (structural edits to distinct regions), `high` (overlapping edits to the same region). Emit a pre-flight report and, for `high`-risk shared files, propose a serialization strategy: one feature runs first, its output becomes the base for the next.
+
+**Phase 4a — Smart Merge:**
+Replace the stub with a concrete, ordered merge algorithm:
+1. Process features in merge order (serialized sequence for `high`-risk shared files, any order for exclusive files).
+2. For each shared file, apply diffs sequentially using a region-based heuristic: identify non-overlapping change regions from each worktree diff and apply them in order; flag overlapping regions as conflicts requiring orchestrator review.
+3. For Markdown files (the dominant file type in specrails), apply section-aware merging: treat `##` headings as merge boundaries and combine sections additively.
+4. For non-Markdown files (YAML, JSON, shell scripts), fall back to a unified diff approach with explicit conflict markers if regions overlap.
+5. Emit a merge report: files merged cleanly, files with resolved regions, files requiring manual resolution, and the specific conflicting regions.
+
+This is intentionally **not** AST-aware in the first iteration. The project is pre-code (shell + Markdown), so Markdown-section-aware merging covers the dominant case. YAML and JSON files are structured enough that region-based diff suffices. Full AST parsing is deferred to a future iteration when the project acquires compiled language source files.
+
+## Scope
+
+**In scope:**
+- Phase 3a.1: full shared file analysis with risk classification (replaces the existing stub)
+- Phase 4a: concrete merge algorithm replacing the "manually" stub
+- Merge order variable: `MERGE_ORDER` list derived from shared file analysis
+- Pre-flight conflict report printed after Phase 3a.1
+- Merge result report at end of Phase 4a
+- Dry-run compatibility: same logic applies when `DRY_RUN=true`, writing to `CACHE_DIR`
+- Updates to `templates/commands/implement.md` and `.claude/commands/implement.md`
+- Updates to `openspec/specs/implement.md` to document the new merge behavior
+
+**Out of scope:**
+- AST-aware merging for compiled languages (TypeScript, Python, Go, Rust) — deferred
+- Automatic three-way merge via `git merge-file` or equivalent — too many edge cases for the current pre-code phase
+- New agent: the resolver runs inline in the orchestrator's Phase 4a logic, not as a background agent
+- Changes to worktree isolation setup (Phase 3b launch modes are unchanged)
+- Changes to the reviewer agent's mandate
+
+## Non-goals
+
+- This feature does NOT guarantee zero conflicts. High-risk shared files with overlapping edits will still surface as conflicts requiring human review — the feature ensures those conflicts are identified clearly, not silently swallowed.
+- This feature does NOT modify the developer agent's behavior. Developers still work in isolation per worktree.
+- This feature does NOT replace `git merge`. It operates on the working tree level, not on git history.
+
+## Acceptance Criteria
+
+1. Phase 3a.1 produces a structured shared-file report (table format) for every multi-feature run, listing each shared file, which features modify it, and its risk classification (`low`, `medium`, `high`).
+2. When a `high`-risk shared file is detected, Phase 3a.1 prints a serialization proposal showing the recommended merge order.
+3. Phase 4a processes features in `MERGE_ORDER` sequence, not arbitrary order.
+4. For Markdown shared files, Phase 4a uses `##`-heading boundaries as merge regions and combines non-overlapping sections additively.
+5. For non-Markdown shared files, Phase 4a applies unified diff regions sequentially, inserting conflict markers (`<<<<<<< feature-A`, `=======`, `>>>>>>> feature-B`) only for truly overlapping regions.
+6. Phase 4a emits a merge report distinguishing: cleanly merged, auto-resolved, requires manual resolution.
+7. Files requiring manual resolution are listed in the Phase 4e final report with their conflict regions.
+8. The dry-run path applies identical merge logic, writing results to `CACHE_DIR`.
+9. Single-feature mode (`SINGLE_MODE=true`) is entirely unaffected — no changes to that path.
+10. Changes are present in both `templates/commands/implement.md` and `.claude/commands/implement.md`.
+
+## Motivation
+
+VPC fit score: 75%. This directly addresses Alex's (Lead Dev) core pain point: parallel feature development is a key value proposition of the pipeline, and its current merge behavior is undefined. Without reliable merging, users with 3+ features cannot trust the pipeline output and must re-implement the merge themselves — defeating the purpose of the tool.
+
+The fix is scoped conservatively: Markdown-section-aware merging handles 90%+ of specrails' current file corpus. This is the right level of complexity for the pre-code phase.

--- a/openspec/changes/archive/2026-03-13-smart-merge-conflict-resolver/tasks.md
+++ b/openspec/changes/archive/2026-03-13-smart-merge-conflict-resolver/tasks.md
@@ -1,0 +1,352 @@
+---
+change: smart-merge-conflict-resolver
+type: tasks
+---
+
+# Tasks: Smart Merge Conflict Resolver
+
+Tasks are ordered by dependency. Each task has a layer tag, description, files involved, and acceptance criteria.
+
+---
+
+## Task 1 — Expand Phase 3a.1 in `templates/commands/implement.md` [templates]
+
+**Description:** Replace the current one-paragraph stub for Phase 3a.1 with the full shared file analysis algorithm. This is a surgical replacement of the existing stub content — do NOT restructure surrounding phases.
+
+**Files:**
+- Modify: `templates/commands/implement.md`
+
+**Current content to replace (the stub):**
+
+```markdown
+### 3a.1 Identify shared file conflicts
+
+Before launching developers, scan all tasks.md files to identify **shared files** that multiple features will modify.
+```
+
+**Replace with:**
+
+```markdown
+### 3a.1 Identify shared file conflicts
+
+**Only runs in multi-feature mode** (more than one feature). Skip entirely if `SINGLE_MODE=true`.
+
+After all architect agents complete, before launching any developer agent:
+
+#### Step 1: Extract file references
+
+For each `openspec/changes/<name>/tasks.md`, extract all paths listed under `**Files:**` entries (both `Create:` and `Modify:` lines). Normalize paths: strip leading `./`.
+
+#### Step 2: Build the shared-file registry
+
+Group file paths across all features. Any path appearing in two or more features' task lists is a **shared file**. Store as `SHARED_FILES` map: `{path: {features: [...], risk: ""}}`.
+
+#### Step 3: Classify risk
+
+For each shared file, classify risk based on file type and which regions each feature modifies (consult each feature's context-bundle.md "Exact Changes" section):
+
+| Risk | Condition |
+|------|-----------|
+| `low` | Both features only append new named sections not present in the other feature's changes |
+| `medium` | Both features modify structurally distinct regions (different `##` sections or different top-level YAML keys) |
+| `high` | Both features modify the same region (same `##` section, same YAML key subtree, or any region in shell scripts) |
+
+Shell scripts (`.sh`, `.bash`): always `high`.
+Non-existent files that two features both create: always `high`.
+
+#### Step 4: Derive MERGE_ORDER
+
+Sort features so that for any pair sharing a `high`-risk file, one appears before the other. Use topological sort; break ties alphabetically. Set `MERGE_ORDER` = sorted feature list.
+
+#### Step 5: Print pre-flight report
+
+```
+## Shared File Analysis
+
+| File | Features | Risk |
+|------|----------|------|
+| <path> | <feature-a>, <feature-b> | <risk> |
+
+Merge order: <feature-a> → <feature-b> → <feature-c>
+
+High-risk files detected. These files will be merged sequentially.
+Developers will still run in parallel — merge order applies at Phase 4a only.
+```
+
+If no shared files: print `No shared files detected. All features modify independent files.`
+```
+
+**Acceptance criteria:**
+- The stub is fully replaced; no "manually" or vague language remains in Phase 3a.1
+- The replacement text matches the above content exactly
+- `SINGLE_MODE=true` skip guard is present
+- Five steps (extract, registry, classify, MERGE_ORDER, report) are all present
+- Risk classification table is present with three rows
+- Pre-flight report format matches the above code block
+- No surrounding phases are modified
+- No `{{PLACEHOLDER}}` strings are broken by the edit
+
+**Dependencies:** None (can start immediately)
+
+---
+
+## Task 2 — Expand Phase 4a in `templates/commands/implement.md` [templates]
+
+**Description:** Replace the vague "merge shared files manually" instruction in Phase 4a with the concrete, ordered merge algorithm. This is a surgical replacement of Phase 4a's body — do NOT alter Phase 4b or surrounding content.
+
+**Files:**
+- Modify: `templates/commands/implement.md`
+
+**Current content to replace:**
+
+```markdown
+### 4a. Merge worktree changes to main repo
+
+- If `SINGLE_MODE`: skip (no worktrees were used).
+- If `DRY_RUN=true`: merge worktree outputs to `CACHE_DIR` instead of the main repo. Apply the same merge logic (copy feature-specific files, handle shared files) but destination is `CACHE_DIR/<file-path>`.
+- Otherwise: merge to main repo working tree as normal (copy feature-specific files, merge shared files manually, clean up worktrees).
+```
+
+**Replace with:**
+
+```markdown
+### 4a. Merge worktree changes to main repo
+
+- If `SINGLE_MODE`: skip (no worktrees were used). Proceed to Phase 4b.
+- If `DRY_RUN=true`: apply the merge algorithm below, writing all outputs to `CACHE_DIR/<file-path>` instead of the main repo working tree. Do NOT clean up worktrees in dry-run mode.
+- Otherwise: apply the merge algorithm below, writing outputs to the main repo working tree. Clean up worktrees at the end.
+
+#### Merge Algorithm
+
+Process features in `MERGE_ORDER` sequence. For each feature:
+
+**Step 1: Identify changed files**
+
+```bash
+git -C <worktree-path> diff main --name-only
+```
+
+Split into `exclusive_files` (only this feature modifies them) and `shared_files_for_this_feature` (also modified by another feature in MERGE_ORDER).
+
+**Step 2: Merge exclusive files**
+
+Copy directly from worktree to target:
+```bash
+cp <worktree-path>/<file> <target>/<file>
+```
+Log: `Copied (exclusive): <file>`
+
+**Step 3: Merge shared files**
+
+For each shared file, choose strategy by file type:
+
+**Strategy A — Markdown section-aware merge** (`.md` files):
+1. Read base: current content of `<target>/<file>`.
+2. Read incoming: `<worktree-path>/<file>`.
+3. Parse both into sections using `##` heading boundaries (heading line + all content until next `##` or EOF).
+4. Build section maps: `{heading_text: content}` for base and incoming.
+5. Merge:
+   - Section in base only: keep.
+   - Section in incoming only: append to merged output.
+   - Section in both, content identical: keep base.
+   - Section in both, content differs: insert conflict markers:
+     ```
+     <<<<<<< <feature-name>
+     <incoming section content>
+     =======
+     <base section content>
+     >>>>>>> base
+     ```
+     Log: `CONFLICT: <file> — section "<heading>" requires manual resolution.`
+6. Write merged result to `<target>/<file>`.
+
+**Strategy B — Unified diff sequential apply** (all other file types):
+1. Generate incoming diff against original `main`:
+   ```bash
+   git -C <worktree-path> diff main -- <file>
+   ```
+2. Apply to current target:
+   ```bash
+   patch --forward --fuzz=3 <target>/<file> < <diff>
+   ```
+3. If `patch` succeeds: log `Merged (diff-apply): <file>`.
+4. If `patch` fails: insert conflict markers around rejected hunks. Log: `CONFLICT: <file> — N hunks rejected.`
+
+If `patch` is not available (detected in Phase -1): use Strategy A for all file types and print: `[warn] patch not available — using section-aware fallback for all shared files.`
+
+**Step 4: Record outcomes**
+
+Maintain `MERGE_REPORT`:
+- `cleanly_merged`: exclusive files + shared files with no conflicts
+- `auto_resolved`: shared files merged without conflict markers
+- `requires_resolution`: `{file, feature, regions}` for files with conflict markers
+
+**Step 5: Emit merge report**
+
+After all features are processed:
+
+```
+## Phase 4a Merge Report
+
+### Cleanly Merged
+- <file> (exclusive to <feature>)
+
+### Auto-Resolved
+- <file> (features: <a>, <b> — distinct sections)
+
+### Requires Manual Resolution
+- <file> (features: <a>, <b> — conflicting section: "<heading>")
+  Search for `<<<<<<< <feature-name>` to locate conflict markers.
+
+Pipeline will continue. Fix conflicts above before the reviewer runs CI.
+```
+
+**Step 6: Clean up worktrees** (skip if `DRY_RUN=true`)
+
+```bash
+git worktree remove <worktree-path> --force
+```
+
+Pass `MERGE_REPORT` to the Phase 4b reviewer agent prompt, listing any files in `requires_resolution`.
+```
+
+**Acceptance criteria:**
+- Phase 4a body is fully replaced; no "manually" language remains
+- `SINGLE_MODE` skip guard is preserved
+- `DRY_RUN` path is preserved and uses `CACHE_DIR`
+- Six steps are all present (identify, exclusive, shared, record, report, cleanup)
+- Both Strategy A (Markdown) and Strategy B (diff/patch) are present with code blocks
+- `patch` fallback warning is present
+- Conflict marker format is exactly: `<<<<<<< <feature-name>` / `=======` / `>>>>>>> base`
+- Merge report format matches the code block above
+- `MERGE_REPORT` is passed to Phase 4b
+- No surrounding phases (4b, 4b-sec) are modified
+- No `{{PLACEHOLDER}}` strings are broken
+
+**Dependencies:** Task 1 (MERGE_ORDER must be defined before Phase 4a references it)
+
+---
+
+## Task 3 — Add conflicts to Phase 4e report in `templates/commands/implement.md` [templates]
+
+**Description:** The Phase 4e final pipeline report table currently has no column or row for merge conflicts. When Phase 4a detects files requiring manual resolution, the Phase 4e report must surface them. This is an additive change to the Phase 4e section.
+
+**Files:**
+- Modify: `templates/commands/implement.md`
+
+**Specific change:**
+
+In the Phase 4e "Otherwise" (non-dry-run) report section, after the pipeline status table, add:
+
+```markdown
+If `MERGE_REPORT.requires_resolution` is non-empty, print an additional section:
+
+```
+### Merge Conflicts Requiring Resolution
+
+| File | Features | Conflicting Region |
+|------|----------|-------------------|
+| <file> | <feature-a>, <feature-b> | <section heading or hunk description> |
+
+Fix these conflicts (search for `<<<<<<<` in each file), then commit the resolved files.
+```
+```
+
+**Acceptance criteria:**
+- The merge conflict table appears in the Phase 4e non-dry-run report section
+- The table is conditional on `MERGE_REPORT.requires_resolution` being non-empty
+- The table has three columns: File, Features, Conflicting Region
+- Instructions to search for `<<<<<<<` are present
+- No other Phase 4e content is modified (pipeline status table is unchanged)
+
+**Dependencies:** Task 2 (MERGE_REPORT is defined in Phase 4a)
+
+---
+
+## Task 4 — Apply same changes to `.claude/commands/implement.md` [cli]
+
+**Description:** Mirror all changes from Tasks 1, 2, and 3 into `.claude/commands/implement.md` (the specrails-adapted generated copy). The generated copy has all `{{PLACEHOLDER}}` strings resolved; apply the same logical content without reintroducing placeholders.
+
+**Files:**
+- Modify: `.claude/commands/implement.md`
+
+**Specific changes:**
+- Replace Phase 3a.1 stub with the expanded algorithm (same content as Task 1, no placeholder changes needed — Phase 3a.1 has no placeholders)
+- Replace Phase 4a body with the concrete merge algorithm (same content as Task 2, no placeholder changes needed — Phase 4a has no placeholders)
+- Add merge conflict table to Phase 4e (same content as Task 3)
+
+**Acceptance criteria:**
+- All three changes from Tasks 1–3 are present in `.claude/commands/implement.md`
+- No template placeholders (`{{...}}`) are introduced — this is a fully resolved file
+- Content is logically identical to the template changes (accounting for already-resolved placeholders)
+- Phase 3a.1 stub is gone; full algorithm is present
+- Phase 4a "manually" language is gone; concrete algorithm is present
+- Phase 4e conflict table is present
+
+**Dependencies:** Tasks 1, 2, 3 (establish the canonical content to mirror)
+
+---
+
+## Task 5 — Update `openspec/specs/implement.md` with Merge Behavior section [core]
+
+**Description:** Add a "Merge Behavior" normative section to `openspec/specs/implement.md`. This section documents the SHALL/MUST/SHOULD contracts for Phase 3a.1 and Phase 4a, and adds three new variables to the Variable Reference table. Follow the delta-spec.md exactly.
+
+**Files:**
+- Modify: `openspec/specs/implement.md`
+
+**Specific changes:**
+
+**Change 1 — Add "Merge Behavior" section** after the "Edge Cases" section (currently last):
+
+Insert the full "Merge Behavior" section from `delta-spec.md`. This section covers:
+- Shared File Analysis normative rules
+- Risk classification table
+- Merge Algorithm normative rules (exclusive files, Markdown strategy, diff/patch strategy)
+- Merge Report requirements
+- Dry-run compatibility requirements
+- Constraints (`SINGLE_MODE` bypass, no git ops, no nested conflict markers)
+
+**Change 2 — Extend the Variable Reference table** with three new rows:
+
+| Variable | Type | Set when | Description |
+|----------|------|----------|-------------|
+| `SHARED_FILES` | map | After Phase 3a.1, multi-feature only | Registry mapping file paths to `{features: [...], risk: "low"\|"medium"\|"high"}` |
+| `MERGE_ORDER` | list | After Phase 3a.1, multi-feature only | Ordered sequence of feature names for Phase 4a processing |
+| `MERGE_REPORT` | map | During Phase 4a, multi-feature only | Accumulates merge outcomes: `cleanly_merged`, `auto_resolved`, `requires_resolution` |
+
+**Acceptance criteria:**
+- "Merge Behavior" section exists after "Edge Cases" in `openspec/specs/implement.md`
+- Section uses SHALL/MUST/SHOULD normative language consistently
+- Risk classification table is present with three rows (low, medium, high)
+- All three algorithm descriptions are present (exclusive, Markdown, diff/patch)
+- Merge Report requirements are present
+- Dry-run compatibility is documented
+- `SINGLE_MODE` bypass constraint is documented
+- Three new rows added to Variable Reference table
+- Existing spec content is unchanged
+
+**Dependencies:** None (can run in parallel with Tasks 1–4)
+
+---
+
+## Execution Order
+
+```
+Task 1 (Phase 3a.1 in template)  ──┐
+                                    ├──> Task 4 (mirror to generated .claude/commands/)
+Task 2 (Phase 4a in template)    ──┤
+                                    │
+Task 3 (Phase 4e in template)    ──┘
+
+Task 5 (spec update)  — independent, runs in parallel
+```
+
+Tasks 1, 2, 3, and 5 can all start in parallel. Task 4 depends on Tasks 1, 2, and 3 (needs all template changes established first).
+
+### Minimum critical path
+
+Task 1 → Task 4 (longest path; Task 2 and 3 must also complete before Task 4)
+
+### Execution note
+
+The developer should apply Tasks 1, 2, and 3 to the template file in a single editing session to minimize re-reading the file. Task 4 can then copy the pattern directly from the already-modified template.

--- a/openspec/specs/implement.md
+++ b/openspec/specs/implement.md
@@ -115,6 +115,9 @@ Variables set during flag detection (Phase 0):
 | `APPLY_MODE` | boolean | `--apply` present | Activates apply-from-cache mode |
 | `APPLY_TARGET` | string | `APPLY_MODE=true` | Feature name argument following `--apply` |
 | `CACHE_DIR` | string | Either flag present | Absolute or relative path to the cache directory |
+| `SHARED_FILES` | map | After Phase 3a.1, multi-feature only | Registry mapping file paths to `{features: [...], risk: "low"\|"medium"\|"high"}` |
+| `MERGE_ORDER` | list | After Phase 3a.1, multi-feature only | Ordered sequence of feature names for Phase 4a processing |
+| `MERGE_REPORT` | map | During Phase 4a, multi-feature only | Accumulates merge outcomes: `cleanly_merged`, `auto_resolved`, `requires_resolution` |
 
 `CACHE_DIR` for `--dry-run` is finalized after the feature name is derived from the remaining input. All phases from 3a onward can reference it.
 
@@ -126,3 +129,54 @@ Variables set during flag detection (Phase 0):
 - **CI gap in dry-run**: The reviewer runs CI against the real repo (developer changes not yet applied). CI results may not reflect the final state. The reviewer prompt explicitly notes this caveat.
 - **Developer path discipline**: Dry-run correctness depends on the developer agent writing to the cache path. The developer prompt includes an explicit prohibition: "Do NOT write to real file paths."
 - **Apply after failure**: If `--apply` fails during Phase 4c, the cache is preserved so the user can retry without re-running the full pipeline.
+
+---
+
+## Merge Behavior
+
+### Shared File Analysis (Phase 3a.1)
+
+**When multi-feature mode is active** (more than one feature is being implemented), the pipeline SHALL run a shared file analysis before launching any developer agent.
+
+The analysis MUST:
+1. Extract all file paths listed in `**Files:**` entries within each feature's `tasks.md`.
+2. Identify paths that appear in two or more features' file lists as **shared files**.
+3. Classify each shared file with a risk level: `low`, `medium`, or `high`.
+4. Derive `MERGE_ORDER`: an ordered sequence of feature names such that features with `high`-risk shared files are processed sequentially.
+5. Print a pre-flight shared file report before developer agents launch.
+
+The analysis SHALL NOT block developer agent launch.
+
+**Risk Classification Rules:**
+
+| Risk | Condition |
+|------|-----------|
+| `low` | Both features append new, named sections that do not exist in the other feature's changes |
+| `medium` | Both features modify structurally distinct regions of the same file |
+| `high` | Both features modify overlapping regions; or the file is a shell script; or both features create the same net-new file |
+
+### Merge Algorithm (Phase 4a)
+
+**When multi-feature mode is active**, Phase 4a MUST process features in `MERGE_ORDER` sequence.
+
+**For exclusive files**: copy directly from worktree to merge target.
+
+**For shared Markdown files** (`.md`): apply section-aware merging using `##` heading boundaries. Non-overlapping sections are combined additively. Overlapping sections receive conflict markers (`<<<<<<< / ======= / >>>>>>>`).
+
+**For shared non-Markdown files**: apply unified diff sequential merging using `patch --forward --fuzz=3`. Failed hunks receive conflict markers.
+
+**If `patch` is unavailable**: fall back to section-aware merge for all file types with a warning.
+
+### Merge Report
+
+Phase 4a MUST emit a merge report listing: Cleanly Merged, Auto-Resolved, and Requires Manual Resolution. Files in "Requires Manual Resolution" MUST appear in the Phase 4e final report. The reviewer agent prompt MUST include the conflict file list.
+
+### Dry-Run Compatibility
+
+When `DRY_RUN=true`, Phase 4a MUST apply the identical merge algorithm writing to `CACHE_DIR`. Merge report MUST be written to `.cache-manifest.json` under `merge_report`. Worktrees SHALL NOT be cleaned up.
+
+### Constraints
+
+- `SINGLE_MODE=true` MUST bypass Phase 3a.1 and Phase 4a smart merge entirely.
+- The merge algorithm MUST NOT create git commits, branches, or pushes.
+- Pre-existing conflict markers in a file MUST NOT be nested with new conflict markers — log a warning instead.

--- a/templates/commands/implement.md
+++ b/templates/commands/implement.md
@@ -142,7 +142,51 @@ Each agent's prompt should include:
 
 ### 3a.1 Identify shared file conflicts
 
-Before launching developers, scan all tasks.md files to identify **shared files** that multiple features will modify.
+**Only runs in multi-feature mode** (more than one feature). Skip entirely if `SINGLE_MODE=true`.
+
+After all architect agents complete, before launching any developer agent:
+
+#### Step 1: Extract file references
+
+For each `openspec/changes/<name>/tasks.md`, extract all paths listed under `**Files:**` entries (both `Create:` and `Modify:` lines). Normalize paths: strip leading `./`.
+
+#### Step 2: Build the shared-file registry
+
+Group file paths across all features. Any path appearing in two or more features' task lists is a **shared file**. Store as `SHARED_FILES` map: `{path: {features: [...], risk: ""}}`.
+
+#### Step 3: Classify risk
+
+For each shared file, classify risk based on file type and which regions each feature modifies (consult each feature's context-bundle.md "Exact Changes" section):
+
+| Risk | Condition |
+|------|-----------|
+| `low` | Both features only append new named sections not present in the other feature's changes |
+| `medium` | Both features modify structurally distinct regions (different `##` sections or different top-level YAML keys) |
+| `high` | Both features modify the same region (same `##` section, same YAML key subtree, or any region in shell scripts) |
+
+Shell scripts (`.sh`, `.bash`): always `high`.
+Non-existent files that two features both create: always `high`.
+
+#### Step 4: Derive MERGE_ORDER
+
+Sort features so that for any pair sharing a `high`-risk file, one appears before the other. Use topological sort; break ties alphabetically. Set `MERGE_ORDER` = sorted feature list.
+
+#### Step 5: Print pre-flight report
+
+```
+## Shared File Analysis
+
+| File | Features | Risk |
+|------|----------|------|
+| <path> | <feature-a>, <feature-b> | <risk> |
+
+Merge order: <feature-a> → <feature-b> → <feature-c>
+
+High-risk files detected. These files will be merged sequentially.
+Developers will still run in parallel — merge order applies at Phase 4a only.
+```
+
+If no shared files: print `No shared files detected. All features modify independent files.`
 
 ### 3a.2 Pre-validate architect output
 
@@ -230,9 +274,102 @@ If a test-writer agent fails or times out:
 
 ### 4a. Merge worktree changes to main repo
 
-- If `SINGLE_MODE`: skip (no worktrees were used).
-- If `DRY_RUN=true`: merge worktree outputs to `CACHE_DIR` instead of the main repo. Apply the same merge logic (copy feature-specific files, handle shared files) but destination is `CACHE_DIR/<file-path>`.
-- Otherwise: merge to main repo working tree as normal (copy feature-specific files, merge shared files manually, clean up worktrees).
+- If `SINGLE_MODE`: skip (no worktrees were used). Proceed to Phase 4b.
+- If `DRY_RUN=true`: apply the merge algorithm below, writing all outputs to `CACHE_DIR/<file-path>` instead of the main repo working tree. Do NOT clean up worktrees in dry-run mode.
+- Otherwise: apply the merge algorithm below, writing outputs to the main repo working tree. Clean up worktrees at the end.
+
+#### Merge Algorithm
+
+Process features in `MERGE_ORDER` sequence. For each feature:
+
+**Step 1: Identify changed files**
+
+```bash
+git -C <worktree-path> diff main --name-only
+```
+
+Split into `exclusive_files` (only this feature modifies them) and `shared_files_for_this_feature` (also modified by another feature in MERGE_ORDER).
+
+**Step 2: Merge exclusive files**
+
+Copy directly from worktree to target:
+```bash
+cp <worktree-path>/<file> <target>/<file>
+```
+Log: `Copied (exclusive): <file>`
+
+**Step 3: Merge shared files**
+
+For each shared file, choose strategy by file type:
+
+**Strategy A — Markdown section-aware merge** (`.md` files):
+1. Read base: current content of `<target>/<file>`.
+2. Read incoming: `<worktree-path>/<file>`.
+3. Parse both into sections using `##` heading boundaries (heading line + all content until next `##` or EOF).
+4. Build section maps: `{heading_text: content}` for base and incoming.
+5. Merge:
+   - Section in base only: keep.
+   - Section in incoming only: append to merged output.
+   - Section in both, content identical: keep base.
+   - Section in both, content differs: insert conflict markers:
+     ```
+     <<<<<<< <feature-name>
+     <incoming section content>
+     =======
+     <base section content>
+     >>>>>>> base
+     ```
+     Log: `CONFLICT: <file> — section "<heading>" requires manual resolution.`
+6. Write merged result to `<target>/<file>`.
+
+**Strategy B — Unified diff sequential apply** (all other file types):
+1. Generate incoming diff against original `main`:
+   ```bash
+   git -C <worktree-path> diff main -- <file>
+   ```
+2. Apply to current target:
+   ```bash
+   patch --forward --fuzz=3 <target>/<file> < <diff>
+   ```
+3. If `patch` succeeds: log `Merged (diff-apply): <file>`.
+4. If `patch` fails: insert conflict markers around rejected hunks. Log: `CONFLICT: <file> — N hunks rejected.`
+
+If `patch` is not available (detected in Phase -1): use Strategy A for all file types and print: `[warn] patch not available — using section-aware fallback for all shared files.`
+
+**Step 4: Record outcomes**
+
+Maintain `MERGE_REPORT`:
+- `cleanly_merged`: exclusive files + shared files with no conflicts
+- `auto_resolved`: shared files merged without conflict markers
+- `requires_resolution`: `{file, feature, regions}` for files with conflict markers
+
+**Step 5: Emit merge report**
+
+After all features are processed:
+
+```
+## Phase 4a Merge Report
+
+### Cleanly Merged
+- <file> (exclusive to <feature>)
+
+### Auto-Resolved
+- <file> (features: <a>, <b> — distinct sections)
+
+### Requires Manual Resolution
+- <file> (features: <a>, <b> — conflicting section: "<heading>")
+  Search for `<<<<<<< <feature-name>` to locate conflict markers.
+
+Pipeline will continue. Fix conflicts above before the reviewer runs CI.
+```
+
+**Step 6: Clean up worktrees** (skip if `DRY_RUN=true`)
+
+```bash
+git worktree remove <worktree-path> --force
+```
+
+Pass `MERGE_REPORT` to the Phase 4b reviewer agent prompt, listing any files in `requires_resolution`.
 
 ### 4b. Launch Reviewer agent
 
@@ -412,6 +549,18 @@ rm -rf .claude/.dry-run/<feature-name>/
 ```
 | Area | Feature | Change Name | Architect | Developer | Tests | Reviewer | Security | CI | Status |
 |------|---------|-------------|-----------|-----------|-------|----------|----------|----|--------|
+```
+
+If `MERGE_REPORT.requires_resolution` is non-empty, print an additional section:
+
+```
+### Merge Conflicts Requiring Resolution
+
+| File | Features | Conflicting Region |
+|------|----------|-------------------|
+| <file> | <feature-a>, <feature-b> | <section heading or hunk description> |
+
+Fix these conflicts (search for `<<<<<<<` in each file), then commit the resolved files.
 ```
 
 Include the shipping mode in the report:


### PR DESCRIPTION
## Summary

- Replaces vague Phase 3a.1 stub with full shared-file analysis algorithm (extract references, build registry, classify risk, derive MERGE_ORDER, print pre-flight report)
- Replaces vague Phase 4a stub with concrete merge algorithm: Markdown section-aware merging (Strategy A) and unified diff/patch (Strategy B), with conflict markers and merge reporting
- Adds conditional merge conflict table to Phase 4e final report
- Updates `openspec/specs/implement.md` with normative "Merge Behavior" section and three new pipeline variables (SHARED_FILES, MERGE_ORDER, MERGE_REPORT)

Closes #3

## Changes

- `templates/commands/implement.md` — Phase 3a.1, 4a, 4e expanded
- `.claude/commands/implement.md` — Mirrored template changes
- `openspec/specs/implement.md` — Merge Behavior spec section + variable reference
- `openspec/changes/archive/2026-03-13-smart-merge-conflict-resolver/` — Archived OpenSpec change artifacts

## Test plan

- [ ] Verify Phase 3a.1 skips in SINGLE_MODE
- [ ] Verify Phase 4a handles DRY_RUN path correctly
- [ ] Run multi-feature `/implement` to exercise merge algorithm
- [ ] Verify conflict markers use `<<<<<<< <feature-name>` format
- [ ] Verify Phase 4e shows merge conflict table when conflicts exist
- [ ] Verify no `{{PLACEHOLDER}}` in generated `.claude/commands/implement.md`

---
Implemented via `/implement` pipeline (architect → developer → reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)