### PR TITLE
feat: add --root-dir param to install.sh for monorepos (#27)

### DIFF
--- a/.claude/agent-memory/reviewer/MEMORY.md
+++ b/.claude/agent-memory/reviewer/MEMORY.md
@@ -1,5 +1,4 @@
 # Reviewer Agent Memory
 
-## Index
-
-- [common-fixes.md](common-fixes.md) — Recurring CI failure patterns and fixes: placeholder grep false positives, template vs instance placeholder count, shellcheck availability
+## Reference
+- [common-fixes.md](common-fixes.md) — CI check false positives, variable quoting gotchas, install.sh patterns

--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,42 @@ CYAN='\033[0;36m'
 BOLD='\033[1m'
 NC='\033[0m'
 
+# ─────────────────────────────────────────────
+# Argument parsing
+# ─────────────────────────────────────────────
+
+CUSTOM_ROOT_DIR=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --root-dir)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --root-dir requires a path argument." >&2
+                exit 1
+            fi
+            CUSTOM_ROOT_DIR="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            echo "Usage: install.sh [--root-dir <path>]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Override REPO_ROOT if --root-dir was provided
+if [[ -n "$CUSTOM_ROOT_DIR" ]]; then
+    REPO_ROOT="$(cd "$CUSTOM_ROOT_DIR" 2>/dev/null && pwd)" || {
+        echo "Error: --root-dir path does not exist or is not accessible: $CUSTOM_ROOT_DIR" >&2
+        exit 1
+    }
+    if [[ ! -d "$REPO_ROOT" ]]; then
+        echo "Error: --root-dir path is not a directory: $CUSTOM_ROOT_DIR" >&2
+        exit 1
+    fi
+fi
+
 print_header() {
     echo ""
     echo -e "${BOLD}${CYAN}╔══════════════════════════════════════════════╗${NC}"
@@ -41,11 +77,16 @@ print_header
 step "Phase 1: Checking prerequisites"
 
 # 1.1 Git repository
-if [ -z "$REPO_ROOT" ]; then
-    fail "Not inside a git repository. Run this from your project's root."
+if [[ -z "$REPO_ROOT" ]]; then
+    fail "Not inside a git repository and no --root-dir provided."
+    echo "  Usage: install.sh [--root-dir <path>]"
     exit 1
 fi
-ok "Git repository: $REPO_ROOT"
+if [[ -n "$CUSTOM_ROOT_DIR" ]]; then
+    ok "Install root (--root-dir): $REPO_ROOT"
+else
+    ok "Git repository root: $REPO_ROOT"
+fi
 
 # 1.2 Claude Code CLI
 if command -v claude &> /dev/null; then

--- a/openspec/changes/archive/2026-03-13-install-root-dir-param/context-bundle.md
+++ b/openspec/changes/archive/2026-03-13-install-root-dir-param/context-bundle.md
@@ -1,0 +1,214 @@
+# Context Bundle: --root-dir parameter
+
+Self-contained implementation guide. A developer can execute this without reading any other
+artifact.
+
+---
+
+## What to change and where
+
+Single file: `install.sh`
+
+Three surgical edits, described in order from top to bottom.
+
+---
+
+## Edit 1 — Initialize CUSTOM_ROOT_DIR and parse arguments
+
+**Location**: after line 18 (`NC='\033[0m'`), before the `print_header` call on line 39.
+
+Insert this block:
+
+```bash
+# ─────────────────────────────────────────────
+# Argument parsing
+# ─────────────────────────────────────────────
+
+CUSTOM_ROOT_DIR=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --root-dir)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --root-dir requires a path argument." >&2
+                exit 1
+            fi
+            CUSTOM_ROOT_DIR="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            echo "Usage: install.sh [--root-dir <path>]" >&2
+            exit 1
+            ;;
+    esac
+done
+```
+
+---
+
+## Edit 2 — Override REPO_ROOT when --root-dir is provided
+
+**Location**: after line 9 (the existing `REPO_ROOT="$(git rev-parse ...)"` line).
+
+Replace:
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+```
+
+With:
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+
+if [[ -n "$CUSTOM_ROOT_DIR" ]]; then
+    REPO_ROOT="$(cd "$CUSTOM_ROOT_DIR" 2>/dev/null && pwd)" || {
+        echo "Error: --root-dir path does not exist or is not accessible: $CUSTOM_ROOT_DIR" >&2
+        exit 1
+    }
+    if [[ ! -d "$REPO_ROOT" ]]; then
+        echo "Error: --root-dir path is not a directory: $CUSTOM_ROOT_DIR" >&2
+        exit 1
+    fi
+fi
+```
+
+Note: Edit 1 must be applied first because `CUSTOM_ROOT_DIR` must be defined before the
+`REPO_ROOT` override block runs. However, since `REPO_ROOT` is set near the top of the
+file (line 9) and Edit 1 is inserted after line 18, the file will need Edit 1's block to
+be placed before the `print_header` call but after the color constants. The `REPO_ROOT`
+override should be placed immediately after the existing `REPO_ROOT` assignment on line 9
+as a second block — but since `CUSTOM_ROOT_DIR` is defined in the arg-parsing block which
+comes after line 9, we need to restructure slightly.
+
+### Correct final order in the file
+
+```
+line 1-8:   shebang, set -euo pipefail, script comment, SCRIPT_DIR
+line 9:     REPO_ROOT="$(git rev-parse ...)"         ← keep as-is
+lines 11-18: color constants
+             ← INSERT Edit 1 here (arg parsing block, sets CUSTOM_ROOT_DIR)
+             ← INSERT REPO_ROOT override block here (uses CUSTOM_ROOT_DIR)
+line 39+:   print_header, Phase 1, ...
+```
+
+So in practice, both the argument parsing and the REPO_ROOT override live together after
+the color constants, not after line 9. The `REPO_ROOT` initial assignment on line 9 stays
+where it is and serves as the default; the override block after the arg parser conditionally
+replaces it.
+
+The working sequence is:
+
+```bash
+# line 9 — default detection
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+
+# lines 11-18 — color constants (unchanged)
+RED='\033[0;31m'
+...
+NC='\033[0m'
+
+# ─────────────────────────────────────────────
+# Argument parsing
+# ─────────────────────────────────────────────
+
+CUSTOM_ROOT_DIR=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --root-dir)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --root-dir requires a path argument." >&2
+                exit 1
+            fi
+            CUSTOM_ROOT_DIR="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            echo "Usage: install.sh [--root-dir <path>]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Override REPO_ROOT if --root-dir was provided
+if [[ -n "$CUSTOM_ROOT_DIR" ]]; then
+    REPO_ROOT="$(cd "$CUSTOM_ROOT_DIR" 2>/dev/null && pwd)" || {
+        echo "Error: --root-dir path does not exist or is not accessible: $CUSTOM_ROOT_DIR" >&2
+        exit 1
+    }
+    if [[ ! -d "$REPO_ROOT" ]]; then
+        echo "Error: --root-dir path is not a directory: $CUSTOM_ROOT_DIR" >&2
+        exit 1
+    fi
+fi
+
+# print_header and Phase 1 follow...
+```
+
+---
+
+## Edit 3 — Update Phase 1 confirmation message
+
+**Location**: current line 48.
+
+Replace:
+```bash
+ok "Git repository: $REPO_ROOT"
+```
+
+With:
+```bash
+if [[ -n "$CUSTOM_ROOT_DIR" ]]; then
+    ok "Install root (--root-dir): $REPO_ROOT"
+else
+    ok "Git repository root: $REPO_ROOT"
+fi
+```
+
+---
+
+## Verification checklist
+
+Run these manually before committing (no CI exists):
+
+```bash
+# 1. shellcheck — must produce no new warnings
+shellcheck install.sh
+
+# 2. Default behavior unchanged
+./install.sh
+
+# 3. Valid relative path
+./install.sh --root-dir ./openspec
+
+# 4. Valid absolute path
+./install.sh --root-dir "$(pwd)/openspec"
+
+# 5. Non-existent path — expect: error message + exit 1
+./install.sh --root-dir /tmp/does-not-exist-xyz 2>&1; echo "exit: $?"
+
+# 6. Path is a file, not a directory — expect: error message + exit 1
+./install.sh --root-dir ./install.sh 2>&1; echo "exit: $?"
+
+# 7. --root-dir with no value — expect: error + exit 1
+./install.sh --root-dir 2>&1; echo "exit: $?"
+
+# 8. Unknown flag — expect: Unknown argument + usage + exit 1
+./install.sh --foo 2>&1; echo "exit: $?"
+```
+
+---
+
+## Key design decisions
+
+**Why `cd && pwd` instead of `realpath`**: `realpath` is not available on macOS without
+Homebrew. `cd && pwd` is POSIX-portable and has no dependencies.
+
+**Why parse args after color constants, not at line 1**: The arg-parsing block uses `echo`
+for errors (no color functions yet) which is fine. Placing it right before `print_header`
+groups all setup logic together and keeps the diff minimal.
+
+**Why allow paths outside the git repo**: Monorepos with git submodules or sparse checkouts
+may legitimately have project roots that are not subdirectories of the detected git root.
+Restricting to inside the git root would break these cases with no benefit.

--- a/openspec/changes/archive/2026-03-13-install-root-dir-param/delta-spec.md
+++ b/openspec/changes/archive/2026-03-13-install-root-dir-param/delta-spec.md
@@ -1,0 +1,47 @@
+# Delta Spec: --root-dir parameter
+
+## Affected spec area
+
+`install.sh` CLI interface — no existing formal spec file covers this. This delta is
+self-contained.
+
+## New behavior specification
+
+### CLI interface
+
+```
+install.sh [--root-dir <path>]
+```
+
+| Parameter | Type | Required | Default |
+|---|---|---|---|
+| `--root-dir` | path (relative or absolute) | No | git repo root |
+
+### Validation rules
+
+1. If `--root-dir` is given, the value must be a non-empty string.
+2. The path must be resolvable (exist and be accessible).
+3. The resolved path must be a directory.
+4. Any other unrecognized argument causes an error with a usage hint.
+
+### Error messages
+
+| Condition | Message | Exit code |
+|---|---|---|
+| `--root-dir` given with no value | `Error: --root-dir requires a path argument.` | 1 |
+| Path does not exist | `Error: --root-dir path does not exist or is not accessible: <value>` | 1 |
+| Path is not a directory | `Error: --root-dir path is not a directory: <value>` | 1 |
+| Unknown argument | `Unknown argument: <value>\nUsage: install.sh [--root-dir <path>]` | 1 |
+
+### Output change
+
+Phase 1 confirmation line changes based on source of root:
+
+- Default: `Git repository root: <path>`
+- Override: `Install root (--root-dir): <path>`
+
+### Invariants preserved
+
+- `REPO_ROOT` is always an absolute path when the script proceeds.
+- Default behavior (no `--root-dir`) is byte-for-byte equivalent to the current script.
+- The git repository check (empty `REPO_ROOT` guard) still runs before any file operations.

--- a/openspec/changes/archive/2026-03-13-install-root-dir-param/design.md
+++ b/openspec/changes/archive/2026-03-13-install-root-dir-param/design.md
@@ -1,0 +1,119 @@
+# Technical Design: --root-dir parameter
+
+## Current state
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+```
+
+`REPO_ROOT` is set once at the top of the script. All subsequent file operations
+(`mkdir -p "$REPO_ROOT/.claude/..."`, `cp ... "$REPO_ROOT/..."`, `cd "$REPO_ROOT"`) use
+this value unchanged.
+
+## Proposed change
+
+### Argument parsing block
+
+Insert an argument-parsing block immediately after the color constants and before
+`print_header`. Placing it before `print_header` keeps the header out of `--help`-style
+error messages but after it is also fine given the script structure — the chosen placement
+is just after the `NC` color constant definition for minimal diff.
+
+```bash
+# ─────────────────────────────────────────────
+# Argument parsing
+# ─────────────────────────────────────────────
+
+CUSTOM_ROOT_DIR=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --root-dir)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --root-dir requires a path argument." >&2
+                exit 1
+            fi
+            CUSTOM_ROOT_DIR="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            echo "Usage: install.sh [--root-dir <path>]" >&2
+            exit 1
+            ;;
+    esac
+done
+```
+
+### REPO_ROOT override
+
+Replace the current single-line `REPO_ROOT` assignment with a block that:
+1. Detects git root as before.
+2. If `--root-dir` was given, validates it and overrides `REPO_ROOT`.
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+
+if [[ -n "$CUSTOM_ROOT_DIR" ]]; then
+    # Resolve to absolute path
+    REPO_ROOT="$(cd "$CUSTOM_ROOT_DIR" 2>/dev/null && pwd)" || {
+        echo "Error: --root-dir path does not exist or is not accessible: $CUSTOM_ROOT_DIR" >&2
+        exit 1
+    }
+    if [[ ! -d "$REPO_ROOT" ]]; then
+        echo "Error: --root-dir path is not a directory: $CUSTOM_ROOT_DIR" >&2
+        exit 1
+    fi
+fi
+```
+
+The `cd ... && pwd` idiom is the POSIX-safe way to resolve a path to absolute form without
+requiring `realpath` (which is not available on macOS by default). The `-d` guard after the
+`cd` is technically redundant but provides a clear error message if the path resolves to a
+non-directory (e.g., a symlink to a file).
+
+### Output — Phase 1 git check
+
+The existing Phase 1 check at line 44 prints the effective `REPO_ROOT`:
+
+```bash
+ok "Git repository: $REPO_ROOT"
+```
+
+When `--root-dir` is used, this line should clarify the origin of the value. Change to:
+
+```bash
+if [[ -n "$CUSTOM_ROOT_DIR" ]]; then
+    ok "Install root (--root-dir): $REPO_ROOT"
+else
+    ok "Git repository root: $REPO_ROOT"
+fi
+```
+
+### No other changes needed
+
+All subsequent `$REPO_ROOT` references (`mkdir`, `cp`, `cd`, `ls`) work correctly once the
+variable is set to the right absolute path. No other lines need modification.
+
+## Edge cases
+
+| Scenario | Behavior |
+|---|---|
+| `--root-dir` not provided | Identical to current behavior |
+| Relative path (`./apps/backend`) | Resolved to absolute via `cd && pwd` |
+| Absolute path | Accepted as-is after `cd && pwd` normalization |
+| Path does not exist | Error message + exit 1 before `print_header` |
+| Path is a file, not a directory | Error message + exit 1 |
+| Empty `--root-dir` value (`--root-dir ""`) | Caught by `-z "${2:-}"` guard |
+| `--root-dir` with no argument at end of arg list | Caught by `-z "${2:-}"` guard |
+| Path outside git repo | Allowed — advanced monorepo/submodule use cases |
+| Unknown flags | Error + usage hint + exit 1 |
+
+## Why not `realpath`?
+
+`realpath` is part of GNU coreutils. On macOS it requires `brew install coreutils` or is
+absent entirely. The `cd && pwd` idiom works on all POSIX systems without dependencies.
+
+## Compatibility
+
+The change is fully backward-compatible. No existing call site of `install.sh` is affected.

--- a/openspec/changes/archive/2026-03-13-install-root-dir-param/proposal.md
+++ b/openspec/changes/archive/2026-03-13-install-root-dir-param/proposal.md
@@ -1,0 +1,30 @@
+# Proposal: --root-dir parameter for install.sh
+
+## Problem
+
+`install.sh` resolves `REPO_ROOT` by calling `git rev-parse --show-toplevel`, which always
+returns the root of the git repository. In a monorepo where multiple projects live as
+subdirectories of a single git repo, this causes specrails to install its artifacts at the
+wrong level — the git root instead of the target project directory.
+
+## Solution
+
+Add an optional `--root-dir <path>` CLI parameter to `install.sh`. When provided, it
+overrides the `git rev-parse`-derived `REPO_ROOT`. The value is validated (must exist, must
+be a directory) and resolved to an absolute path before use.
+
+Default behavior (no flag) is unchanged.
+
+## Scope
+
+- **File changed**: `install.sh` only.
+- **No template changes**: the templates and commands installed are already relative to
+  `REPO_ROOT`, so no downstream changes are needed.
+- **No spec changes to existing specs**: this is additive-only.
+
+## Non-goals
+
+- Supporting multiple `--root-dir` values in one invocation.
+- Changing what gets installed — only *where* it is installed changes.
+- Validating that the path is inside the git repo (out of scope; advanced monorepos may use
+  git submodules or worktrees where the project root legitimately diverges).

--- a/openspec/changes/archive/2026-03-13-install-root-dir-param/tasks.md
+++ b/openspec/changes/archive/2026-03-13-install-root-dir-param/tasks.md
@@ -1,0 +1,74 @@
+# Tasks: --root-dir parameter
+
+## T1 [core] Add argument-parsing block to install.sh
+
+**File**: `install.sh`
+
+**Description**: Insert a `while [[ $# -gt 0 ]]` argument-parsing loop immediately after
+the color constant definitions (after line 18, before `print_header`). The loop handles
+`--root-dir <path>` and rejects unknown arguments with a usage hint.
+
+**Acceptance criteria**:
+- `--root-dir ./some/path` sets `CUSTOM_ROOT_DIR="./some/path"`
+- `--root-dir` with no following argument prints an error to stderr and exits 1
+- An unrecognized flag prints `Unknown argument: <flag>` and the usage line to stderr, exits 1
+- No argument at all: loop body never executes, `CUSTOM_ROOT_DIR` remains `""`
+
+**Dependencies**: none
+
+---
+
+## T2 [core] Override REPO_ROOT when --root-dir is provided
+
+**File**: `install.sh`
+
+**Description**: After the existing `REPO_ROOT="$(git rev-parse ...)"` line (line 9), add
+a conditional block that — when `CUSTOM_ROOT_DIR` is non-empty — resolves the given path
+to absolute form using `cd "$CUSTOM_ROOT_DIR" && pwd` and assigns the result to `REPO_ROOT`.
+Exit 1 with a descriptive error if the path is unresolvable or not a directory.
+
+**Acceptance criteria**:
+- Relative path `./apps/backend` is resolved to its absolute form
+- Absolute path is accepted and normalized
+- Non-existent path exits 1 with message referencing the original value
+- Non-directory path exits 1 with message referencing the original value
+- When `CUSTOM_ROOT_DIR` is empty, this block is a no-op
+
+**Dependencies**: T1 (CUSTOM_ROOT_DIR variable must exist)
+
+---
+
+## T3 [core] Update Phase 1 confirmation message
+
+**File**: `install.sh`
+
+**Description**: Replace the single `ok "Git repository: $REPO_ROOT"` line (line 48) with
+a conditional that prints `Install root (--root-dir): $REPO_ROOT` when `--root-dir` was
+used, and `Git repository root: $REPO_ROOT` otherwise.
+
+**Acceptance criteria**:
+- Default invocation prints `Git repository root: <path>`
+- `--root-dir` invocation prints `Install root (--root-dir): <path>`
+
+**Dependencies**: T1, T2
+
+---
+
+## T4 [core] Manual verification
+
+**File**: `install.sh`
+
+**Description**: Manually test the following scenarios since there is no CI yet.
+
+Test matrix:
+1. `./install.sh` — default behavior unchanged, installs at git root
+2. `./install.sh --root-dir ./openspec` — valid relative path, installs into `openspec/`
+3. `./install.sh --root-dir /tmp/nonexistent` — exits 1 with path error
+4. `./install.sh --root-dir install.sh` — exits 1 with "not a directory" error
+5. `./install.sh --root-dir` (no value) — exits 1 with "requires a path argument" error
+6. `./install.sh --unknown-flag` — exits 1 with "Unknown argument" error
+7. `shellcheck install.sh` — no new warnings
+
+**Acceptance criteria**: All 7 test cases behave as described. `shellcheck` passes clean.
+
+**Dependencies**: T1, T2, T3


### PR DESCRIPTION
## Summary

- Adds optional `--root-dir <path>` parameter to `install.sh` that overrides the auto-detected `REPO_ROOT`
- Enables specrails installation into specific subdirectories in monorepo setups
- Uses portable `cd + pwd` for path resolution (no `realpath` dependency on macOS)
- Validates path exists and is a directory, with clear error messages to stderr

Closes #27

## Changes

- `install.sh` — argument parsing block, REPO_ROOT override, updated Phase 1 confirmation message

## Test plan

- [ ] `./install.sh` — default behavior unchanged (auto-detects git root)
- [ ] `./install.sh --root-dir ./openspec` — installs at specified subdirectory
- [ ] `./install.sh --root-dir /absolute/path` — works with absolute paths
- [ ] `./install.sh --root-dir /nonexistent` — exits with error
- [ ] `./install.sh --root-dir` (no value) — exits with error
- [ ] `./install.sh --unknown-flag` — exits with usage hint

---
Implemented via `/implement` pipeline (architect → developer → reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)