### PR TITLE
fix: prompt for target repo when installer runs from source

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -53,6 +53,34 @@ if [[ -n "$CUSTOM_ROOT_DIR" ]]; then
     fi
 fi
 
+# Detect if running from within the specrails source repo itself
+if [[ -z "$CUSTOM_ROOT_DIR" && -f "$SCRIPT_DIR/install.sh" && -d "$SCRIPT_DIR/templates" && "$SCRIPT_DIR" == "$REPO_ROOT"* ]]; then
+    # We're inside the specrails source — ask for target repo
+    echo ""
+    echo -e "${YELLOW}⚠${NC}  You're running the installer from inside the specrails source repo."
+    echo "   specrails installs into a ${BOLD}target${NC} repository, not into itself."
+    echo ""
+    read -p "   Enter the path to the target repo (or 'q' to quit): " TARGET_PATH
+    if [[ "$TARGET_PATH" == "q" || -z "$TARGET_PATH" ]]; then
+        echo "   Aborted. No changes made."
+        exit 0
+    fi
+    # Expand ~ and resolve path
+    TARGET_PATH="${TARGET_PATH/#\~/$HOME}"
+    REPO_ROOT="$(cd "$TARGET_PATH" 2>/dev/null && pwd)" || {
+        echo "Error: path does not exist or is not accessible: $TARGET_PATH" >&2
+        exit 1
+    }
+    if [[ ! -d "$REPO_ROOT/.git" ]]; then
+        echo -e "${YELLOW}⚠${NC}  Warning: $REPO_ROOT does not appear to be a git repository."
+        read -p "   Continue anyway? (y/n): " CONTINUE_NOGIT
+        if [[ "$CONTINUE_NOGIT" != "y" && "$CONTINUE_NOGIT" != "Y" ]]; then
+            echo "   Aborted. No changes made."
+            exit 0
+        fi
+    fi
+fi
+
 print_header() {
     echo ""
     echo -e "${BOLD}${CYAN}╔══════════════════════════════════════════════╗${NC}"


### PR DESCRIPTION
## Summary
- Detects when `./install.sh` is run from inside the specrails source repo
- Prompts the user for the target repository path instead of self-installing
- Validates the target is a git repo (warns if not, allows override)
- `--root-dir <path>` still bypasses the prompt as before

Closes #33

## Test plan
- [ ] Run `./install.sh` from specrails repo — should prompt for target path
- [ ] Run `./install.sh --root-dir ~/other-repo` — should skip prompt
- [ ] Enter invalid path — should show error
- [ ] Enter non-git directory — should warn and ask to continue
- [ ] Press 'q' or empty input — should abort cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)