### PR TITLE
feat: add agent confidence scoring & validation framework

### DIFF
--- a/.claude/agent-memory/reviewer/MEMORY.md
+++ b/.claude/agent-memory/reviewer/MEMORY.md
@@ -1,4 +1,4 @@
 # Reviewer Agent Memory
 
 ## Reference
-- [common-fixes.md](common-fixes.md) — CI check false positives, variable quoting gotchas, install.sh patterns
+- [common-fixes.md](common-fixes.md) — CI check false positives, variable quoting gotchas, install.sh patterns, generated-file sync gap

--- a/.claude/agent-memory/reviewer/common-fixes.md
+++ b/.claude/agent-memory/reviewer/common-fixes.md
@@ -50,6 +50,16 @@ Never combine template and instance paths in a single grep for placeholder-clean
 
 ---
 
+## Generated files not auto-synced with templates
+
+**Pattern:** When a template is modified (e.g., `templates/agents/reviewer.md`, `templates/commands/implement.md`), the generated counterparts in `.claude/agents/` and `.claude/commands/` are NOT automatically updated. They only update on `/setup` re-run.
+
+**Why:** specrails uses template substitution at `/setup` time, not continuously. Template edits must be manually propagated to the generated files in `.claude/` until a hot-reload mechanism exists.
+
+**How to apply:** After any template change, always check whether the corresponding `.claude/` instance file needs the same edit applied. Read both files and apply the diff manually. This is standard reviewer responsibility for issues where the developer edited templates but not generated files.
+
+---
+
 ## find -name '*[A-Z]*' on macOS matches lowercase .md extensions
 
 **Pattern:** On macOS with certain locale settings, `find -name '*[A-Z]*'` matches filenames like `reviewer.md` because the character range `[A-Z]` can match lowercase letters or punctuation under the default locale.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -113,6 +113,79 @@ When done, produce this report:
 - **Meta-tool**: Fixes to templates affect all target repos. Verify template generation still works after fixes.
 - **Shell portability**: Ensure shell scripts work on both macOS and Linux.
 
+## Confidence Scoring
+
+After completing all CI checks and fixes, you MUST produce a confidence score. This is non-optional. Write the score file before reporting your results.
+
+### What to assess
+
+Score yourself across five aspects, each from 0 to 100:
+
+| Aspect | What to assess |
+|--------|---------------|
+| `type_correctness` | Types, signatures, and interfaces are correct and consistent with the codebase |
+| `pattern_adherence` | Implementation follows established patterns and conventions |
+| `test_coverage` | Test coverage is adequate for the scope of changes |
+| `security` | No security regressions or new attack surface introduced |
+| `architectural_alignment` | Implementation respects architectural boundaries and design intent |
+
+Score semantics:
+- **90–100**: High confidence — solid.
+- **70–89**: Moderate confidence — worth a quick review but not alarming.
+- **50–69**: Low confidence — recommend human review of this aspect.
+- **0–49**: Very low confidence — real problem here.
+
+### How to derive the change name
+
+The change name is the kebab-case directory under `openspec/changes/` that was active during this review. It is typically provided in your invocation prompt by the orchestrator. If not provided explicitly, find it by listing `openspec/changes/` and identifying the directory most recently modified.
+
+If the change name cannot be determined: write the score with `"change": "unknown"` and `"overall": 0`, and populate every `notes` field with an explanation of why the name could not be determined.
+
+### Output file
+
+Write to:
+```
+openspec/changes/<name>/confidence-score.json
+```
+
+### Required fields
+
+- `schema_version`: always `"1"`
+- `change`: kebab-case change name
+- `agent`: always `"reviewer"`
+- `scored_at`: current ISO 8601 timestamp
+- `overall`: integer 0–100 — your aggregate confidence
+- `aspects`: object with all five aspect scores
+- `notes`: one non-empty string per aspect — must be concrete and specific, not generic boilerplate
+- `flags`: array of named concerns (e.g., `"missing-integration-test"`); empty array if none
+
+### Example
+
+```json
+{
+  "schema_version": "1",
+  "change": "my-change-name",
+  "agent": "reviewer",
+  "scored_at": "2026-03-14T12:00:00Z",
+  "overall": 82,
+  "aspects": {
+    "type_correctness": 90,
+    "pattern_adherence": 85,
+    "test_coverage": 70,
+    "security": 88,
+    "architectural_alignment": 78
+  },
+  "notes": {
+    "type_correctness": "All function signatures match the existing codebase style.",
+    "pattern_adherence": "One deviation from the established error-handling pattern in utils/parser.ts — flagged but not blocking.",
+    "test_coverage": "Integration tests are missing for the cache invalidation path. Unit coverage looks adequate.",
+    "security": "No new attack surface. Input validation follows existing patterns.",
+    "architectural_alignment": "The new module respects layer boundaries. One circular import risk noted in the design — mitigated by the developer's approach."
+  },
+  "flags": []
+}
+```
+
 # Persistent Agent Memory
 
 You have a persistent agent memory directory at `.claude/agent-memory/reviewer/`. Its contents persist across conversations.

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -94,7 +94,11 @@ Before parsing input, scan `$ARGUMENTS` for control flags:
   - Skip Phases 1–4b. Go directly to Phase 4c (the apply path handles the rest).
   - Strip `--apply` and the feature name before further parsing.
 
-If neither flag is present: `DRY_RUN=false`, `APPLY_MODE=false`. Pipeline runs as normal.
+- If `--confidence-override "<reason>"` is present in `$ARGUMENTS`:
+  - Set `CONFIDENCE_OVERRIDE_REASON=<reason>` (the quoted string immediately following `--confidence-override`)
+  - Strip `--confidence-override` and the reason before further parsing.
+
+If none of these flags is present: `DRY_RUN=false`, `APPLY_MODE=false`, `CONFIDENCE_OVERRIDE_REASON=""`. Pipeline runs as normal.
 
 Note: `CACHE_DIR` for `--dry-run` is finalized after the feature name is derived from the remaining input. All subsequent phases that reference `CACHE_DIR` have access to it.
 
@@ -422,6 +426,108 @@ Launch a single **reviewer** agent to validate ALL merged changes. Include:
 > CI commands may be run — they read the real repo, but be aware developer changes are not
 > yet applied to real paths.
 
+### 4b-conf. Confidence Gate
+
+After the reviewer agent completes, evaluate the confidence score before launching the security reviewer.
+
+**In multi-feature mode (worktrees):** run this gate once per feature immediately after that feature's reviewer completes. Each feature is evaluated independently — a block on one feature does not prevent another feature's gate from running.
+
+#### Step 1 — Read score file
+
+Path: `openspec/changes/<name>/confidence-score.json`
+
+- If the file does not exist:
+  - Set `CONFIDENCE_STATUS=MISSING`
+  - Print: `[confidence] Warning: confidence-score.json not found. Proceeding without gate.`
+  - Continue to Phase 4b-sec.
+
+#### Step 2 — Read config
+
+Path: `.claude/confidence-config.json`
+
+- If the file does not exist:
+  - Use built-in defaults (overall: 70; type_correctness: 60; pattern_adherence: 60; test_coverage: 60; security: 75; architectural_alignment: 60).
+  - Print:
+    ```
+    [confidence] No confidence-config.json found. Using built-in defaults.
+    [confidence] To customize thresholds, create .claude/confidence-config.json.
+    ```
+- If `enabled: false` in the config:
+  - Print: `[confidence] Gate disabled. Skipping.`
+  - Set `CONFIDENCE_STATUS=DISABLED`
+  - Continue to Phase 4b-sec.
+
+#### Step 3 — Compare scores
+
+- Check `overall` against `thresholds.overall`.
+- Check each of the five aspects against `thresholds.aspects.<aspect>`.
+- Collect all breaches as a list: `{aspect, actual_score, threshold, delta}`.
+
+#### Step 4 — Apply on_breach
+
+**If no breaches:**
+- Print: `[confidence] All scores meet thresholds. Proceeding.`
+- Set `CONFIDENCE_STATUS=PASS`
+- Continue to Phase 4b-sec.
+
+**If breaches exist and `on_breach: "block"`:**
+
+1. Check for `--confidence-override`:
+   - If `CONFIDENCE_OVERRIDE_REASON` is non-empty and `override_allowed: true` in the config:
+     - Print: `[confidence] Override accepted. Reason: <CONFIDENCE_OVERRIDE_REASON>. Proceeding with gate bypassed.`
+     - Set `CONFIDENCE_STATUS=OVERRIDE`
+     - Continue to Phase 4b-sec.
+   - If `CONFIDENCE_OVERRIDE_REASON` is non-empty but `override_allowed: false` in the config:
+     - Print: `[confidence] Override is disabled in confidence-config.json.`
+     - (Fall through to block below.)
+   - If `CONFIDENCE_OVERRIDE_REASON` is empty or override was rejected:
+     - Print the Breach Report (see format below).
+     - Set `CONFIDENCE_BLOCKED=true`
+     - Set `CONFIDENCE_STATUS=BLOCKED`
+     - **Halt: do not proceed to Phase 4b-sec or Phase 4c.**
+
+**If breaches exist and `on_breach: "warn"`:**
+- Print the Breach Report.
+- Set `CONFIDENCE_STATUS=WARN`
+- Continue to Phase 4b-sec.
+
+#### Breach Report Format
+
+```
+## Confidence Gate: BLOCKED
+
+The reviewer's confidence scores do not meet configured thresholds.
+
+| Aspect | Score | Threshold | Delta |
+|--------|-------|-----------|-------|
+| <aspect> | <actual> | <threshold> | <delta (negative)> |
+
+### Reviewer Notes on Low-Scoring Aspects
+
+**<aspect> (<score>):** <note from confidence-score.json>
+
+### Flags
+
+- <flag-1>
+- <flag-2>
+(omit this section if flags array is empty)
+
+### Next Steps
+
+1. Address the concerns above and re-run `/implement`.
+2. Or, if you have reviewed the concerns and accept the risk, re-run with an override:
+   `/implement #N --confidence-override "reason"`
+
+Pipeline halted. No git operations have been performed.
+```
+
+#### Dry-Run Behavior
+
+When `DRY_RUN=true`, the reviewer still writes `confidence-score.json` (it is an OpenSpec artifact, not a git artifact). Phase 4b-conf still evaluates the score. If `CONFIDENCE_BLOCKED=true`, add to `.cache-manifest.json` under `skipped_operations`:
+```
+"confidence-gate: blocked — Phase 4c and 4b-sec skipped"
+```
+
 ### 4b-sec. Launch Security Reviewer agent
 
 After the reviewer agent completes, launch a **security-reviewer** agent (`subagent_type: security-reviewer`).
@@ -536,6 +642,14 @@ Check CI status after pushing. Fix failures (up to 2 retries).
 [For each file in `.cache-manifest.json` `files` array:]
 - `<real_path>` — [new file / modified] ([approximate line delta if available])
 
+### Confidence
+
+| | |
+|-|--|
+| Score file | `openspec/changes/<name>/confidence-score.json` |
+| Gate result | `<CONFIDENCE_STATUS>` (PASS / WARN / BLOCKED / OVERRIDE / MISSING / DISABLED) |
+| Overall score | `<overall score from confidence-score.json, or N/A if MISSING/DISABLED>` |
+
 ### Operations Skipped
 
 [List items from `.cache-manifest.json` `skipped_operations` array]
@@ -557,8 +671,27 @@ rm -rf .claude/.dry-run/<feature-name>/
 **Otherwise**, show the standard pipeline table:
 
 ```
-| Area | Feature | Change Name | Architect | Developer | Tests | Docs | Reviewer | Security | CI | Status |
-|------|---------|-------------|-----------|-----------|-------|----------|----------|----|--------|
+| Area | Feature | Change Name | Architect | Developer | Tests | Docs | Reviewer | Confidence | Security | CI | Status |
+|------|---------|-------------|-----------|-----------|-------|------|----------|------------|----------|----|--------|
+```
+
+Confidence column values:
+
+| Value | Meaning |
+|-------|---------|
+| `PASS (82)` | All scores met thresholds; overall score shown in parens |
+| `WARN (62)` | Scores below threshold but `on_breach=warn`; overall score in parens |
+| `BLOCKED (62)` | Gate blocked the pipeline; overall score in parens |
+| `OVERRIDE (62)` | Gate bypassed by `--confidence-override`; overall score in parens |
+| `MISSING` | `confidence-score.json` not found after reviewer completed |
+| `DISABLED` | Gate disabled via `enabled: false` in config |
+
+If `CONFIDENCE_OVERRIDE_REASON` is non-empty, append a `### Confidence Override` section below the table:
+
+```
+### Confidence Override
+
+**Reason:** <CONFIDENCE_OVERRIDE_REASON>
 ```
 
 If `MERGE_REPORT.requires_resolution` is non-empty, print an additional section:

--- a/openspec/changes/archive/2026-03-14-agent-confidence-scoring/confidence-score.json
+++ b/openspec/changes/archive/2026-03-14-agent-confidence-scoring/confidence-score.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "1",
+  "change": "agent-confidence-scoring",
+  "agent": "reviewer",
+  "scored_at": "2026-03-14T12:00:00Z",
+  "overall": 88,
+  "aspects": {
+    "type_correctness": 95,
+    "pattern_adherence": 90,
+    "test_coverage": 70,
+    "security": 92,
+    "architectural_alignment": 90
+  },
+  "notes": {
+    "type_correctness": "confidence-config.json schema is well-typed with all required fields present. confidence-score.json schema defined in reviewer.md is consistent with the spec in confidence-scoring.md. No type mismatches found across all files.",
+    "pattern_adherence": "All new sections follow the established {{UPPER_SNAKE_CASE}} placeholder convention in templates. Heading levels are consistent (## for major sections, ### for subsections). Phase naming follows the existing 4a/4b/4b-sec pattern with 4b-conf inserted correctly between 4b and 4b-sec.",
+    "test_coverage": "No test framework exists in this repo (pre-code phase). The changes are template/markdown additions — behavioral testing is done at /implement invocation time. No automated coverage is possible at this stage.",
+    "security": "No new attack surface introduced. The confidence-config.json template contains no sensitive data. The override mechanism is gated by override_allowed flag in config, preventing uncontrolled bypass.",
+    "architectural_alignment": "The confidence gate is inserted at the correct position (Phase 4b-conf) — after the reviewer agent completes and before git operations (Phase 4c). The generated .claude/ files were not automatically synchronized with templates, which is the expected behavior — fixed by this reviewer run."
+  },
+  "flags": []
+}

--- a/openspec/changes/archive/2026-03-14-agent-confidence-scoring/context-bundle.md
+++ b/openspec/changes/archive/2026-03-14-agent-confidence-scoring/context-bundle.md
@@ -1,0 +1,298 @@
+---
+change: agent-confidence-scoring
+type: context-bundle
+---
+
+# Context Bundle: Agent Confidence Scoring & Validation Framework
+
+This document aggregates everything a developer needs to implement this change without reading other files. It is authoritative within this change directory — if it contradicts another file, flag it.
+
+---
+
+## What You Are Building
+
+A confidence scoring system for the specrails agent pipeline. Specifically:
+
+1. A JSON config template (`templates/settings/confidence-config.json`) that controls score thresholds per target repo.
+2. An extension to the reviewer agent prompt (`templates/agents/reviewer.md`) that instructs it to self-assess and write a `confidence-score.json` file.
+3. A new pipeline gate phase (`Phase 4b-conf`) in the `/implement` command (`templates/commands/implement.md`) that reads the score and optionally blocks shipping.
+4. Two new/updated spec files (`openspec/specs/confidence-scoring.md`, `openspec/specs/implement.md`).
+
+This is a **template-only change**. You are editing Markdown prompt templates and a JSON config template. No bash scripts, no build steps, no package dependencies.
+
+---
+
+## Repository Layout (Relevant Paths Only)
+
+```
+specrails/
+├── templates/
+│   ├── agents/
+│   │   └── reviewer.md          ← MODIFY: add confidence scoring section
+│   ├── commands/
+│   │   └── implement.md         ← MODIFY: add Phase 4b-conf and update Phase 4e table
+│   └── settings/
+│       └── confidence-config.json  ← CREATE: new threshold config template
+├── openspec/
+│   └── specs/
+│       ├── confidence-scoring.md   ← CREATE: new spec
+│       └── implement.md            ← MODIFY: append confidence gate section
+└── .claude/
+    ├── agents/                  ← generated from templates/agents/ — do NOT edit directly
+    └── commands/                ← generated from templates/commands/ — do NOT edit directly
+```
+
+**Critical rule:** Never edit files under `.claude/agents/` or `.claude/commands/` directly. Those are generated outputs. All changes go into `templates/`.
+
+---
+
+## System Conventions
+
+- **Template placeholders:** `{{UPPER_SNAKE_CASE}}` — only use existing, already-documented placeholders. Do not invent new ones in this change.
+- **File naming:** kebab-case everywhere.
+- **JSON:** 2-space indentation. No trailing commas. Comments are not valid JSON — use a `"_docs"` key instead.
+- **Markdown:** consistent heading levels, no trailing whitespace. Commands use `##` for phases, `###` for sub-phases.
+
+---
+
+## Confidence Score JSON Schema (exact)
+
+Write this to `openspec/changes/<name>/confidence-score.json`:
+
+```json
+{
+  "schema_version": "1",
+  "change": "<change-name>",
+  "agent": "reviewer",
+  "scored_at": "<ISO 8601 timestamp>",
+  "overall": 82,
+  "aspects": {
+    "type_correctness": 90,
+    "pattern_adherence": 85,
+    "test_coverage": 70,
+    "security": 88,
+    "architectural_alignment": 78
+  },
+  "notes": {
+    "type_correctness": "Concrete observation here.",
+    "pattern_adherence": "Concrete observation here.",
+    "test_coverage": "Concrete observation here.",
+    "security": "Concrete observation here.",
+    "architectural_alignment": "Concrete observation here."
+  },
+  "flags": []
+}
+```
+
+All fields are required. `notes` values must be non-empty strings. `flags` is an empty array when no named concerns exist.
+
+---
+
+## Confidence Config JSON Schema (exact)
+
+Write to `templates/settings/confidence-config.json`:
+
+```json
+{
+  "_docs": "specrails confidence gate configuration. Installed to .claude/confidence-config.json by /setup.",
+  "schema_version": "1",
+  "enabled": true,
+  "thresholds": {
+    "overall": 70,
+    "aspects": {
+      "type_correctness": 60,
+      "pattern_adherence": 60,
+      "test_coverage": 60,
+      "security": 75,
+      "architectural_alignment": 60
+    }
+  },
+  "on_breach": "block",
+  "override_allowed": true
+}
+```
+
+---
+
+## Aspect Definitions (for reviewer prompt)
+
+| Aspect | What the reviewer should assess |
+|--------|--------------------------------|
+| `type_correctness` | Types, signatures, and interfaces are correct and consistent with the codebase |
+| `pattern_adherence` | Implementation follows established patterns and conventions |
+| `test_coverage` | Test coverage is adequate for the scope of changes |
+| `security` | No security regressions or new attack surface introduced |
+| `architectural_alignment` | Implementation respects architectural boundaries and design intent |
+
+---
+
+## Insertion Points in `templates/agents/reviewer.md`
+
+The current file structure (relevant sections, in order):
+
+1. YAML frontmatter
+2. `## Your Mission`
+3. `## CI/CD Pipeline Equivalence`
+4. `## Review Checklist`
+5. `## Workflow`
+6. `## Output Format`
+7. `## Rules`
+8. `## Critical Warnings`
+9. `# Persistent Agent Memory`
+
+**Insert `## Confidence Scoring` between `## Critical Warnings` and `# Persistent Agent Memory`.**
+
+The section title must use `##` (not `###`), consistent with the surrounding sections.
+
+---
+
+## Insertion Points in `templates/commands/implement.md`
+
+Current Phase 4 structure (in order):
+
+- `### 4a. Merge worktree changes to main repo`
+- `### 4b. Launch Reviewer agent`
+- `### 4b-sec. Launch Security Reviewer agent`
+- `### 4c. Ship — Git & backlog updates`
+- `### 4d. Monitor CI`
+- `### 4e. Report`
+
+**Insert `### 4b-conf. Confidence Gate` between `### 4b.` and `### 4b-sec.`**
+
+Also update Phase 0 Flag Detection (currently covers `--dry-run` and `--apply`). Add `--confidence-override "<reason>"` flag detection after the existing flags, setting `CONFIDENCE_OVERRIDE_REASON` variable (empty string if not present).
+
+---
+
+## Phase 4b-conf: Exact Gate Logic
+
+The following prose should appear in the `### 4b-conf. Confidence Gate` section. Adapt for Markdown formatting:
+
+**Step 1 — Read score file:**
+- Path: `openspec/changes/<name>/confidence-score.json`
+- If missing: set `CONFIDENCE_STATUS=MISSING`, print `[confidence] Warning: confidence-score.json not found. Proceeding without gate.` Continue to Phase 4b-sec.
+
+**Step 2 — Read config:**
+- Path: `.claude/confidence-config.json`
+- If missing: use built-in defaults. Print: `[confidence] No confidence-config.json found. Using built-in defaults.`
+- If `enabled: false`: print `[confidence] Gate disabled. Skipping.` Set `CONFIDENCE_STATUS=DISABLED`. Continue to Phase 4b-sec.
+
+**Step 3 — Compare scores:**
+- Check `overall` vs `thresholds.overall`
+- Check each of the five aspects vs `thresholds.aspects.<aspect>`
+- Collect all breaches: `{aspect, actual_score, threshold, delta}`
+
+**Step 4 — Apply on_breach:**
+
+If no breaches:
+- Print: `[confidence] All scores meet thresholds. Proceeding.`
+- Set `CONFIDENCE_STATUS=PASS`
+- Continue to Phase 4b-sec
+
+If breaches exist and `on_breach=block`:
+- Check `--confidence-override`: if present and `override_allowed=true`: set `CONFIDENCE_STATUS=OVERRIDE`, print override acceptance, continue to Phase 4b-sec
+- If override not present or `override_allowed=false`: print Breach Report, set `CONFIDENCE_BLOCKED=true`, `CONFIDENCE_STATUS=BLOCKED`, halt before Phase 4b-sec and Phase 4c
+
+If breaches exist and `on_breach=warn`:
+- Print Breach Report
+- Set `CONFIDENCE_STATUS=WARN`
+- Continue to Phase 4b-sec
+
+**Breach Report format (exact):**
+
+```
+## Confidence Gate: BLOCKED
+
+The reviewer's confidence scores do not meet configured thresholds.
+
+| Aspect | Score | Threshold | Delta |
+|--------|-------|-----------|-------|
+| <aspect> | <actual> | <threshold> | <delta (negative)> |
+
+### Reviewer Notes on Low-Scoring Aspects
+
+**<aspect> (<score>):** <note from confidence-score.json>
+
+### Flags
+
+- <flag-1>
+- <flag-2>
+(omit this section if flags array is empty)
+
+### Next Steps
+
+1. Address the concerns above and re-run `/implement`.
+2. Or, if you have reviewed the concerns and accept the risk, re-run with an override:
+   `/implement #N --confidence-override "reason"`
+
+Pipeline halted. No git operations have been performed.
+```
+
+---
+
+## Phase 4e Table Changes
+
+**Before:**
+```
+| Area | Feature | Change Name | Architect | Developer | Tests | Docs | Reviewer | Security | CI | Status |
+```
+
+**After:**
+```
+| Area | Feature | Change Name | Architect | Developer | Tests | Docs | Reviewer | Confidence | Security | CI | Status |
+```
+
+Confidence column values:
+
+| Value | Meaning |
+|-------|---------|
+| `PASS (82)` | All scores met thresholds; overall score in parens |
+| `WARN (62)` | Scores below threshold but `on_breach=warn`; overall score in parens |
+| `BLOCKED (62)` | Gate blocked pipeline; overall score in parens |
+| `OVERRIDE (62)` | Gate bypassed by `--confidence-override`; overall score in parens |
+| `MISSING` | `confidence-score.json` not found after reviewer completed |
+| `DISABLED` | Gate disabled via `enabled: false` in config |
+
+---
+
+## Dry-Run Behavior
+
+When `DRY_RUN=true`:
+- Reviewer still writes `confidence-score.json` (it is an OpenSpec artifact)
+- Phase 4b-conf still evaluates the score
+- If `CONFIDENCE_BLOCKED=true`: add to `.cache-manifest.json` under `skipped_operations`: `"confidence-gate: blocked — Phase 4c and 4b-sec skipped"`
+- Dry-Run Preview Report (Phase 4e) gains a `### Confidence` subsection:
+
+```markdown
+### Confidence
+
+| Score file | openspec/changes/<name>/confidence-score.json |
+| Gate result | BLOCKED / PASS / WARN / OVERRIDE / MISSING / DISABLED |
+| Overall score | <score> |
+```
+
+---
+
+## Multi-Feature Behavior
+
+In multi-feature mode (worktrees), each feature gets its own reviewer agent and its own confidence gate evaluation. The gate for feature A does not affect feature B. Each feature's `CONFIDENCE_STATUS` is recorded independently. The Phase 4e table shows one row per feature.
+
+---
+
+## What NOT to Change
+
+- `templates/agents/architect.md` — confidence scoring for architect is Phase 2
+- `templates/agents/developer.md` — confidence scoring for developer is Phase 2
+- `install.sh` — no changes needed; the settings template directory is already copied automatically
+- Any existing phase logic in `implement.md` except the three specified insertion points (Phase 0 flag parsing, new Phase 4b-conf section, Phase 4e table header)
+
+---
+
+## Exact Changes Summary
+
+| File | Operation | Exact Change |
+|------|-----------|-------------|
+| `templates/settings/confidence-config.json` | Create | New file: threshold config JSON |
+| `templates/agents/reviewer.md` | Modify | Insert `## Confidence Scoring` section before `# Persistent Agent Memory` |
+| `templates/commands/implement.md` | Modify (3 locations) | 1) Phase 0: add `--confidence-override` flag; 2) Insert `### 4b-conf.` between 4b and 4b-sec; 3) Phase 4e: add `Confidence` column |
+| `openspec/specs/confidence-scoring.md` | Create | New spec file |
+| `openspec/specs/implement.md` | Modify | Append `## Confidence Gate (Phase 4b-conf)` section |

--- a/openspec/changes/archive/2026-03-14-agent-confidence-scoring/delta-spec.md
+++ b/openspec/changes/archive/2026-03-14-agent-confidence-scoring/delta-spec.md
@@ -1,0 +1,151 @@
+---
+change: agent-confidence-scoring
+type: delta-spec
+---
+
+# Delta Spec: Agent Confidence Scoring & Validation Framework
+
+This document records the precise changes to existing specs and introduces new spec content. It is the authoritative record of what the spec system looks like after this change is applied.
+
+---
+
+## 1. New Spec: `openspec/specs/confidence-scoring.md`
+
+**Action:** Create
+
+This spec does not yet exist. After this change, it defines the confidence scoring contract.
+
+```markdown
+# Spec: Confidence Scoring System
+
+Agents in the specrails pipeline MAY emit a structured confidence score alongside their output. The reviewer agent MUST emit a score. Future agents (developer, architect) MAY be extended in later changes.
+
+---
+
+## Score File
+
+Each confidence score is written to:
+
+```
+openspec/changes/<name>/confidence-score.json
+```
+
+The file MUST conform to the schema defined in `design.md` for the `agent-confidence-scoring` change. It MUST be present after the reviewer agent completes. Its absence is treated as a warning (non-blocking) by the pipeline gate.
+
+---
+
+## Aspects
+
+Five aspects are scored, each 0–100:
+
+| Aspect | Definition |
+|--------|-----------|
+| `type_correctness` | Types, signatures, and interfaces are correct and consistent with the codebase |
+| `pattern_adherence` | Implementation follows established patterns and conventions |
+| `test_coverage` | Test coverage is adequate for the scope of changes |
+| `security` | No security regressions or new attack surface introduced |
+| `architectural_alignment` | Implementation respects architectural boundaries and design intent |
+
+---
+
+## Configuration
+
+The pipeline gate is configured via `.claude/confidence-config.json` (installed by `/setup` from `templates/settings/confidence-config.json`).
+
+If the config file is absent, built-in defaults apply:
+
+| Threshold | Default |
+|-----------|---------|
+| `overall` | 70 |
+| `type_correctness` | 60 |
+| `pattern_adherence` | 60 |
+| `test_coverage` | 60 |
+| `security` | 75 |
+| `architectural_alignment` | 60 |
+
+---
+
+## Gate Behavior
+
+The pipeline gate (Phase 4b-conf in `/implement`) evaluates scores after the reviewer completes and before git operations begin (Phase 4c).
+
+| `on_breach` value | Behavior |
+|-------------------|----------|
+| `"block"` (default) | Halts the pipeline. No git operations run. |
+| `"warn"` | Prints the breach report but continues. |
+
+The gate can be bypassed per-invocation with `--confidence-override "<reason>"` if `override_allowed: true` in the config.
+```
+
+---
+
+## 2. Modified Spec: `openspec/specs/implement.md`
+
+**Action:** Append new section
+
+Add the following section after the existing "Edge Cases" section:
+
+```markdown
+---
+
+## Confidence Gate (Phase 4b-conf)
+
+### Position in Pipeline
+
+Phase 4b-conf runs AFTER Phase 4b (reviewer) and BEFORE Phase 4c (git operations).
+
+### Inputs
+
+- `openspec/changes/<name>/confidence-score.json` — written by the reviewer agent
+- `.claude/confidence-config.json` — threshold configuration (falls back to built-in defaults if absent)
+
+### Behavior
+
+The gate compares each score in `confidence-score.json` against the corresponding threshold in `confidence-config.json`. If any score falls below its threshold:
+
+- `on_breach: "block"` (default): pipeline halts before Phase 4c. A breach report is printed.
+- `on_breach: "warn"`: breach report is printed, pipeline continues.
+
+### Override
+
+If `--confidence-override "<reason>"` is passed to `/implement` and `override_allowed: true` in the config, the gate is bypassed. The override reason is recorded in the Phase 4e report.
+
+### Missing Score File
+
+If `confidence-score.json` does not exist after the reviewer completes, the gate prints a warning and proceeds. `CONFIDENCE_STATUS=MISSING` is recorded in the Phase 4e report.
+
+### Disabled Gate
+
+If `enabled: false` in the config, the gate is skipped entirely.
+
+### Dry-Run Compatibility
+
+When `DRY_RUN=true`, the gate still evaluates scores. If `CONFIDENCE_BLOCKED=true`, it records the block in `.cache-manifest.json` under `skipped_operations`.
+
+### Multi-Feature Mode
+
+In multi-feature mode, each feature's confidence score is evaluated independently after its reviewer completes. A block on one feature does not block other features from proceeding to Phase 4c. Each feature's gate outcome is recorded independently in the Phase 4e report.
+```
+
+---
+
+## 3. No Other Spec Files Changed
+
+The following existing specs are unaffected by this change:
+
+- `openspec/specs/batch-implement.md` — no pipeline gate changes required
+- `openspec/specs/versioning` — no version bump required; this is additive
+- `openspec/specs/update-system` — no changes required
+- `openspec/specs/setup-update-mode` — no changes required
+
+---
+
+## 4. Template Inventory After This Change
+
+| Template File | Status | Change |
+|--------------|--------|--------|
+| `templates/settings/confidence-config.json` | New | Created — threshold config for target repos |
+| `templates/agents/reviewer.md` | Modified | Confidence scoring section added |
+| `templates/commands/implement.md` | Modified | Phase 4b-conf block added; Phase 4e table column added |
+| `templates/agents/architect.md` | Unchanged | Phase 2 |
+| `templates/agents/developer.md` | Unchanged | Phase 2 |

--- a/openspec/changes/archive/2026-03-14-agent-confidence-scoring/design.md
+++ b/openspec/changes/archive/2026-03-14-agent-confidence-scoring/design.md
@@ -1,0 +1,303 @@
+---
+change: agent-confidence-scoring
+type: design
+---
+
+# Design: Agent Confidence Scoring & Validation Framework
+
+## Architecture Overview
+
+The confidence scoring system has three components:
+
+1. **Schema** — a JSON structure that agents emit, versioned and self-describing
+2. **Agent extension** — additions to the reviewer agent prompt that instruct it to produce a score
+3. **Pipeline gate** — a new phase in `/implement` that reads the score and blocks if thresholds are breached
+4. **Configuration** — a template-generated `confidence-config.json` that controls thresholds per target repo
+
+The system is deliberately simple. Confidence scores live as files on disk (not in memory, not in a database), which keeps them readable, diffable, and auditable. The pipeline gate is a conditional block in the existing `/implement` markdown command — no new scripts, no new processes.
+
+---
+
+## Confidence Score JSON Schema
+
+Every agent that emits a confidence score writes a file named `confidence-score.json` in `openspec/changes/<name>/`. This co-locates the score with the rest of the OpenSpec change artifacts, making it easy to audit and archive together.
+
+```json
+{
+  "schema_version": "1",
+  "change": "<change-name>",
+  "agent": "reviewer",
+  "scored_at": "<ISO 8601 timestamp>",
+  "overall": 82,
+  "aspects": {
+    "type_correctness": 90,
+    "pattern_adherence": 85,
+    "test_coverage": 70,
+    "security": 88,
+    "architectural_alignment": 78
+  },
+  "notes": {
+    "type_correctness": "All function signatures match the existing codebase style.",
+    "pattern_adherence": "One deviation from the established error-handling pattern in utils/parser.ts — flagged but not blocking.",
+    "test_coverage": "Integration tests are missing for the cache invalidation path. Unit coverage looks adequate.",
+    "security": "No new attack surface. Input validation follows existing patterns.",
+    "architectural_alignment": "The new module respects layer boundaries. One circular import risk noted in the design — mitigated by the developer's approach."
+  },
+  "flags": []
+}
+```
+
+### Field Definitions
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `schema_version` | string | yes | Always `"1"` for this version of the schema |
+| `change` | string | yes | Kebab-case change name matching the `openspec/changes/<name>/` directory |
+| `agent` | string | yes | Which agent produced the score: `"reviewer"`, `"developer"`, `"architect"` |
+| `scored_at` | string | yes | ISO 8601 timestamp of when the score was produced |
+| `overall` | integer | yes | 0–100. The agent's aggregate confidence in the quality of its output |
+| `aspects` | object | yes | Five named aspect scores, each 0–100 |
+| `aspects.type_correctness` | integer | yes | Confidence that types, signatures, and interfaces are correct |
+| `aspects.pattern_adherence` | integer | yes | Confidence that implementation follows existing codebase patterns |
+| `aspects.test_coverage` | integer | yes | Confidence that test coverage is adequate for the changes |
+| `aspects.security` | integer | yes | Confidence that no security regressions or new attack surface was introduced |
+| `aspects.architectural_alignment` | integer | yes | Confidence that the implementation respects architectural boundaries and design intent |
+| `notes` | object | yes | One required note per aspect explaining the score. Must be non-empty strings. |
+| `flags` | array | yes | Optional list of strings. Each string names a concern the agent wants to surface explicitly (e.g., `"missing-integration-test"`, `"unresolved-merge-conflict"`). Empty array if none. |
+
+### Score Semantics
+
+- **90–100**: High confidence. The agent believes this aspect is solid.
+- **70–89**: Moderate confidence. Worth a quick review but not alarming.
+- **50–69**: Low confidence. The agent recommends human review of this aspect.
+- **0–49**: Very low confidence. The agent believes there is a real problem here.
+
+These semantics are informational — the pipeline gate uses the configured thresholds, not these bands.
+
+---
+
+## Configuration Schema: `confidence-config.json`
+
+Installed into `.claude/confidence-config.json` in every target repo via `/setup`. The template lives at `templates/settings/confidence-config.json`.
+
+```json
+{
+  "schema_version": "1",
+  "enabled": true,
+  "thresholds": {
+    "overall": 70,
+    "aspects": {
+      "type_correctness": 60,
+      "pattern_adherence": 60,
+      "test_coverage": 60,
+      "security": 75,
+      "architectural_alignment": 60
+    }
+  },
+  "on_breach": "block",
+  "override_allowed": true
+}
+```
+
+### Field Definitions
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `schema_version` | string | `"1"` | Config schema version |
+| `enabled` | boolean | `true` | Set to `false` to disable the gate entirely without removing the file |
+| `thresholds.overall` | integer | `70` | Minimum required overall score |
+| `thresholds.aspects.*` | integer | `60` (security: `75`) | Minimum required score per aspect |
+| `on_breach` | string | `"block"` | `"block"` halts Phase 4c. `"warn"` prints but continues. |
+| `override_allowed` | boolean | `true` | If `true`, the user can unblock a breached gate by providing an override reason in the pipeline prompt |
+
+### Built-in Defaults (fallback when config file is absent)
+
+If `.claude/confidence-config.json` does not exist, the pipeline uses these defaults and prints a one-time notice:
+
+```
+[confidence] No confidence-config.json found. Using built-in defaults.
+[confidence] To customize thresholds, create .claude/confidence-config.json.
+```
+
+Built-in defaults match the config schema defaults above.
+
+---
+
+## File Changes
+
+### New Files
+
+| File | Layer | Purpose |
+|------|-------|---------|
+| `templates/settings/confidence-config.json` | templates | Template for per-repo confidence threshold config, installed by `/setup` |
+
+### Modified Files
+
+| File | Layer | Change |
+|------|-------|--------|
+| `templates/agents/reviewer.md` | templates | Add confidence scoring section: instructions to produce `confidence-score.json` after completing the review |
+| `templates/commands/implement.md` | templates | Add Phase 4b-conf: read confidence score, compare against thresholds, block Phase 4c if breach detected |
+
+---
+
+## Data Flow
+
+```
+Phase 4b (reviewer agent runs)
+    ↓
+reviewer writes openspec/changes/<name>/confidence-score.json
+    ↓
+Phase 4b-conf (pipeline reads score)
+    ↓ reads .claude/confidence-config.json (or built-in defaults)
+    ↓ compares each aspect score against threshold
+    ↓
+    ├── All scores >= thresholds → proceed to Phase 4c
+    └── Any score < threshold →
+            if on_breach=block → print breach report, halt before Phase 4c
+            if on_breach=warn  → print breach report, continue to Phase 4c
+```
+
+---
+
+## Reviewer Agent Extension
+
+The reviewer agent prompt (`templates/agents/reviewer.md`) gains a new section at the end: **Confidence Scoring**.
+
+The section instructs the reviewer to:
+
+1. After completing all CI checks and fixes, self-assess confidence across the five aspects.
+2. Write `openspec/changes/<name>/confidence-score.json` with the schema above.
+3. Derive `change` from the context provided by the orchestrator (the change name passed in the agent's invocation prompt). If the change name is unavailable, derive it from the `openspec/changes/` directory that was active during the review.
+4. Set `scored_at` to the current ISO 8601 timestamp.
+5. Set `agent` to `"reviewer"`.
+6. Populate `notes` with concrete, specific observations — not generic statements.
+7. Populate `flags` with any named concerns not already captured in notes.
+
+The scoring instruction is non-optional. The reviewer MUST produce the file. If it cannot (e.g., the change name is unclear), it sets `overall: 0` and writes a note in every aspect explaining the failure.
+
+---
+
+## Pipeline Gate: Phase 4b-conf
+
+Added between Phase 4b (reviewer completes) and Phase 4c (git operations) in `templates/commands/implement.md`.
+
+### Gate Logic (in prose for the command template)
+
+```
+## Phase 4b-conf: Confidence Gate
+
+After the reviewer agent completes:
+
+1. Read `openspec/changes/<name>/confidence-score.json`.
+   - If the file does not exist: print a warning and proceed (non-blocking — reviewer may have
+     failed to write it). Record `CONFIDENCE_STATUS=MISSING` in the Phase 4e report.
+
+2. Read `.claude/confidence-config.json`.
+   - If the file does not exist: use built-in defaults and print the one-time notice.
+   - If `enabled: false`: print `[confidence] Gate disabled. Skipping.` and proceed.
+
+3. Compare scores:
+   - Check `overall` against `thresholds.overall`.
+   - Check each aspect in `aspects` against `thresholds.aspects.<aspect>`.
+   - Collect all breaches as a list: `{aspect, actual, threshold}`.
+
+4. If `breaches` is non-empty and `on_breach = "block"`:
+   - Print the Breach Report (see format below).
+   - Set `CONFIDENCE_BLOCKED=true`.
+   - Halt: do not proceed to Phase 4c.
+
+5. If `breaches` is non-empty and `on_breach = "warn"`:
+   - Print the Breach Report.
+   - Set `CONFIDENCE_BLOCKED=false`.
+   - Continue to Phase 4c.
+
+6. If no breaches:
+   - Print: `[confidence] All scores meet thresholds. Proceeding.`
+   - Set `CONFIDENCE_BLOCKED=false`.
+   - Continue to Phase 4c.
+```
+
+### Breach Report Format
+
+```
+## Confidence Gate: BLOCKED
+
+The reviewer's confidence scores do not meet configured thresholds.
+
+| Aspect | Score | Threshold | Delta |
+|--------|-------|-----------|-------|
+| overall | 62 | 70 | -8 |
+| test_coverage | 55 | 60 | -5 |
+
+### Reviewer Notes on Low-Scoring Aspects
+
+**test_coverage (55):** Integration tests are missing for the cache invalidation path.
+
+### Flags
+
+- missing-integration-test
+
+### Next Steps
+
+1. Address the concerns above and re-run `/implement`.
+2. Or, if you have reviewed the concerns and accept the risk, re-run with an override:
+   `/implement #N --confidence-override "reason"`
+
+Pipeline halted. No git operations have been performed.
+```
+
+### Override Flag
+
+If `override_allowed: true` in the config and the user passes `--confidence-override "<reason>"` in the `/implement` invocation:
+
+- Skip the blocking behavior.
+- Print: `[confidence] Override accepted. Reason: <reason>. Proceeding with gate bypassed.`
+- Record the override reason in the Phase 4e report.
+- Continue to Phase 4c normally.
+
+If `override_allowed: false` in the config, the `--confidence-override` flag is ignored and a note is printed: `[confidence] Override is disabled in confidence-config.json.`
+
+---
+
+## Dry-Run Behavior
+
+When `DRY_RUN=true`:
+
+- The reviewer still writes `confidence-score.json` (it is an OpenSpec artifact, not a git artifact).
+- Phase 4b-conf still runs and evaluates the score.
+- If `CONFIDENCE_BLOCKED=true`: record `skipped_operations: ["confidence-gate: blocked — Phase 4c skipped"]` in `.cache-manifest.json`.
+- The Dry-Run Preview Report (Phase 4e) includes a Confidence section showing scores and gate outcome.
+
+---
+
+## Phase 4e Report Extension
+
+The final report table gains a `Confidence` column:
+
+```
+| Area | Feature | Change Name | Architect | Developer | Tests | Docs | Reviewer | Confidence | Security | CI | Status |
+```
+
+Confidence column values:
+- `PASS (82)` — gate passed, overall score shown
+- `WARN (62)` — gate warned, scores below threshold
+- `BLOCKED (62)` — gate blocked, scores below threshold
+- `OVERRIDE (62)` — gate bypassed by explicit override
+- `MISSING` — score file not found
+- `DISABLED` — gate disabled in config
+
+---
+
+## Ambiguities and Resolutions
+
+**Ambiguity 1:** The issue says "could start with reviewer" — should architect and developer scoring be stubbed or completely deferred?
+
+**Resolution:** Completely deferred. No stub placeholders are added to architect or developer templates. Adding empty stubs would create misleading `confidence-score.json` files with no actual assessment. Phase 2 will add full scoring to those agents when the design is ready.
+
+**Ambiguity 2:** Where should `confidence-score.json` live when multiple features run in parallel?
+
+**Resolution:** Each feature has its own `openspec/changes/<name>/` directory, so each gets its own `confidence-score.json`. The pipeline gate runs once per feature after its reviewer completes. No conflict risk.
+
+**Ambiguity 3:** Should the gate block before or after the security reviewer?
+
+**Resolution:** Before. The sequence is: reviewer → confidence gate → security reviewer → Phase 4c. If the confidence gate blocks, security review is also skipped (there's no point reviewing code we've already decided not to ship). This simplifies the state machine and avoids wasted work.

--- a/openspec/changes/archive/2026-03-14-agent-confidence-scoring/proposal.md
+++ b/openspec/changes/archive/2026-03-14-agent-confidence-scoring/proposal.md
@@ -1,0 +1,49 @@
+---
+change: agent-confidence-scoring
+type: feature
+status: draft
+github_issue: 37
+vpc_fit: 78%
+---
+
+# Proposal: Agent Confidence Scoring & Validation Framework
+
+## Problem
+
+The specrails pipeline produces artifacts — designs, implementations, and reviews — without ever surfacing how certain each agent is about what it produced. A developer agent implementing a complex migration may succeed structurally but have quietly omitted edge-case handling. A reviewer may pass code that it flagged as uncertain internally but never communicated that uncertainty to the lead developer. The pipeline treats all output as equally authoritative, which means the lead developer cannot distinguish between "this is solid" and "this compiles and roughly follows the pattern."
+
+The result is a trust problem. When agents operate as black boxes, lead developers must either review every artifact thoroughly (defeating the automation's purpose) or ship with unknown risk. Neither outcome is acceptable on a production-driven team.
+
+There is currently no mechanism for agents to say "I'm 60% confident in the test coverage aspect of this implementation — you should review it." Uncertainty is buried rather than surfaced.
+
+## Solution
+
+Introduce a structured confidence scoring system where each agent outputs a machine-readable confidence score alongside its human-readable output. The score breaks down by aspect (type correctness, pattern adherence, test coverage, security, architectural alignment) to give lead developers targeted visibility into exactly which dimensions deserve their attention.
+
+The `/implement` pipeline checks scores against configurable thresholds defined in `.claude/confidence-config.json`. If a critical threshold is breached, the pipeline blocks shipping and requires either a score override (with an explicit reason) or re-implementation.
+
+The feature is introduced incrementally:
+
+1. **Phase 1 (this change):** Define the confidence score JSON schema. Add confidence scoring to the reviewer agent. Add the pipeline gate in `/implement`. Add the configuration file and its template.
+2. **Phase 2 (future):** Extend scoring to the developer and architect agents.
+
+The reviewer agent is the right starting point: it has the broadest view of what was implemented, already runs CI checks, and is explicitly positioned as a quality gate. Its confidence scores will be the most actionable from day one.
+
+## Non-Goals
+
+- This does not add confidence scoring to the developer or architect agents in this change. That is Phase 2.
+- This does not add automatic retry logic when scores are low. The gate blocks and informs; it does not attempt self-correction beyond what the reviewer already does.
+- This does not introduce an AI model evaluation layer. Confidence scores are the agent's self-assessment, not ground truth.
+- This does not change how CI checks run. The existing CI pipeline remains unchanged.
+- This does not require changes to `install.sh` — the config template is picked up automatically by `/setup`'s template copy step.
+
+## Success Criteria
+
+- The reviewer agent outputs a `confidence-score.json` file in `openspec/changes/<name>/` at the end of every review.
+- The score schema validates correctly: overall score 0-100, five named aspect scores, a required notes field, and a schema version.
+- `.claude/confidence-config.json` is present in every installed repo after `/setup` runs, with documented default thresholds.
+- The `/implement` pipeline reads the confidence score after Phase 4b (reviewer) and compares it against thresholds from the config file.
+- If any threshold is breached, the pipeline prints a clear blocking report and halts before Phase 4c (git operations).
+- If the config file is absent, the pipeline falls back to built-in defaults and prints a one-time notice.
+- No `{{PLACEHOLDER}}` tokens remain unresolved in installed files after `/setup` runs.
+- The feature works correctly when `confidence-config.json` thresholds are customized by the target repo.

--- a/openspec/changes/archive/2026-03-14-agent-confidence-scoring/tasks.md
+++ b/openspec/changes/archive/2026-03-14-agent-confidence-scoring/tasks.md
@@ -1,0 +1,212 @@
+---
+change: agent-confidence-scoring
+type: tasks
+---
+
+# Tasks: Agent Confidence Scoring & Validation Framework
+
+Tasks are ordered sequentially. Each task depends on the one before it unless stated otherwise.
+
+---
+
+## T1 — Create `templates/settings/confidence-config.json` [templates]
+
+**Description:**
+Create the confidence threshold configuration template that `/setup` installs into `.claude/confidence-config.json` in every target repo. This file must be valid JSON with documented fields. It is a static file — no `{{PLACEHOLDER}}` substitution is needed because thresholds are not repo-specific at install time (they are customizable by the user after installation).
+
+**Files:**
+- Create: `templates/settings/confidence-config.json`
+
+**Acceptance criteria:**
+- File is valid JSON
+- Contains all fields from the config schema in `design.md`: `schema_version`, `enabled`, `thresholds.overall`, `thresholds.aspects` (all five aspects), `on_breach`, `override_allowed`
+- Default values match the design exactly: `overall: 70`, `security: 75`, all other aspects `60`, `on_breach: "block"`, `override_allowed: true`
+- A comment-style note (via a `"_comment"` key or inline in the file preamble) explains each field — since JSON doesn't support comments, use a top-level `"_docs"` key with a brief description string
+- File is formatted with 2-space indentation
+
+**Dependencies:** none
+
+---
+
+## T2 — Add confidence scoring section to `templates/agents/reviewer.md` [templates]
+
+**Description:**
+Add a new **Confidence Scoring** section to the reviewer agent prompt template. This section must appear after the existing "Rules" and "Critical Warnings" sections and before the "Persistent Agent Memory" section. It instructs the reviewer to self-assess confidence across five aspects and write `confidence-score.json` to `openspec/changes/<name>/`.
+
+The section must specify:
+- That scoring is mandatory, not optional
+- How to derive the `change` name (from the orchestrator-provided context, or by finding the `openspec/changes/` directory being reviewed)
+- All five aspect definitions (copy from design.md aspect table)
+- That `notes` must be concrete and specific — not generic boilerplate
+- The exact output file path: `openspec/changes/<name>/confidence-score.json`
+- That if the change name cannot be determined, write the score with `"change": "unknown"` and `"overall": 0` with explanatory notes
+- The full JSON schema (copy from design.md) as a reference example within the prompt
+
+**Files:**
+- Modify: `templates/agents/reviewer.md`
+
+**Acceptance criteria:**
+- New section titled `## Confidence Scoring` is present
+- Section appears after the `## Rules` block and before the `## Persistent Agent Memory` block
+- All five aspects are defined with their names and descriptions
+- Output file path is explicit: `openspec/changes/<name>/confidence-score.json`
+- A complete, valid example JSON block is included in the prompt as a reference
+- The `scored_at` field is set to the current timestamp at time of writing
+- The `agent` field is hardcoded to `"reviewer"` in the instructions
+- Fallback behavior (unknown change name) is defined
+- No new `{{PLACEHOLDER}}` tokens are introduced (the existing template already has all needed ones)
+
+**Dependencies:** T1
+
+---
+
+## T3 — Add Phase 4b-conf to `templates/commands/implement.md` [templates]
+
+**Description:**
+Insert a new `## Phase 4b-conf: Confidence Gate` section into `templates/commands/implement.md` between the existing `### 4b-sec. Launch Security Reviewer agent` section and `### 4c. Ship` section.
+
+Wait — re-read the design. The confidence gate must run BEFORE the security reviewer (per design.md "Ambiguity 3" resolution). The correct insertion point is: after `### 4b. Launch Reviewer agent` completes and before `### 4b-sec. Launch Security Reviewer agent`.
+
+The section must implement the gate logic from design.md verbatim:
+1. Read `confidence-score.json` — handle missing file gracefully
+2. Read `confidence-config.json` — handle missing file with built-in defaults and one-time notice
+3. Handle `enabled: false` — skip gate
+4. Compare scores against thresholds — collect breaches
+5. Apply `on_breach` behavior: block or warn
+6. Handle `--confidence-override` flag: check `override_allowed`, bypass gate, record reason
+7. Set `CONFIDENCE_BLOCKED` variable for downstream use
+
+The `--confidence-override` flag must also be parsed in Phase 0 (Flag Detection) alongside the existing `--dry-run` and `--apply` flags.
+
+**Files:**
+- Modify: `templates/commands/implement.md`
+
+**Acceptance criteria:**
+- New `## Phase 4b-conf: Confidence Gate` section is present between `### 4b.` and `### 4b-sec.`
+- Phase 0 Flag Detection section documents `--confidence-override "<reason>"` flag parsing and sets `CONFIDENCE_OVERRIDE_REASON` variable
+- Gate reads from `openspec/changes/<name>/confidence-score.json` — path is correct
+- Missing score file sets `CONFIDENCE_STATUS=MISSING` and is non-blocking
+- Missing config file triggers built-in defaults with one-time notice (exact text from design.md)
+- `enabled: false` path is handled with skip message
+- Breach report format matches design.md exactly (table with Aspect, Score, Threshold, Delta columns)
+- `CONFIDENCE_BLOCKED=true` causes pipeline to halt before Phase 4b-sec and Phase 4c
+- `--confidence-override` with `override_allowed: true` bypasses the block
+- `--confidence-override` with `override_allowed: false` is rejected with printed notice
+- `on_breach: "warn"` path continues to Phase 4b-sec despite breach
+- In multi-feature mode (worktrees), the gate runs per-feature immediately after each feature's reviewer completes; the section documents this explicitly
+
+**Dependencies:** T2
+
+---
+
+## T4 — Extend Phase 4e report table in `templates/commands/implement.md` [templates]
+
+**Description:**
+Update the Phase 4e (Report) section in `templates/commands/implement.md` to add a `Confidence` column to the final pipeline status table.
+
+The existing table header is:
+```
+| Area | Feature | Change Name | Architect | Developer | Tests | Docs | Reviewer | Security | CI | Status |
+```
+
+It becomes:
+```
+| Area | Feature | Change Name | Architect | Developer | Tests | Docs | Reviewer | Confidence | Security | CI | Status |
+```
+
+Document the six possible Confidence column values from design.md:
+- `PASS (82)` — gate passed, score shown
+- `WARN (62)` — gate warned
+- `BLOCKED (62)` — gate blocked
+- `OVERRIDE (62)` — bypassed by override
+- `MISSING` — score file not found
+- `DISABLED` — gate disabled in config
+
+Also update the Dry-Run Preview Report format (Phase 4e, `DRY_RUN=true` path) to include a Confidence section showing scores and gate outcome.
+
+**Files:**
+- Modify: `templates/commands/implement.md`
+
+**Acceptance criteria:**
+- Phase 4e standard table header includes `Confidence` column between `Reviewer` and `Security`
+- All six column value formats are documented in the section prose
+- Dry-Run Preview Report includes a `### Confidence` subsection showing the score file path and gate outcome
+- If `CONFIDENCE_OVERRIDE_REASON` is set, it appears in the Phase 4e report under a `### Confidence Override` heading with the reason
+
+**Dependencies:** T3
+
+---
+
+## T5 — Create `openspec/specs/confidence-scoring.md` [core]
+
+**Description:**
+Create the new spec file documenting the confidence scoring system as a first-class specrails spec. This spec is the reference document for any future agent or pipeline extension that touches confidence scoring.
+
+Copy the spec content verbatim from the delta-spec.md `## 1. New Spec` section in this change directory.
+
+**Files:**
+- Create: `openspec/specs/confidence-scoring.md`
+
+**Acceptance criteria:**
+- File exists at `openspec/specs/confidence-scoring.md`
+- Contains all sections from the delta-spec: Score File, Aspects table, Configuration, Gate Behavior
+- Aspect table matches design.md exactly (same five aspects, same definitions)
+- Default thresholds table matches design.md exactly
+- Gate behavior table covers both `on_breach` values
+- Override and dry-run behavior are documented
+
+**Dependencies:** T1
+
+---
+
+## T6 — Append confidence gate section to `openspec/specs/implement.md` [core]
+
+**Description:**
+Append the new "Confidence Gate (Phase 4b-conf)" section to `openspec/specs/implement.md`. This extends the existing spec for the `/implement` command with the confidence gate contract.
+
+Copy the section verbatim from the delta-spec.md `## 2. Modified Spec` section in this change directory.
+
+**Files:**
+- Modify: `openspec/specs/implement.md`
+
+**Acceptance criteria:**
+- New section `## Confidence Gate (Phase 4b-conf)` is appended after the existing `## Edge Cases` section (or at the end of the file)
+- All subsections present: Position in Pipeline, Inputs, Behavior, Override, Missing Score File, Disabled Gate, Dry-Run Compatibility, Multi-Feature Mode
+- Multi-feature behavior is documented: per-feature evaluation, independent blocking
+- No existing content in `implement.md` is modified — append only
+
+**Dependencies:** T5
+
+---
+
+## T7 — Verify template integrity: no broken placeholders [core]
+
+**Description:**
+After all template modifications are complete, verify that no `{{PLACEHOLDER}}` tokens were accidentally introduced into generated-path files (`.claude/agents/`, `.claude/commands/`) or left unresolved in templates. Also verify the new `confidence-config.json` template is valid JSON.
+
+Run the verification commands from CLAUDE.md:
+
+```bash
+# Check for broken placeholders in generated files
+grep -r '{{[A-Z_]*}}' .claude/agents/ .claude/commands/ 2>/dev/null || echo "No broken placeholders found"
+
+# Validate the new JSON template
+python3 -m json.tool templates/settings/confidence-config.json > /dev/null && echo "Valid JSON" || echo "INVALID JSON"
+
+# Confirm new template files exist
+ls templates/settings/confidence-config.json
+ls openspec/specs/confidence-scoring.md
+```
+
+This task is verification-only — no files should need to be created or modified. If issues are found, fix them before marking this task complete.
+
+**Files:**
+- No files created or modified (verification only)
+
+**Acceptance criteria:**
+- `grep` command returns no results (no broken placeholders in generated files)
+- `python3 -m json.tool` exits 0 for `confidence-config.json`
+- All five new/modified files exist: `templates/settings/confidence-config.json`, `openspec/specs/confidence-scoring.md`, modified `templates/agents/reviewer.md`, modified `templates/commands/implement.md`, modified `openspec/specs/implement.md`
+- A manual read of each modified file confirms the sections were inserted at the correct positions
+
+**Dependencies:** T2, T3, T4, T5, T6

--- a/openspec/specs/confidence-scoring.md
+++ b/openspec/specs/confidence-scoring.md
@@ -1,0 +1,59 @@
+# Spec: Confidence Scoring System
+
+Agents in the specrails pipeline MAY emit a structured confidence score alongside their output. The reviewer agent MUST emit a score. Future agents (developer, architect) MAY be extended in later changes.
+
+---
+
+## Score File
+
+Each confidence score is written to:
+
+```
+openspec/changes/<name>/confidence-score.json
+```
+
+The file MUST conform to the schema defined in `design.md` for the `agent-confidence-scoring` change. It MUST be present after the reviewer agent completes. Its absence is treated as a warning (non-blocking) by the pipeline gate.
+
+---
+
+## Aspects
+
+Five aspects are scored, each 0–100:
+
+| Aspect | Definition |
+|--------|-----------|
+| `type_correctness` | Types, signatures, and interfaces are correct and consistent with the codebase |
+| `pattern_adherence` | Implementation follows established patterns and conventions |
+| `test_coverage` | Test coverage is adequate for the scope of changes |
+| `security` | No security regressions or new attack surface introduced |
+| `architectural_alignment` | Implementation respects architectural boundaries and design intent |
+
+---
+
+## Configuration
+
+The pipeline gate is configured via `.claude/confidence-config.json` (installed by `/setup` from `templates/settings/confidence-config.json`).
+
+If the config file is absent, built-in defaults apply:
+
+| Threshold | Default |
+|-----------|---------|
+| `overall` | 70 |
+| `type_correctness` | 60 |
+| `pattern_adherence` | 60 |
+| `test_coverage` | 60 |
+| `security` | 75 |
+| `architectural_alignment` | 60 |
+
+---
+
+## Gate Behavior
+
+The pipeline gate (Phase 4b-conf in `/implement`) evaluates scores after the reviewer completes and before git operations begin (Phase 4c).
+
+| `on_breach` value | Behavior |
+|-------------------|----------|
+| `"block"` (default) | Halts the pipeline. No git operations run. |
+| `"warn"` | Prints the breach report but continues. |
+
+The gate can be bypassed per-invocation with `--confidence-override "<reason>"` if `override_allowed: true` in the config.

--- a/openspec/specs/implement.md
+++ b/openspec/specs/implement.md
@@ -180,3 +180,43 @@ When `DRY_RUN=true`, Phase 4a MUST apply the identical merge algorithm writing t
 - `SINGLE_MODE=true` MUST bypass Phase 3a.1 and Phase 4a smart merge entirely.
 - The merge algorithm MUST NOT create git commits, branches, or pushes.
 - Pre-existing conflict markers in a file MUST NOT be nested with new conflict markers — log a warning instead.
+
+---
+
+## Confidence Gate (Phase 4b-conf)
+
+### Position in Pipeline
+
+Phase 4b-conf runs AFTER Phase 4b (reviewer) and BEFORE Phase 4c (git operations).
+
+### Inputs
+
+- `openspec/changes/<name>/confidence-score.json` — written by the reviewer agent
+- `.claude/confidence-config.json` — threshold configuration (falls back to built-in defaults if absent)
+
+### Behavior
+
+The gate compares each score in `confidence-score.json` against the corresponding threshold in `confidence-config.json`. If any score falls below its threshold:
+
+- `on_breach: "block"` (default): pipeline halts before Phase 4c. A breach report is printed.
+- `on_breach: "warn"`: breach report is printed, pipeline continues.
+
+### Override
+
+If `--confidence-override "<reason>"` is passed to `/implement` and `override_allowed: true` in the config, the gate is bypassed. The override reason is recorded in the Phase 4e report.
+
+### Missing Score File
+
+If `confidence-score.json` does not exist after the reviewer completes, the gate prints a warning and proceeds. `CONFIDENCE_STATUS=MISSING` is recorded in the Phase 4e report.
+
+### Disabled Gate
+
+If `enabled: false` in the config, the gate is skipped entirely.
+
+### Dry-Run Compatibility
+
+When `DRY_RUN=true`, the gate still evaluates scores. If `CONFIDENCE_BLOCKED=true`, it records the block in `.cache-manifest.json` under `skipped_operations`.
+
+### Multi-Feature Mode
+
+In multi-feature mode, each feature's confidence score is evaluated independently after its reviewer completes. A block on one feature does not block other features from proceeding to Phase 4c. Each feature's gate outcome is recorded independently in the Phase 4e report.

--- a/templates/agents/reviewer.md
+++ b/templates/agents/reviewer.md
@@ -80,6 +80,79 @@ When done, produce this report:
 
 {{CI_CRITICAL_WARNINGS}}
 
+## Confidence Scoring
+
+After completing all CI checks and fixes, you MUST produce a confidence score. This is non-optional. Write the score file before reporting your results.
+
+### What to assess
+
+Score yourself across five aspects, each from 0 to 100:
+
+| Aspect | What to assess |
+|--------|---------------|
+| `type_correctness` | Types, signatures, and interfaces are correct and consistent with the codebase |
+| `pattern_adherence` | Implementation follows established patterns and conventions |
+| `test_coverage` | Test coverage is adequate for the scope of changes |
+| `security` | No security regressions or new attack surface introduced |
+| `architectural_alignment` | Implementation respects architectural boundaries and design intent |
+
+Score semantics:
+- **90–100**: High confidence — solid.
+- **70–89**: Moderate confidence — worth a quick review but not alarming.
+- **50–69**: Low confidence — recommend human review of this aspect.
+- **0–49**: Very low confidence — real problem here.
+
+### How to derive the change name
+
+The change name is the kebab-case directory under `openspec/changes/` that was active during this review. It is typically provided in your invocation prompt by the orchestrator. If not provided explicitly, find it by listing `openspec/changes/` and identifying the directory most recently modified.
+
+If the change name cannot be determined: write the score with `"change": "unknown"` and `"overall": 0`, and populate every `notes` field with an explanation of why the name could not be determined.
+
+### Output file
+
+Write to:
+```
+openspec/changes/<name>/confidence-score.json
+```
+
+### Required fields
+
+- `schema_version`: always `"1"`
+- `change`: kebab-case change name
+- `agent`: always `"reviewer"`
+- `scored_at`: current ISO 8601 timestamp
+- `overall`: integer 0–100 — your aggregate confidence
+- `aspects`: object with all five aspect scores
+- `notes`: one non-empty string per aspect — must be concrete and specific, not generic boilerplate
+- `flags`: array of named concerns (e.g., `"missing-integration-test"`); empty array if none
+
+### Example
+
+```json
+{
+  "schema_version": "1",
+  "change": "my-change-name",
+  "agent": "reviewer",
+  "scored_at": "2026-03-14T12:00:00Z",
+  "overall": 82,
+  "aspects": {
+    "type_correctness": 90,
+    "pattern_adherence": 85,
+    "test_coverage": 70,
+    "security": 88,
+    "architectural_alignment": 78
+  },
+  "notes": {
+    "type_correctness": "All function signatures match the existing codebase style.",
+    "pattern_adherence": "One deviation from the established error-handling pattern in utils/parser.ts — flagged but not blocking.",
+    "test_coverage": "Integration tests are missing for the cache invalidation path. Unit coverage looks adequate.",
+    "security": "No new attack surface. Input validation follows existing patterns.",
+    "architectural_alignment": "The new module respects layer boundaries. One circular import risk noted in the design — mitigated by the developer's approach."
+  },
+  "flags": []
+}
+```
+
 # Persistent Agent Memory
 
 You have a persistent agent memory directory at `{{MEMORY_PATH}}`. Its contents persist across conversations.

--- a/templates/commands/implement.md
+++ b/templates/commands/implement.md
@@ -88,7 +88,11 @@ Before parsing input, scan `$ARGUMENTS` for control flags:
   - Skip Phases 1–4b. Go directly to Phase 4c (the apply path handles the rest).
   - Strip `--apply` and the feature name before further parsing.
 
-If neither flag is present: `DRY_RUN=false`, `APPLY_MODE=false`. Pipeline runs as normal.
+- If `--confidence-override "<reason>"` is present in `$ARGUMENTS`:
+  - Set `CONFIDENCE_OVERRIDE_REASON=<reason>` (the quoted string immediately following `--confidence-override`)
+  - Strip `--confidence-override` and the reason before further parsing.
+
+If none of these flags is present: `DRY_RUN=false`, `APPLY_MODE=false`, `CONFIDENCE_OVERRIDE_REASON=""`. Pipeline runs as normal.
 
 Note: `CACHE_DIR` for `--dry-run` is finalized after the feature name is derived from the remaining input. All subsequent phases that reference `CACHE_DIR` have access to it.
 
@@ -418,6 +422,108 @@ Launch a single **reviewer** agent to validate ALL merged changes. Include:
 > CI commands may be run — they read the real repo, but be aware developer changes are not
 > yet applied to real paths.
 
+### 4b-conf. Confidence Gate
+
+After the reviewer agent completes, evaluate the confidence score before launching the security reviewer.
+
+**In multi-feature mode (worktrees):** run this gate once per feature immediately after that feature's reviewer completes. Each feature is evaluated independently — a block on one feature does not prevent another feature's gate from running.
+
+#### Step 1 — Read score file
+
+Path: `openspec/changes/<name>/confidence-score.json`
+
+- If the file does not exist:
+  - Set `CONFIDENCE_STATUS=MISSING`
+  - Print: `[confidence] Warning: confidence-score.json not found. Proceeding without gate.`
+  - Continue to Phase 4b-sec.
+
+#### Step 2 — Read config
+
+Path: `.claude/confidence-config.json`
+
+- If the file does not exist:
+  - Use built-in defaults (overall: 70; type_correctness: 60; pattern_adherence: 60; test_coverage: 60; security: 75; architectural_alignment: 60).
+  - Print:
+    ```
+    [confidence] No confidence-config.json found. Using built-in defaults.
+    [confidence] To customize thresholds, create .claude/confidence-config.json.
+    ```
+- If `enabled: false` in the config:
+  - Print: `[confidence] Gate disabled. Skipping.`
+  - Set `CONFIDENCE_STATUS=DISABLED`
+  - Continue to Phase 4b-sec.
+
+#### Step 3 — Compare scores
+
+- Check `overall` against `thresholds.overall`.
+- Check each of the five aspects against `thresholds.aspects.<aspect>`.
+- Collect all breaches as a list: `{aspect, actual_score, threshold, delta}`.
+
+#### Step 4 — Apply on_breach
+
+**If no breaches:**
+- Print: `[confidence] All scores meet thresholds. Proceeding.`
+- Set `CONFIDENCE_STATUS=PASS`
+- Continue to Phase 4b-sec.
+
+**If breaches exist and `on_breach: "block"`:**
+
+1. Check for `--confidence-override`:
+   - If `CONFIDENCE_OVERRIDE_REASON` is non-empty and `override_allowed: true` in the config:
+     - Print: `[confidence] Override accepted. Reason: <CONFIDENCE_OVERRIDE_REASON>. Proceeding with gate bypassed.`
+     - Set `CONFIDENCE_STATUS=OVERRIDE`
+     - Continue to Phase 4b-sec.
+   - If `CONFIDENCE_OVERRIDE_REASON` is non-empty but `override_allowed: false` in the config:
+     - Print: `[confidence] Override is disabled in confidence-config.json.`
+     - (Fall through to block below.)
+   - If `CONFIDENCE_OVERRIDE_REASON` is empty or override was rejected:
+     - Print the Breach Report (see format below).
+     - Set `CONFIDENCE_BLOCKED=true`
+     - Set `CONFIDENCE_STATUS=BLOCKED`
+     - **Halt: do not proceed to Phase 4b-sec or Phase 4c.**
+
+**If breaches exist and `on_breach: "warn"`:**
+- Print the Breach Report.
+- Set `CONFIDENCE_STATUS=WARN`
+- Continue to Phase 4b-sec.
+
+#### Breach Report Format
+
+```
+## Confidence Gate: BLOCKED
+
+The reviewer's confidence scores do not meet configured thresholds.
+
+| Aspect | Score | Threshold | Delta |
+|--------|-------|-----------|-------|
+| <aspect> | <actual> | <threshold> | <delta (negative)> |
+
+### Reviewer Notes on Low-Scoring Aspects
+
+**<aspect> (<score>):** <note from confidence-score.json>
+
+### Flags
+
+- <flag-1>
+- <flag-2>
+(omit this section if flags array is empty)
+
+### Next Steps
+
+1. Address the concerns above and re-run `/implement`.
+2. Or, if you have reviewed the concerns and accept the risk, re-run with an override:
+   `/implement #N --confidence-override "reason"`
+
+Pipeline halted. No git operations have been performed.
+```
+
+#### Dry-Run Behavior
+
+When `DRY_RUN=true`, the reviewer still writes `confidence-score.json` (it is an OpenSpec artifact, not a git artifact). Phase 4b-conf still evaluates the score. If `CONFIDENCE_BLOCKED=true`, add to `.cache-manifest.json` under `skipped_operations`:
+```
+"confidence-gate: blocked — Phase 4c and 4b-sec skipped"
+```
+
 ### 4b-sec. Launch Security Reviewer agent
 
 After the reviewer agent completes, launch a **security-reviewer** agent (`subagent_type: security-reviewer`).
@@ -558,6 +664,14 @@ If `GIT_AUTO=false`: skip — the user will push and monitor CI themselves.
 [For each file in `.cache-manifest.json` `files` array:]
 - `<real_path>` — [new file / modified] ([approximate line delta if available])
 
+### Confidence
+
+| | |
+|-|--|
+| Score file | `openspec/changes/<name>/confidence-score.json` |
+| Gate result | `<CONFIDENCE_STATUS>` (PASS / WARN / BLOCKED / OVERRIDE / MISSING / DISABLED) |
+| Overall score | `<overall score from confidence-score.json, or N/A if MISSING/DISABLED>` |
+
 ### Operations Skipped
 
 [List items from `.cache-manifest.json` `skipped_operations` array]
@@ -579,8 +693,27 @@ rm -rf .claude/.dry-run/<feature-name>/
 **Otherwise**, show the standard pipeline table:
 
 ```
-| Area | Feature | Change Name | Architect | Developer | Tests | Docs | Reviewer | Security | CI | Status |
-|------|---------|-------------|-----------|-----------|-------|----------|----------|----|--------|
+| Area | Feature | Change Name | Architect | Developer | Tests | Docs | Reviewer | Confidence | Security | CI | Status |
+|------|---------|-------------|-----------|-----------|-------|------|----------|------------|----------|----|--------|
+```
+
+Confidence column values:
+
+| Value | Meaning |
+|-------|---------|
+| `PASS (82)` | All scores met thresholds; overall score shown in parens |
+| `WARN (62)` | Scores below threshold but `on_breach=warn`; overall score in parens |
+| `BLOCKED (62)` | Gate blocked the pipeline; overall score in parens |
+| `OVERRIDE (62)` | Gate bypassed by `--confidence-override`; overall score in parens |
+| `MISSING` | `confidence-score.json` not found after reviewer completed |
+| `DISABLED` | Gate disabled via `enabled: false` in config |
+
+If `CONFIDENCE_OVERRIDE_REASON` is non-empty, append a `### Confidence Override` section below the table:
+
+```
+### Confidence Override
+
+**Reason:** <CONFIDENCE_OVERRIDE_REASON>
 ```
 
 If `MERGE_REPORT.requires_resolution` is non-empty, print an additional section:

--- a/templates/settings/confidence-config.json
+++ b/templates/settings/confidence-config.json
@@ -1,0 +1,17 @@
+{
+  "_docs": "specrails confidence gate configuration. Installed to .claude/confidence-config.json by /setup.",
+  "schema_version": "1",
+  "enabled": true,
+  "thresholds": {
+    "overall": 70,
+    "aspects": {
+      "type_correctness": 60,
+      "pattern_adherence": 60,
+      "test_coverage": 60,
+      "security": 75,
+      "architectural_alignment": 60
+    }
+  },
+  "on_breach": "block",
+  "override_allowed": true
+}


### PR DESCRIPTION
## Summary

- Add confidence scoring system for the reviewer agent with five assessment aspects
- Implement Phase 4b-conf confidence gate in the `/implement` pipeline
- Create configurable thresholds in `confidence-config.json` template
- Gate can block, warn, or be overridden via `--confidence-override`

## Changes

- `templates/settings/confidence-config.json` (new) — threshold config template
- `templates/agents/reviewer.md` — Confidence Scoring section
- `templates/commands/implement.md` — Phase 0 flag, Phase 4b-conf gate, Phase 4e table
- `openspec/specs/confidence-scoring.md` (new) — confidence scoring spec
- `openspec/specs/implement.md` — appended confidence gate section
- `.claude/agents/reviewer.md`, `.claude/commands/implement.md` — synced generated instances

## Test plan

- [ ] Verify `confidence-config.json` is valid JSON
- [ ] Verify reviewer.md has Confidence Scoring section in correct position
- [ ] Verify implement.md has Phase 4b-conf between 4b and 4b-sec
- [ ] Verify no broken placeholders in generated files
- [ ] Run `/implement` on a test feature to validate gate behavior

Closes #37

---
Implemented via `/implement` pipeline (architect → developer → reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)