### PR TITLE
feat: add specialized layer reviewers

### DIFF
--- a/.claude/agent-memory/architect/project_implement_pipeline.md
+++ b/.claude/agent-memory/architect/project_implement_pipeline.md
@@ -48,19 +48,30 @@ Error Handling
 
 ---
 
-## Pending pipeline change: security-reviewer agent (Issue #4)
+## Pending pipeline change: specialized-layer-reviewers (Issue #40)
 
-OpenSpec artifacts created at `openspec/changes/security-reviewer-agent/`.
+OpenSpec artifacts created at `openspec/changes/specialized-layer-reviewers/`.
 
 The planned Phase 4 structure after this change ships:
 ```
-4b.     Launch Reviewer agent (CI/quality gate)
-4b-sec. Launch Security Reviewer agent (security gate)
-4c.     Ship — blocked if SECURITY_BLOCKED=true
+4b.     Layer Dispatch and Review
+  Step 1: Layer Classification (orchestrator, no agent launch)
+  Step 2: Launch layer reviewers in parallel (run_in_background: true)
+          - frontend-reviewer (if FRONTEND_FILES non-empty)
+          - backend-reviewer  (if BACKEND_FILES non-empty)
+          - security-reviewer (always)
+  Step 3: Launch generalist reviewer (foreground) with layer reports injected
+[4b-sec removed — security-reviewer moves to 4b Step 2]
+4c.     Ship — SECURITY_BLOCKED gate stays here, unchanged
 4d.     Monitor CI
-4e.     Report (Security column added to table)
+4e.     Report (Frontend and Backend columns added to table)
 ```
 
-`SECURITY_STATUS:` (last line of security-reviewer output): `BLOCKED | WARNINGS | CLEAN`
+Status line protocols:
+- `FRONTEND_REVIEW_STATUS: ISSUES_FOUND | CLEAN` (last line)
+- `BACKEND_REVIEW_STATUS: ISSUES_FOUND | CLEAN` (last line)
+- `SECURITY_STATUS: BLOCKED | WARNINGS | CLEAN` (unchanged)
 
-New variable: `SECURITY_BLOCKED` — set from security-reviewer output, gates Phase 4c.
+Runtime injection notation for reviewer.md: use `[injected]` placeholder blocks, NOT `{{...}}` — avoids `/setup` mishandling.
+
+Layer classification: heuristic-based, matches on file extension + directory path segments. Files can be classified as both frontend and backend.

--- a/.claude/agent-memory/reviewer/MEMORY.md
+++ b/.claude/agent-memory/reviewer/MEMORY.md
@@ -2,6 +2,7 @@
 
 ## Reference
 - [common-fixes.md](common-fixes.md) — CI check false positives, variable quoting gotchas, install.sh patterns, generated-file sync gap
+- [placeholder-resolution-bug.md](placeholder-resolution-bug.md) — Broken placeholder substitution in resolved agent copies: `/setup`-time placeholders must be preserved verbatim in `.claude/agents/`, not replaced with wrong literals
 
 ## Known False Positives
 - File naming check: `find .claude/agents .claude/commands .claude/rules -name '*[A-Z]*'` matches directory names (e.g., `.claude/agents`), not just files — this is a false positive. Actual file names are all kebab-case.

--- a/.claude/agent-memory/reviewer/placeholder-resolution-bug.md
+++ b/.claude/agent-memory/reviewer/placeholder-resolution-bug.md
@@ -1,0 +1,13 @@
+---
+name: placeholder-resolution-bug
+description: Broken placeholder substitution in .claude/agents/ resolved copies — setup-time placeholders replaced with incorrect literal text instead of being preserved
+type: feedback
+---
+
+When new agent templates are created with `/setup`-time placeholders (e.g., `{{FRONTEND_STACK}}`, `{{BACKEND_STACK}}`), the `.claude/agents/` resolved copies must retain the `{{PLACEHOLDER}}` syntax verbatim. The `/setup` command fills them in against a real target repo at install time.
+
+In the specialized-layer-reviewers change (2026-03-14), both `frontend-reviewer.md` and `backend-reviewer.md` in `.claude/agents/` had their stack placeholders incorrectly replaced with "detected from codebase" instead of keeping the original `{{FRONTEND_STACK}}` / `{{BACKEND_STACK}}` tokens.
+
+**Why:** The CI placeholder check (`grep -r '{{[A-Z_]*}}' .claude/agents/`) normally catches *unexpected* placeholders that were never resolved. But for these new agents, the placeholders are *intentional* (resolved at `/setup` time). The failure mode is the opposite: placeholders being replaced with wrong literal text rather than being left in place.
+
+**How to apply:** When reviewing new agent templates that define `/setup`-time placeholders, verify the resolved copies in `.claude/agents/` preserve those exact `{{PLACEHOLDER}}` tokens. Check the `specializing in` or other identity-sentence lines specifically — these are the most common place for placeholder substitution to go wrong.

--- a/.claude/agents/backend-reviewer.md
+++ b/.claude/agents/backend-reviewer.md
@@ -1,0 +1,139 @@
+---
+name: backend-reviewer
+description: "Use this agent when backend files have been modified. Scan-and-report only. Scans for N+1 query patterns, connection pool safety issues, pagination safety problems, and missing database indexes. Do NOT use this agent to fix issues — it scans and reports only.
+
+Examples:
+
+- Example 1:
+  user: (orchestrator) Backend files were modified. Run backend layer review.
+  assistant: \"Launching the backend-reviewer agent to scan modified backend files for N+1, connection pool, pagination, and index issues.\"
+
+- Example 2:
+  user: (orchestrator) Phase 4b Step 2: launch layer reviewers in parallel.
+  assistant: \"I'll launch the backend-reviewer agent to perform the backend layer scan.\""
+model: sonnet
+color: purple
+memory: project
+---
+
+You are a backend code auditor specializing in {{BACKEND_STACK}}. You scan backend files for N+1 query patterns, connection pool safety issues, pagination safety problems, and missing database indexes. You produce a structured findings report — you never fix code, never suggest code changes, and never ask for clarification.
+
+## Your Mission
+
+- Scan every file in BACKEND_FILES_LIST for the issues defined below
+- Produce a structured report with a finding table per check category
+- Set BACKEND_REVIEW_STATUS as the final line of your output
+
+## What You Receive
+
+The orchestrator injects two inputs into your invocation prompt:
+
+- **BACKEND_FILES_LIST**: the list of backend files created or modified during this implementation run. Scan every file in this list.
+- **PIPELINE_CONTEXT**: a brief description of what was implemented — feature names and change names. Use this for context when assessing findings.
+
+## N+1 Queries
+
+Look for patterns where queries are issued inside loops or per-item resolution. These cause exponential database load under real traffic.
+
+| Pattern | Languages | Severity |
+|---------|-----------|----------|
+| ORM `.find()`, `.get()`, `.filter()`, or `.findOne()` calls inside `for`, `forEach`, or `.map()` loops | Python/Django, Ruby/Rails, JavaScript/TypeScript | High |
+| `await db.query()` or `await Model.find()` inside an `async` `for` loop or `for...of` loop | Node.js/TypeScript | High |
+| Multiple sequential `SELECT` statements where a `JOIN` or `IN (...)` would suffice (look for comment patterns or variable names like `userIds.forEach` followed by individual selects) | SQL context | High |
+| Missing `.select_related()` or `.prefetch_related()` on a relationship that is accessed in a loop (Django ORM) | Python | Medium |
+| Missing `.includes()` on a relationship that is accessed in a loop (Rails/ActiveRecord) | Ruby | Medium |
+
+## Connection Pool Safety
+
+Scan for patterns where database connections may be leaked or held longer than necessary.
+
+| Pattern | What to look for | Severity |
+|---------|-----------------|----------|
+| Connection not released in error paths | `conn = db.connect()` or equivalent without a corresponding `conn.close()` or `conn.release()` in a `finally` block or `with` statement | High |
+| Connection passed as function argument | Connection objects passed as parameters across function boundaries, increasing the risk of holding connections across `await` points | Medium |
+| Pool size not configured | A new database client or pool is instantiated without explicit pool size configuration (e.g., `new Pool()` without `max` option) | Medium |
+
+## Pagination Safety
+
+Scan API handlers and data access functions for queries that could return unbounded result sets.
+
+| Pattern | What to look for | Severity |
+|---------|-----------------|----------|
+| Unbounded queries | `findAll()`, `.all()`, `SELECT *`, or equivalent without a `LIMIT`/`OFFSET` or cursor in a context that is exposed via an API handler or returns data to a client | High |
+| Missing total count | Paginated responses that lack a total count field, preventing clients from knowing how many pages exist | Medium |
+| Offset pagination without index | Offset-based pagination (`OFFSET N`) on large tables where the sort column lacks an index (cross-reference migration files to check for index presence) | Medium |
+
+## Missing Indexes
+
+Scan migration files and raw SQL for index omissions that will cause full table scans under load.
+
+| Pattern | What to look for | Severity |
+|---------|-----------------|----------|
+| FK constraint without index | `FOREIGN KEY` constraint added on a referencing column that has no corresponding index | High |
+| WHERE clause column without index | Columns used in `WHERE` clauses in new queries that lack an index — cross-reference migration files to confirm whether an index exists | Medium |
+| Unique constraint without unique index | A unique constraint added in a migration that omits the corresponding explicit unique index (flag if DB migration syntax may not auto-create one) | Medium |
+
+## Output Format
+
+Produce exactly this report structure:
+
+```
+## Backend Review Results
+
+### N+1 Queries
+| File | Line | Pattern | Severity |
+|------|------|---------|----------|
+(rows or "None")
+
+### Connection Pool Safety
+| File | Finding | Severity |
+|------|---------|----------|
+(rows or "None")
+
+### Pagination Safety
+| File | Finding | Severity |
+|------|---------|----------|
+(rows or "None")
+
+### Missing Indexes
+| File | Finding | Severity |
+|------|---------|----------|
+(rows or "None")
+
+---
+BACKEND_REVIEW_STATUS: ISSUES_FOUND
+```
+
+Set the `BACKEND_REVIEW_STATUS:` value as follows:
+- `ISSUES_FOUND` — one or more High or Medium findings exist across any category
+- `CLEAN` — no findings in any category
+
+The status line MUST be the very last line of your output. Nothing may follow it.
+
+## Rules
+
+- Never fix code. Never suggest code changes. Scan and report only.
+- Never ask for clarification. Complete the scan with available information.
+- Always scan every file in BACKEND_FILES_LIST.
+- Always emit the `BACKEND_REVIEW_STATUS:` line as the very last line of output.
+- The `BACKEND_REVIEW_STATUS:` line MUST be the very last line of your output. Nothing may follow it.
+
+# Persistent Agent Memory
+
+You have a persistent agent memory directory at `.claude/agent-memory/backend-reviewer/`. Its contents persist across conversations.
+
+As you work, consult your memory files to build on previous experience.
+
+Guidelines:
+- `MEMORY.md` is always loaded — keep it under 200 lines
+- Create separate topic files for detailed notes and link to them from MEMORY.md
+- Update or remove memories that turn out to be wrong or outdated
+
+What to save:
+- False positive patterns you discovered in this repo's backend stack (patterns that look like N+1 or connection issues but are intentional or safe)
+- ORM or framework-specific patterns that produce false positives (e.g., lazy loading that is actually safe in this codebase's context)
+- Migration conventions specific to this repo that affect index detection
+
+## MEMORY.md
+
+Your MEMORY.md is currently empty.

--- a/.claude/agents/frontend-reviewer.md
+++ b/.claude/agents/frontend-reviewer.md
@@ -1,0 +1,132 @@
+---
+name: frontend-reviewer
+description: "Use this agent when frontend files have been modified. Scan-and-report only. Scans for bundle size regressions, accessibility violations (WCAG 2.1 AA), and render performance issues. Do NOT use this agent to fix issues — it scans and reports only.
+
+Examples:
+
+- Example 1:
+  user: (orchestrator) Frontend files were modified. Run frontend layer review.
+  assistant: \"Launching the frontend-reviewer agent to scan modified frontend files for bundle, accessibility, and render issues.\"
+
+- Example 2:
+  user: (orchestrator) Phase 4b Step 2: launch layer reviewers in parallel.
+  assistant: \"I'll launch the frontend-reviewer agent to perform the frontend layer scan.\""
+model: sonnet
+color: blue
+memory: project
+---
+
+You are a frontend code auditor specializing in {{FRONTEND_STACK}}. You scan frontend files for bundle size regressions, accessibility violations, and render performance problems. You produce a structured findings report — you never fix code, never suggest code changes, and never ask for clarification.
+
+## Your Mission
+
+- Scan every file in FRONTEND_FILES_LIST for the issues defined below
+- Produce a structured report with a finding table per check category
+- Set FRONTEND_REVIEW_STATUS as the final line of your output
+
+## What You Receive
+
+The orchestrator injects two inputs into your invocation prompt:
+
+- **FRONTEND_FILES_LIST**: the list of frontend files created or modified during this implementation run. Scan every file in this list.
+- **PIPELINE_CONTEXT**: a brief description of what was implemented — feature names and change names. Use this for context when assessing findings.
+
+## Bundle Size
+
+Look for signals of bundle size regression in the modified files.
+
+| Pattern | What to look for | Severity |
+|---------|-----------------|----------|
+| Dynamic imports without chunk naming | New `import()` calls that lack a `/* webpackChunkName: "..." */` hint | Medium |
+| Large static assets without compression | Images or fonts added without evidence of compression or lazy loading | Medium |
+| Heavy library synchronous imports | New synchronous imports of moment.js, full lodash (without tree-shaking path like `lodash/get`), or similarly large libraries in components in the critical rendering path | High |
+| Unused CSS classes | A class defined in a modified CSS/SCSS file that is not referenced in any modified component file in this changeset | Medium |
+
+Severity: High if a known heavy library (moment.js, full lodash, etc.) is added synchronously. Medium for all other bundle signals.
+
+## Accessibility
+
+Scan all `.html`, `.htm`, `.jsx`, `.tsx`, `.vue`, and `.svelte` files for WCAG 2.1 AA violations.
+
+| Rule | What to look for | File types | Severity |
+|------|-----------------|------------|----------|
+| Missing alt text | `<img>` tags without an `alt` attribute | `.html`, `.htm`, `.jsx`, `.tsx`, `.vue`, `.svelte` | High |
+| Missing form labels | `<input>` elements without an associated `<label>` element or `aria-label` attribute | `.html`, `.htm`, `.jsx`, `.tsx`, `.vue`, `.svelte` | High |
+| Non-semantic interactive elements | `<div>` or `<span>` with an `onClick` handler but no `role` attribute and no `tabIndex` | `.jsx`, `.tsx`, `.vue`, `.svelte` | High |
+| Missing ARIA roles | Custom interactive patterns (sliders, dropdowns, modals) without appropriate ARIA attributes | `.html`, `.htm`, `.jsx`, `.tsx`, `.vue`, `.svelte` | Medium |
+| Low contrast (static) | Hard-coded color pairs where the contrast ratio is estimably below 4.5:1 — flag for manual review, not auto-detectable with certainty | `.css`, `.scss`, `.sass`, `.less` | Medium |
+| Missing landmark regions | Pages or top-level components that lack `<main>`, `<nav>`, `<header>`, or equivalent ARIA landmark roles | `.html`, `.htm`, `.jsx`, `.tsx`, `.vue`, `.svelte` | Medium |
+| Missing page title | `<title>` absent or empty in modified HTML files or page-level components | `.html`, `.htm`, `.jsx`, `.tsx` | Medium |
+
+For the low contrast rule: flag the color pair and note "requires manual review" — do not assert a violation without confirmation.
+
+## Render Performance
+
+Scan modified files for patterns that degrade rendering speed.
+
+| Pattern | What to look for | Severity |
+|---------|-----------------|----------|
+| Render-blocking scripts | `<script>` tags in `<head>` without `async` or `defer` attributes | High |
+| Synchronous data fetching in render path | `useEffect` with an empty dependency array (`[]`) that `await`s an API call without throttling or debouncing | Medium |
+| Missing key props on list renders | `.map()` calls in JSX/TSX/Vue templates that render elements without a `key` prop | High |
+| Missing memoization on hot-path derived values | Expensive computed values (filtering, sorting, transforming large arrays) in component render scope without `memo`, `useMemo`, or `computed` | Medium |
+
+## Output Format
+
+Produce exactly this report structure:
+
+```
+## Frontend Review Results
+
+### Bundle Size
+| File | Finding | Severity |
+|------|---------|----------|
+(rows or "None")
+
+### Accessibility
+| File | Line | Rule | Severity |
+|------|------|------|----------|
+(rows or "None")
+
+### Render Performance
+| File | Finding | Severity |
+|------|---------|----------|
+(rows or "None")
+
+---
+FRONTEND_REVIEW_STATUS: ISSUES_FOUND
+```
+
+Set the `FRONTEND_REVIEW_STATUS:` value as follows:
+- `ISSUES_FOUND` — one or more High or Medium findings exist across any category
+- `CLEAN` — no findings in any category
+
+The status line MUST be the very last line of your output. Nothing may follow it.
+
+## Rules
+
+- Never fix code. Never suggest code changes. Scan and report only.
+- Never ask for clarification. Complete the scan with available information.
+- Always scan every file in FRONTEND_FILES_LIST.
+- Always emit the `FRONTEND_REVIEW_STATUS:` line as the very last line of output.
+- The `FRONTEND_REVIEW_STATUS:` line MUST be the very last line of your output. Nothing may follow it.
+
+# Persistent Agent Memory
+
+You have a persistent agent memory directory at `.claude/agent-memory/frontend-reviewer/`. Its contents persist across conversations.
+
+As you work, consult your memory files to build on previous experience.
+
+Guidelines:
+- `MEMORY.md` is always loaded — keep it under 200 lines
+- Create separate topic files for detailed notes and link to them from MEMORY.md
+- Update or remove memories that turn out to be wrong or outdated
+
+What to save:
+- False positive patterns you discovered in this repo's frontend stack (patterns that look like violations but are not)
+- File paths or naming patterns that commonly trigger false positives in this repo
+- Framework-specific idioms that are safe but resemble the patterns flagged by accessibility or performance checks
+
+## MEMORY.md
+
+Your MEMORY.md is currently empty.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -50,6 +50,23 @@ The CI pipeline runs these checks. You MUST run ALL of them in this exact order:
 - Shell scripts may behave differently on Linux vs macOS (check `sed`, `grep` flags)
 - Template placeholders must be checked in generated output, NOT in template source files
 
+## Layer Review Findings (injected at runtime by orchestrator)
+
+The orchestrator runs specialized layer reviewers in parallel before you launch. Their reports are injected here. A value of `"SKIPPED"` means no files of that layer type were in the changeset.
+
+**These are NOT `/setup` placeholders. They use `[injected]` notation, not `{{...}}` notation.** The `[injected]` markers below are replaced by the actual report text when the orchestrator launches you.
+
+FRONTEND_REVIEW_REPORT:
+[injected]
+
+BACKEND_REVIEW_REPORT:
+[injected]
+
+SECURITY_REVIEW_REPORT:
+[injected]
+
+---
+
 ## Review Checklist
 
 After running CI checks, also review for:
@@ -124,6 +141,15 @@ When done, produce this report:
 ### Issues Fixed
 - [list of issues found and how they were fixed]
 
+### Layer Review Summary
+| Layer | Status | Finding Count | Notable Issues |
+|-------|--------|--------------|----------------|
+| Frontend | CLEAN / ISSUES_FOUND / SKIPPED | N | ... |
+| Backend | CLEAN / ISSUES_FOUND / SKIPPED | N | ... |
+| Security | CLEAN / WARNINGS / BLOCKED / SKIPPED | N | ... |
+
+[List any High or Critical findings from layer reviews that warrant attention]
+
 ### Files Modified by Reviewer
 - [list of files the reviewer had to touch]
 ```
@@ -134,6 +160,7 @@ When done, produce this report:
 - Always run ALL checks, even if you think nothing changed in a layer.
 - When fixing lint errors, understand the rule before applying a fix — don't just suppress with disable comments.
 - If a test fails, read the test AND the implementation to understand the root cause before fixing.
+- If a layer reviewer reports High severity findings, include them in your Issues Fixed or Issues Found section. Attempt to fix High-severity layer findings that are straightforward (e.g., adding a missing `alt` attribute, adding a missing `LIMIT` to a query). Flag Critical or architecturally complex findings for human review — do NOT attempt to fix them automatically.
 
 ## Explain Your Work
 

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -411,13 +411,77 @@ git worktree remove <worktree-path> --force
 
 Pass `MERGE_REPORT` to the Phase 4b reviewer agent prompt, listing any files in `requires_resolution`.
 
-### 4b. Launch Reviewer agent
+### 4b. Layer Dispatch and Review
 
-Launch a single **reviewer** agent to validate ALL merged changes. Include:
+#### Step 1: Layer Classification
+
+Before launching any reviewer, classify `MODIFIED_FILES_LIST` into layer-specific file sets.
+
+**Frontend files** — a file is frontend if any of these conditions match:
+- Extension is one of: `.jsx`, `.tsx`, `.vue`, `.svelte`, `.css`, `.scss`, `.sass`, `.less`, `.html`, `.htm`
+- Extension is `.js` or `.ts` AND path contains one of: `components/`, `pages/`, `views/`, `ui/`, `client/`, `frontend/`, `app/`
+- Path starts with: `public/`, `static/`, `assets/`
+
+Set `FRONTEND_FILES` = files matching frontend rules.
+
+**Backend files** — a file is backend if any of these conditions match:
+- Extension is one of: `.py`, `.go`, `.java`, `.rb`, `.php`, `.rs`, `.cs`, `.sql`
+- Extension is `.js` or `.ts` AND path contains one of: `server/`, `api/`, `routes/`, `controllers/`, `services/`, `models/`, `db/`, `backend/`
+- Path is under: `migrations/`, `alembic/`, `db/migrate/`
+
+Set `BACKEND_FILES` = files matching backend rules.
+
+**Overlap rule:** a file may appear in both `FRONTEND_FILES` and `BACKEND_FILES` (e.g., a Next.js API route at `pages/api/`). Both reviewers will scan it independently.
+
+If `FRONTEND_FILES` is empty: set `FRONTEND_REVIEW_REPORT = "SKIPPED"` and skip frontend-reviewer launch. Note: "No frontend files detected."
+If `BACKEND_FILES` is empty: set `BACKEND_REVIEW_REPORT = "SKIPPED"` and skip backend-reviewer launch. Note: "No backend files detected."
+
+#### Step 2: Launch Layer Reviewers in Parallel
+
+Launch all applicable layer reviewers in parallel (`run_in_background: true`):
+
+**frontend-reviewer** (if `FRONTEND_FILES` is non-empty):
+- Pass `FRONTEND_FILES_LIST`: the list of files in `FRONTEND_FILES`
+- Pass `PIPELINE_CONTEXT`: brief description of what was implemented
+
+**backend-reviewer** (if `BACKEND_FILES` is non-empty):
+- Pass `BACKEND_FILES_LIST`: the list of files in `BACKEND_FILES`
+- Pass `PIPELINE_CONTEXT`: brief description of what was implemented
+
+**security-reviewer** (always):
+- Pass `MODIFIED_FILES_LIST`: the complete list of all files created or modified during this run
+- Pass `PIPELINE_CONTEXT`: brief description of what was implemented
+- Pass the exemptions config path: `.claude/security-exemptions.yaml`
+
+Wait for all launched layer reviewers to complete before proceeding to Step 3.
+
+Parse status lines from each completed reviewer:
+- `FRONTEND_REVIEW_STATUS: ISSUES_FOUND` or `CLEAN` → set `FRONTEND_STATUS`
+- `BACKEND_REVIEW_STATUS: ISSUES_FOUND` or `CLEAN` → set `BACKEND_STATUS`
+- `SECURITY_STATUS: BLOCKED | WARNINGS | CLEAN` → set `SECURITY_BLOCKED=true` if `BLOCKED`, otherwise `false`
+
+If a layer reviewer fails or times out: set the relevant report variable to `"ERROR: reviewer did not complete"` and continue.
+
+#### Step 3: Launch Generalist Reviewer
+
+Construct the generalist reviewer's invocation prompt with layer reports injected. Set each variable to the full output of the corresponding reviewer, or to the string `"SKIPPED"` if that reviewer was not launched:
+
+- `FRONTEND_REVIEW_REPORT`: full output of frontend-reviewer (or `"SKIPPED"`)
+- `BACKEND_REVIEW_REPORT`: full output of backend-reviewer (or `"SKIPPED"`)
+- `SECURITY_REVIEW_REPORT`: full output of security-reviewer
+
+Include in the reviewer prompt:
 - Full CI commands
 - Cross-feature merge issue checks
-- Record learnings to `common-fixes.md`
-- Archive completed changes via OpenSpec
+- Instruction to record learnings to `common-fixes.md`
+- Instruction to archive completed changes via OpenSpec
+- The three layer report variables substituted into the `[injected]` slots in the reviewer agent template
+
+Note: if total layer report length is very large, truncate each layer report to its findings tables only (omit skipped-file logs) to stay within prompt limits.
+
+**The security gate (blocking ship on `SECURITY_STATUS: BLOCKED`) is enforced in Phase 4c.** Do not apply it here.
+
+Launch the **reviewer** agent (foreground, `run_in_background: false`). Wait for it to complete.
 
 **If `DRY_RUN=true`**, add the following to the reviewer agent prompt:
 
@@ -428,7 +492,7 @@ Launch a single **reviewer** agent to validate ALL merged changes. Include:
 
 ### 4b-conf. Confidence Gate
 
-After the reviewer agent completes, evaluate the confidence score before launching the security reviewer.
+After the generalist reviewer agent completes, evaluate the confidence score before proceeding to Phase 4c.
 
 **In multi-feature mode (worktrees):** run this gate once per feature immediately after that feature's reviewer completes. Each feature is evaluated independently — a block on one feature does not prevent another feature's gate from running.
 
@@ -439,7 +503,7 @@ Path: `openspec/changes/<name>/confidence-score.json`
 - If the file does not exist:
   - Set `CONFIDENCE_STATUS=MISSING`
   - Print: `[confidence] Warning: confidence-score.json not found. Proceeding without gate.`
-  - Continue to Phase 4b-sec.
+  - Continue to Phase 4c.
 
 #### Step 2 — Read config
 
@@ -455,7 +519,7 @@ Path: `.claude/confidence-config.json`
 - If `enabled: false` in the config:
   - Print: `[confidence] Gate disabled. Skipping.`
   - Set `CONFIDENCE_STATUS=DISABLED`
-  - Continue to Phase 4b-sec.
+  - Continue to Phase 4c.
 
 #### Step 3 — Compare scores
 
@@ -468,7 +532,7 @@ Path: `.claude/confidence-config.json`
 **If no breaches:**
 - Print: `[confidence] All scores meet thresholds. Proceeding.`
 - Set `CONFIDENCE_STATUS=PASS`
-- Continue to Phase 4b-sec.
+- Continue to Phase 4c.
 
 **If breaches exist and `on_breach: "block"`:**
 
@@ -476,7 +540,7 @@ Path: `.claude/confidence-config.json`
    - If `CONFIDENCE_OVERRIDE_REASON` is non-empty and `override_allowed: true` in the config:
      - Print: `[confidence] Override accepted. Reason: <CONFIDENCE_OVERRIDE_REASON>. Proceeding with gate bypassed.`
      - Set `CONFIDENCE_STATUS=OVERRIDE`
-     - Continue to Phase 4b-sec.
+     - Continue to Phase 4c.
    - If `CONFIDENCE_OVERRIDE_REASON` is non-empty but `override_allowed: false` in the config:
      - Print: `[confidence] Override is disabled in confidence-config.json.`
      - (Fall through to block below.)
@@ -484,12 +548,12 @@ Path: `.claude/confidence-config.json`
      - Print the Breach Report (see format below).
      - Set `CONFIDENCE_BLOCKED=true`
      - Set `CONFIDENCE_STATUS=BLOCKED`
-     - **Halt: do not proceed to Phase 4b-sec or Phase 4c.**
+     - **Halt: do not proceed to Phase 4c.**
 
 **If breaches exist and `on_breach: "warn"`:**
 - Print the Breach Report.
 - Set `CONFIDENCE_STATUS=WARN`
-- Continue to Phase 4b-sec.
+- Continue to Phase 4c.
 
 #### Breach Report Format
 
@@ -525,22 +589,8 @@ Pipeline halted. No git operations have been performed.
 
 When `DRY_RUN=true`, the reviewer still writes `confidence-score.json` (it is an OpenSpec artifact, not a git artifact). Phase 4b-conf still evaluates the score. If `CONFIDENCE_BLOCKED=true`, add to `.cache-manifest.json` under `skipped_operations`:
 ```
-"confidence-gate: blocked — Phase 4c and 4b-sec skipped"
+"confidence-gate: blocked — Phase 4c skipped"
 ```
-
-### 4b-sec. Launch Security Reviewer agent
-
-After the reviewer agent completes, launch a **security-reviewer** agent (`subagent_type: security-reviewer`).
-
-Construct the agent invocation prompt to include:
-- **MODIFIED_FILES_LIST**: the complete list of files created or modified during this implementation run
-- **PIPELINE_CONTEXT**: brief description — feature names and change names implemented
-- The exemptions config path: `.claude/security-exemptions.yaml`
-
-Wait for the security-reviewer to complete. Parse the final line of its output:
-- `SECURITY_STATUS: BLOCKED` → set `SECURITY_BLOCKED=true`
-- `SECURITY_STATUS: WARNINGS` → set `SECURITY_BLOCKED=false`, capture warning summary
-- `SECURITY_STATUS: CLEAN` → set `SECURITY_BLOCKED=false`
 
 ### 4c. Ship — Git & backlog updates
 
@@ -671,8 +721,8 @@ rm -rf .claude/.dry-run/<feature-name>/
 **Otherwise**, show the standard pipeline table:
 
 ```
-| Area | Feature | Change Name | Architect | Developer | Tests | Docs | Reviewer | Confidence | Security | CI | Status |
-|------|---------|-------------|-----------|-----------|-------|------|----------|------------|----------|----|--------|
+| Area | Feature | Change Name | Architect | Developer | Tests | Docs | Reviewer | Frontend | Backend | Confidence | Security | CI | Status |
+|------|---------|-------------|-----------|-----------|-------|------|----------|----------|---------|------------|----------|----|--------|
 ```
 
 Confidence column values:
@@ -693,6 +743,11 @@ If `CONFIDENCE_OVERRIDE_REASON` is non-empty, append a `### Confidence Override`
 
 **Reason:** <CONFIDENCE_OVERRIDE_REASON>
 ```
+
+Column values:
+- **Frontend**: `CLEAN`, `ISSUES`, or `SKIPPED` (no frontend files in changeset)
+- **Backend**: `CLEAN`, `ISSUES`, or `SKIPPED` (no backend files in changeset)
+- **Security**: `CLEAN`, `WARNINGS`, `BLOCKED`, or `SKIPPED`
 
 If `MERGE_REPORT.requires_resolution` is non-empty, print an additional section:
 

--- a/openspec/changes/archive/2026-03-14-specialized-layer-reviewers/context-bundle.md
+++ b/openspec/changes/archive/2026-03-14-specialized-layer-reviewers/context-bundle.md
@@ -1,0 +1,240 @@
+---
+change: specialized-layer-reviewers
+type: context-bundle
+---
+
+# Context Bundle: Specialized Layer Reviewers
+
+Everything a developer needs to implement this change without asking questions. Read this entire document before starting any task.
+
+---
+
+## What You Are Building
+
+Three new or modified agent templates that introduce specialized code review for frontend and backend layers. The generalist reviewer (`reviewer.md`) gains the ability to receive and synthesize specialist reports. The `/implement` pipeline is updated to launch layer reviewers in parallel before the generalist reviewer makes its pass/fail decision.
+
+This is a pure Markdown template change. No new build tooling, no scripts, no configuration files. The implementation medium is: write Markdown, following existing agent template conventions.
+
+---
+
+## Current State (Before This Change)
+
+### `/implement` Phase 4b (current)
+
+```
+Phase 4b: Launch single generalist reviewer (foreground)
+Phase 4b-sec: Launch security-reviewer (sequential, after generalist reviewer)
+```
+
+The security-reviewer runs AFTER the generalist reviewer has already fixed issues and produced its report. This means the security scan happens on already-reviewed code, which is good, but it adds sequential latency and is architecturally disconnected from the review process.
+
+### Reviewer agent (current)
+
+`templates/agents/reviewer.md` is self-contained. It runs CI checks, fixes issues, and produces a report with three sections: CI Checks, Issues Fixed, Files Modified. It has no concept of other reviewers or specialist inputs.
+
+### Security reviewer (current)
+
+`templates/agents/security-reviewer.md` is mature and fully specified. Its output protocol (`SECURITY_STATUS:` terminal line) is the model for the new layer reviewers. Study it carefully — the frontend and backend reviewers must follow the same conventions.
+
+---
+
+## Files to Read Before Starting
+
+These are the files you must read and understand before writing any code:
+
+1. `/Users/javi/repos/specrails/templates/agents/security-reviewer.md` — the canonical scan-and-report agent pattern. Frontend and backend reviewers mirror its structure exactly.
+
+2. `/Users/javi/repos/specrails/templates/agents/reviewer.md` — the generalist reviewer you will modify. Understand the existing output format before adding to it.
+
+3. `/Users/javi/repos/specrails/templates/agents/frontend-developer.md` — shows what `{{FRONTEND_STACK}}`, `{{FRONTEND_TECH_LIST}}`, and `{{FRONTEND_EXPERTISE}}` look like in a frontend agent context. Informs naming conventions.
+
+4. `/Users/javi/repos/specrails/templates/agents/backend-developer.md` — same, for backend context.
+
+5. `/Users/javi/repos/specrails/.claude/commands/implement.md` — the current, fully-resolved implement pipeline. You will modify both this file AND the template version.
+
+6. `/Users/javi/repos/specrails/templates/commands/implement.md` — the template version with `{{PLACEHOLDER}}` tokens. Modify this in parallel with the resolved version.
+
+7. `openspec/changes/specialized-layer-reviewers/design.md` — the authoritative check specifications. Do not invent checks or patterns beyond what is documented there.
+
+8. `openspec/changes/specialized-layer-reviewers/delta-spec.md` — the normative classification rules and behavioral contracts. The file classification logic in T11 must match section 4 exactly.
+
+---
+
+## Agent Template Conventions
+
+All agent templates in `templates/agents/` follow this structure. Deviate only if the design explicitly requires it.
+
+### Frontmatter
+
+```yaml
+---
+name: agent-name-in-kebab-case
+description: "Use this agent when... (orchestrator instruction). Examples: ..."
+model: sonnet
+color: <color>
+memory: project
+---
+```
+
+The `description` field is what Claude reads when deciding whether to launch this agent. It must start with "Use this agent when..." and include 1-2 examples in the format shown in `security-reviewer.md`.
+
+### Color convention (from existing agents)
+
+- `red` — reviewer (generalist)
+- `orange` — security-reviewer
+- `blue` — frontend agents
+- `purple` — backend agents
+- `green` — (unused, available)
+
+New assignments:
+- `frontend-reviewer` → `blue` (consistent with `frontend-developer`)
+- `backend-reviewer` → `purple` (consistent with `backend-developer`)
+
+### Memory section
+
+Every agent ends with a Persistent Agent Memory section. Copy this section from `security-reviewer.md` and adapt the "What to save" bullet points for the new agent's domain.
+
+### Placeholder naming
+
+`{{UPPER_SNAKE_CASE}}` for all `/setup`-time placeholders. The two new placeholders are:
+- `{{FRONTEND_STACK}}` — e.g., `React 18 + TypeScript + Vite`
+- `{{BACKEND_STACK}}` — e.g., `Node.js 20 + Express + PostgreSQL 15`
+
+Runtime injections (values passed by the orchestrator at agent launch, not resolved by `/setup`) use `[injected]` notation, NOT `{{...}}` notation. This is critical — see T9.
+
+---
+
+## The Status Line Protocol
+
+This is the most important convention for the new agents. Study how `security-reviewer.md` implements it, then mirror it exactly:
+
+1. The status line is the **very last line** of the agent's output.
+2. It is formatted as: `KEY: VALUE` with no trailing whitespace or newlines.
+3. The orchestrator parses it by reading the final line of the agent's output.
+4. Nothing may follow the status line.
+
+For the new agents:
+- `FRONTEND_REVIEW_STATUS: ISSUES_FOUND` or `FRONTEND_REVIEW_STATUS: CLEAN`
+- `BACKEND_REVIEW_STATUS: ISSUES_FOUND` or `BACKEND_REVIEW_STATUS: CLEAN`
+
+The `security-reviewer.md` Rules section has: "The `SECURITY_STATUS:` line MUST be the very last line of your output. Nothing may follow it." Use the exact same wording, adapted for the new status key name.
+
+---
+
+## Phase 4b Restructuring: Exact Changes
+
+### Before (current `implement.md` Phase 4b and 4b-sec)
+
+```
+### 4b. Launch Reviewer agent
+
+Launch a single reviewer agent to validate ALL merged changes. Include:
+- Full CI commands
+- Cross-feature merge issue checks
+- Record learnings to common-fixes.md
+- Archive completed changes via OpenSpec
+
+[... dry-run instructions ...]
+
+### 4b-sec. Launch Security Reviewer agent
+
+After the reviewer agent completes, launch a security-reviewer agent...
+
+[... SECURITY_STATUS parsing, SECURITY_BLOCKED variable ...]
+```
+
+### After (new Phase 4b structure)
+
+```
+### 4b. Layer Dispatch and Review
+
+#### Step 1: Layer Classification
+
+[enumerate FRONTEND_FILES and BACKEND_FILES using classification rules from delta-spec.md section 4]
+
+#### Step 2: Launch Layer Reviewers in Parallel
+
+[launch frontend-reviewer (if applicable), backend-reviewer (if applicable), security-reviewer]
+[wait for all to complete]
+[parse status lines: FRONTEND_STATUS, BACKEND_STATUS, SECURITY_BLOCKED]
+
+#### Step 3: Launch Generalist Reviewer
+
+[construct prompt with layer reports injected]
+[launch reviewer (foreground)]
+
+[Note: Phase 4b-sec is removed. Security gate enforced in Phase 4c.]
+```
+
+The security gate logic (`if SECURITY_BLOCKED=true: stop, print findings, skip to Phase 4e`) stays in Phase 4c exactly where it is. Do not move it; just remove the reference to Phase 4b-sec as its source.
+
+---
+
+## What NOT to Change
+
+- Do not touch `install.sh`. New agent templates are picked up automatically via `cp -r "$SCRIPT_DIR/templates/"*` in the installer.
+- Do not modify the `/setup` command. Stack detection is already built into `/setup`'s codebase analysis. The new placeholders (`{{FRONTEND_STACK}}`, `{{BACKEND_STACK}}`) are resolved by the same mechanism that resolves `{{FRONTEND_STACK}}` in `frontend-developer.md`, which already exists.
+- Do not modify `security-reviewer.md`. Its output contract is unchanged. It moves position in the pipeline (from Phase 4b-sec to Phase 4b Step 2) but its template content does not change.
+- Do not add a `delta-spec.md` field for the `/setup` command changes. Stack detection is an implementation detail of `/setup`, not a new spec.
+
+---
+
+## Exact Changes Summary (for conflict detection)
+
+| File | Operation | Regions modified |
+|------|-----------|-----------------|
+| `templates/agents/frontend-reviewer.md` | Create | entire file |
+| `templates/agents/backend-reviewer.md` | Create | entire file |
+| `templates/agents/reviewer.md` | Modify | after `## CI/CD Pipeline Equivalence` section (insert Layer Review Findings); inside `## Output Format` (insert Layer Review Summary table); inside `## Rules` (insert one rule) |
+| `templates/commands/implement.md` | Modify | `### 4b.` section (rewrite); `### 4b-sec.` section (remove); Phase 4e report table (add 2 columns) |
+| `.claude/commands/implement.md` | Modify | same regions as template |
+
+---
+
+## Verification Approach
+
+The design calls for test fixtures (T16, T17). Here is the convention:
+
+- Create fixtures under `test-fixtures/<feature-name>/`
+- These are temporary — delete them after verification
+- Do not commit test fixtures
+- The fixture files should be minimal: 20-40 lines, containing exactly the patterns you need to verify
+
+For T16 (`Button.jsx`), the file needs:
+```jsx
+// missing alt on img
+<img src="icon.png" />
+
+// non-semantic interactive (no role)
+<div onClick={handleClick}>Click me</div>
+
+// heavy import
+import moment from 'moment';
+```
+
+For T17 (`users.js`), the file needs:
+```js
+// N+1: query inside async loop
+for (const id of userIds) {
+  const user = await db.query('SELECT * FROM users WHERE id = $1', [id]);
+}
+
+// Unbounded query
+const allUsers = await User.findAll();
+```
+
+---
+
+## Open Questions (Resolved)
+
+**Q: Should layer reviewers be able to block the pipeline?**
+A: No. Only the generalist reviewer and the security-reviewer's SECURITY_STATUS: BLOCKED gate can stop the pipeline. Layer findings are advisory inputs to the generalist reviewer, which makes the final call.
+
+**Q: What if both frontend and backend reviewers find the same file has issues?**
+A: Both report independently. The generalist reviewer sees both reports and synthesizes. There is no deduplication requirement — the generalist applies judgment.
+
+**Q: How does the orchestrator handle a layer reviewer that crashes or times out?**
+A: Set the relevant report to `"ERROR: reviewer did not complete"` and continue. The generalist reviewer is launched with that placeholder in place of the report. The generalist notes the failure in its Layer Review Summary (status: ERROR).
+
+**Q: Should `{{FRONTEND_STACK}}` and `{{BACKEND_STACK}}` be required or optional in `/setup`?**
+A: Optional with a safe default. If `/setup` cannot detect the stack, it uses `"detected from codebase"`. This is already the convention for other stack placeholders in `frontend-developer.md` and `backend-developer.md`.

--- a/openspec/changes/archive/2026-03-14-specialized-layer-reviewers/delta-spec.md
+++ b/openspec/changes/archive/2026-03-14-specialized-layer-reviewers/delta-spec.md
@@ -1,0 +1,131 @@
+---
+change: specialized-layer-reviewers
+type: delta-spec
+---
+
+# Delta Spec: Specialized Layer Reviewers
+
+This document describes what changes in the system's specification as a result of this feature. It is the authoritative record of spec drift — every item here reflects a new behavioral contract that future changes must respect.
+
+---
+
+## 1. New Agents
+
+### `templates/agents/frontend-reviewer.md` (new)
+
+**Behavioral contract:**
+
+- Identity: scan-and-report only. Never fixes code, never asks for clarification.
+- Inputs: `FRONTEND_FILES_LIST`, `PIPELINE_CONTEXT`, resolves `{{FRONTEND_STACK}}` and `{{MEMORY_PATH}}` at `/setup` time.
+- Checks performed: bundle size signals, accessibility (WCAG 2.1 AA subset), render performance patterns.
+- Output: structured findings report ending with `FRONTEND_REVIEW_STATUS: ISSUES_FOUND` or `FRONTEND_REVIEW_STATUS: CLEAN` as the very last line.
+- Status line protocol: identical to `security-reviewer`'s `SECURITY_STATUS:` protocol (last line, no trailing content).
+- Memory: persistent agent memory at `{{MEMORY_PATH}}`, same conventions as other agents.
+
+### `templates/agents/backend-reviewer.md` (new)
+
+**Behavioral contract:**
+
+- Identity: scan-and-report only. Never fixes code, never asks for clarification.
+- Inputs: `BACKEND_FILES_LIST`, `PIPELINE_CONTEXT`, resolves `{{BACKEND_STACK}}` and `{{MEMORY_PATH}}` at `/setup` time.
+- Checks performed: N+1 query patterns, connection pool safety, pagination safety, missing indexes.
+- Output: structured findings report ending with `BACKEND_REVIEW_STATUS: ISSUES_FOUND` or `BACKEND_REVIEW_STATUS: CLEAN` as the very last line.
+- Status line protocol: same as `security-reviewer`.
+- Memory: persistent agent memory at `{{MEMORY_PATH}}`.
+
+---
+
+## 2. Modified Agents
+
+### `templates/agents/reviewer.md` (modified)
+
+**Additions:**
+
+- Receives three new inputs at runtime (injected by orchestrator): `FRONTEND_REVIEW_REPORT`, `BACKEND_REVIEW_REPORT`, `SECURITY_REVIEW_REPORT`. Any may be the string `"SKIPPED"`.
+- New "Layer Review Summary" table in the output format (required field in every review report).
+- New rule: High-severity layer findings may be attempted as fixes; Critical/complex findings are flagged only.
+
+**No removals.** All existing behavior (CI checks, fix-and-retry loop, existing output format) is preserved.
+
+---
+
+## 3. Modified Pipeline (`templates/commands/implement.md` and `.claude/commands/implement.md`)
+
+### Phase 4b — Layer Dispatch (new structure)
+
+**Before:**
+- Phase 4b: Launch single generalist reviewer (foreground).
+- Phase 4b-sec: Launch security-reviewer (sequential, after generalist reviewer).
+
+**After:**
+- Phase 4b, Step 1: Orchestrator classifies `MODIFIED_FILES_LIST` into `FRONTEND_FILES` and `BACKEND_FILES` using heuristic rules.
+- Phase 4b, Step 2: Launch layer reviewers in parallel (`run_in_background: true`):
+  - `frontend-reviewer` (if `FRONTEND_FILES` non-empty)
+  - `backend-reviewer` (if `BACKEND_FILES` non-empty)
+  - `security-reviewer` (always)
+  Wait for all to complete. Parse status lines.
+- Phase 4b, Step 3: Launch generalist reviewer (foreground) with layer reports injected.
+- Phase 4b-sec: **Removed.** Security reviewer now runs in Phase 4b Step 2.
+
+**`SECURITY_BLOCKED` gate logic:** Moves from Phase 4b-sec to Phase 4c (unchanged behavior — still blocks git/PR operations if `SECURITY_STATUS: BLOCKED`).
+
+### Phase 4e Report Table
+
+**Before:** `| ... | Reviewer | Security | CI | Status |`
+
+**After:** `| ... | Reviewer | Frontend | Backend | Security | CI | Status |`
+
+New column values:
+- `CLEAN` — layer reviewer ran and found no issues
+- `ISSUES` — layer reviewer found issues (details in reviewer report)
+- `SKIPPED` — no files of this type were in the changeset
+
+---
+
+## 4. File Classification Spec (new, part of pipeline spec)
+
+Layer classification rules are now a defined part of the `/implement` pipeline spec. The following is normative:
+
+### Frontend classification
+
+A file is frontend if:
+- Extension is one of: `.jsx`, `.tsx`, `.vue`, `.svelte`, `.css`, `.scss`, `.sass`, `.less`, `.html`, `.htm`
+- OR extension is `.js` or `.ts` AND path contains one of: `components/`, `pages/`, `views/`, `ui/`, `client/`, `frontend/`, `app/`
+- OR path starts with: `public/`, `static/`, `assets/`
+
+### Backend classification
+
+A file is backend if:
+- Extension is one of: `.py`, `.go`, `.java`, `.rb`, `.php`, `.rs`, `.cs`, `.sql`
+- OR extension is `.js` or `.ts` AND path contains one of: `server/`, `api/`, `routes/`, `controllers/`, `services/`, `models/`, `db/`, `backend/`
+- OR path is under: `migrations/`, `alembic/`, `db/migrate/`
+
+### Overlap
+
+A file matching both frontend and backend rules appears in both lists. Both reviewers scan it.
+
+---
+
+## 5. New `/setup` Placeholders
+
+Two new placeholders are introduced for layer reviewer templates:
+
+| Placeholder | Used in | Resolved by |
+|-------------|---------|-------------|
+| `{{FRONTEND_STACK}}` | `frontend-reviewer.md` | `/setup` codebase analysis |
+| `{{BACKEND_STACK}}` | `backend-reviewer.md` | `/setup` codebase analysis |
+
+The `/setup` command must detect these stacks during its codebase analysis phase. Detection approach:
+- `FRONTEND_STACK`: check `package.json` dependencies for React, Vue, Angular, Svelte, Next.js, Nuxt; note version.
+- `BACKEND_STACK`: check for `requirements.txt` (Python), `go.mod` (Go), `pom.xml`/`build.gradle` (Java), `Gemfile` (Ruby), `Cargo.toml` (Rust); check for DB config files indicating PostgreSQL, MySQL, SQLite, MongoDB.
+
+If detection is ambiguous, `/setup` defaults to a generic description: `"detected from codebase"`.
+
+---
+
+## 6. Backward Compatibility
+
+- Target repos with no frontend files: frontend-reviewer is never launched. Pipeline behavior is identical to pre-change.
+- Target repos with no backend files: backend-reviewer is never launched. Pipeline behavior is identical to pre-change.
+- Target repos with neither: only the generalist reviewer and security-reviewer run. Net change: security-reviewer now runs in parallel with the generalist reviewer's setup step rather than sequentially after it (minor latency improvement only).
+- All existing `/setup` placeholder names are unchanged. The two new placeholders are additive.

--- a/openspec/changes/archive/2026-03-14-specialized-layer-reviewers/design.md
+++ b/openspec/changes/archive/2026-03-14-specialized-layer-reviewers/design.md
@@ -1,0 +1,382 @@
+---
+change: specialized-layer-reviewers
+type: design
+---
+
+# Design: Specialized Layer Reviewers
+
+## Overview
+
+Three layer reviewers run in parallel during Phase 4b of the `/implement` pipeline, before the generalist reviewer makes its pass/fail decision. The generalist reviewer receives all layer reports as input and synthesizes them into its final output.
+
+```
+Phase 4a: Merge
+     |
+     v
+Phase 4b: Layer Dispatch (parallel)
+     ├── frontend-reviewer  (if frontend files detected)
+     ├── backend-reviewer   (if backend files detected)
+     └── security-reviewer  (always, already exists)
+     |
+     v
+Phase 4b: Generalist Reviewer
+     (receives all layer findings, runs CI, produces final report)
+     |
+     v
+Phase 4c: Ship
+```
+
+---
+
+## Layer Classification
+
+File classification runs inside the `/implement` pipeline orchestrator at the start of Phase 4b, before any reviewer launches. The orchestrator scans `MODIFIED_FILES_LIST` and partitions it into three sets:
+
+### Frontend Files
+
+A file is classified as frontend if it matches any of:
+
+- Extension: `.jsx`, `.tsx`, `.vue`, `.svelte`, `.css`, `.scss`, `.sass`, `.less`
+- Extension: `.html`, `.htm`
+- Extension: `.js` or `.ts` AND path contains any of: `components/`, `pages/`, `views/`, `ui/`, `client/`, `frontend/`, `app/`
+- Path starts with: `public/`, `static/`, `assets/`
+
+### Backend Files
+
+A file is classified as backend if it matches any of:
+
+- Extension: `.py`, `.go`, `.java`, `.rb`, `.php`, `.rs`, `.cs`
+- Extension: `.js` or `.ts` AND path contains any of: `server/`, `api/`, `routes/`, `controllers/`, `services/`, `models/`, `db/`, `backend/`
+- SQL files: `.sql`
+- ORM/migration files: paths under `migrations/`, `alembic/`, `db/migrate/`
+
+### Classification Rules
+
+- A file can be classified as both frontend AND backend (e.g., a Next.js API route at `pages/api/`).
+- Files matching neither category are reviewed only by the generalist and security reviewers.
+- If `FRONTEND_FILES` is empty: skip frontend-reviewer, note "No frontend files detected."
+- If `BACKEND_FILES` is empty: skip backend-reviewer, note "No backend files detected."
+
+---
+
+## Frontend Reviewer Agent (`templates/agents/frontend-reviewer.md`)
+
+### Identity and Role
+
+The frontend-reviewer is a scan-and-report agent. It never fixes code. It produces a structured findings report with a single-line status code as its last line of output.
+
+### Inputs (injected by orchestrator)
+
+- `FRONTEND_FILES_LIST`: files classified as frontend
+- `PIPELINE_CONTEXT`: brief description of what was implemented
+- `FRONTEND_STACK`: detected from target repo (placeholder resolved at `/setup` time)
+
+### Checks
+
+**1. Bundle Size**
+
+Look for signals of bundle size regression:
+- New dynamic `import()` calls that lack chunk naming hints (`/* webpackChunkName: */`)
+- Large static assets (images, fonts) added without compression or lazy loading
+- New synchronous imports of heavy libraries (moment.js, lodash without tree-shaking, etc.) in components that are in the critical rendering path
+- Presence of unused CSS classes (flag if a class defined in modified CSS is not referenced in modified component files)
+
+Severity: High if a known heavy library is added synchronously; Medium for other signals.
+
+**2. Accessibility (WCAG 2.1 AA)**
+
+Scan all HTML, JSX, TSX, Vue, and Svelte files for:
+
+| Rule | What to look for | Severity |
+|------|-----------------|----------|
+| Missing alt text | `<img>` without `alt` attribute | High |
+| Missing form labels | `<input>` without associated `<label>` or `aria-label` | High |
+| Non-semantic interactive elements | `<div>` or `<span>` with `onClick` but no `role` or `tabIndex` | High |
+| Missing ARIA roles | Custom interactive patterns without appropriate ARIA attributes | Medium |
+| Low contrast (static) | Hard-coded color pairs where contrast ratio is estimably below 4.5:1 (flag for manual review) | Medium |
+| Missing landmark regions | Pages without `<main>`, `<nav>`, `<header>` or equivalent ARIA landmarks | Medium |
+| Missing page title | `<title>` absent or empty in modified HTML/page-level components | Medium |
+
+**3. Render Performance**
+
+- Render-blocking scripts: `<script>` tags without `async` or `defer` in `<head>`
+- Synchronous data fetching in component render paths (e.g., `useEffect` with empty deps that awaits unthrottled API calls)
+- Missing `key` props on list renders in React/Vue templates
+- Missing `memo`/`useMemo`/`computed` on expensive derived values in hot paths
+
+### Output Format
+
+```
+## Frontend Review Results
+
+### Bundle Size
+| File | Finding | Severity |
+|------|---------|----------|
+(rows or "None")
+
+### Accessibility
+| File | Line | Rule | Severity |
+|------|------|------|----------|
+(rows or "None")
+
+### Render Performance
+| File | Finding | Severity |
+|------|---------|----------|
+(rows or "None")
+
+---
+FRONTEND_REVIEW_STATUS: ISSUES_FOUND | CLEAN
+```
+
+`FRONTEND_REVIEW_STATUS: ISSUES_FOUND` if any High or Medium finding exists.
+`FRONTEND_REVIEW_STATUS: CLEAN` if no findings.
+
+The status line MUST be the very last line of output.
+
+### Placeholders
+
+| Placeholder | Resolved at | Description |
+|-------------|-------------|-------------|
+| `{{FRONTEND_STACK}}` | `/setup` | Detected frontend framework (e.g., "React 18 + TypeScript") |
+| `{{MEMORY_PATH}}` | `/setup` | Agent memory directory path |
+
+---
+
+## Backend Reviewer Agent (`templates/agents/backend-reviewer.md`)
+
+### Identity and Role
+
+The backend-reviewer is a scan-and-report agent. It never fixes code. It produces a structured findings report with a single-line status code as its last line of output.
+
+### Inputs (injected by orchestrator)
+
+- `BACKEND_FILES_LIST`: files classified as backend
+- `PIPELINE_CONTEXT`: brief description of what was implemented
+- `BACKEND_STACK`: detected from target repo (placeholder resolved at `/setup` time)
+
+### Checks
+
+**1. N+1 Query Detection**
+
+Look for patterns where queries are issued inside loops or per-item resolution:
+
+| Pattern | Languages | Severity |
+|---------|-----------|----------|
+| ORM `.find()`, `.get()`, `.filter()` calls inside `for`/`forEach`/`.map()` | Python/Django, Ruby/Rails, JS/TypeScript | High |
+| `await db.query()` or `await Model.find()` inside an async loop | Node.js/TypeScript | High |
+| Multiple sequential `SELECT` statements where a `JOIN` or `IN (...)` would suffice (look for comment patterns or variable names like `user_ids.forEach`) | SQL context | High |
+| Missing `.select_related()` or `.prefetch_related()` on relationships accessed in a loop (Django) | Python | Medium |
+| Missing `.includes()` on relationships accessed in a loop (Rails/ActiveRecord) | Ruby | Medium |
+
+**2. Connection Pool Safety**
+
+- Database connections acquired but not released in error paths (look for `conn = db.connect()` without corresponding `conn.close()` in a finally block)
+- Connection objects passed as function arguments (increases risk of holding connections across await boundaries)
+- Pool size not configured (flag if a new DB client is instantiated without pool configuration)
+
+**3. Pagination Safety**
+
+- Unbounded queries: `findAll()`, `.all()`, `SELECT *` without `LIMIT`/`OFFSET` or cursor in an API handler
+- Missing total count for paginated responses (pagination without telling the client how many pages exist)
+- Offset-based pagination on large tables without an index on the sort column
+
+**4. Missing Indexes**
+
+Scan migration files and raw SQL for:
+- `FOREIGN KEY` constraints added without a corresponding index on the referencing column
+- Columns added to a `WHERE` clause in a new query that lack an index (cross-reference migration files)
+- Unique constraints added without a corresponding unique index (flag if DB migration syntax omits it)
+
+### Output Format
+
+```
+## Backend Review Results
+
+### N+1 Queries
+| File | Line | Pattern | Severity |
+|------|------|---------|----------|
+(rows or "None")
+
+### Connection Pool Safety
+| File | Finding | Severity |
+|------|---------|----------|
+(rows or "None")
+
+### Pagination Safety
+| File | Finding | Severity |
+|------|---------|----------|
+(rows or "None")
+
+### Missing Indexes
+| File | Finding | Severity |
+|------|---------|----------|
+(rows or "None")
+
+---
+BACKEND_REVIEW_STATUS: ISSUES_FOUND | CLEAN
+```
+
+`BACKEND_REVIEW_STATUS: ISSUES_FOUND` if any High or Medium finding exists.
+`BACKEND_REVIEW_STATUS: CLEAN` if no findings.
+
+The status line MUST be the very last line of output.
+
+### Placeholders
+
+| Placeholder | Resolved at | Description |
+|-------------|-------------|-------------|
+| `{{BACKEND_STACK}}` | `/setup` | Detected backend stack (e.g., "Node.js + PostgreSQL") |
+| `{{MEMORY_PATH}}` | `/setup` | Agent memory directory path |
+
+---
+
+## Generalist Reviewer Changes (`templates/agents/reviewer.md`)
+
+The generalist reviewer receives layer reports as additional input. Two sections are added to the template:
+
+### New Section: Layer Review Inputs
+
+Inserted after the existing "What You Receive" section (if present) or at the top of the workflow:
+
+```
+## Layer Review Findings (injected by orchestrator)
+
+The orchestrator runs specialized layer reviewers in parallel before you launch.
+Their reports are injected here:
+
+FRONTEND_REVIEW_REPORT:
+{{FRONTEND_REVIEW_REPORT}}
+
+BACKEND_REVIEW_REPORT:
+{{BACKEND_REVIEW_REPORT}}
+
+SECURITY_REVIEW_REPORT:
+{{SECURITY_REVIEW_REPORT}}
+
+A value of "SKIPPED" means no files of that type were modified.
+```
+
+These are runtime variables injected by the orchestrator at launch time, not `/setup`-time placeholders. The `{{...}}` syntax is used here as orchestrator substitution tokens, not template placeholders. The developer implementing this must document this distinction clearly in the template.
+
+### New Section: Report Synthesis
+
+Added to the "Output Format" section of reviewer.md, after the existing `### Issues Fixed` table:
+
+```
+### Layer Review Summary
+| Layer | Status | Finding Count | Notable Issues |
+|-------|--------|--------------|----------------|
+| Frontend | CLEAN / ISSUES_FOUND / SKIPPED | N | ... |
+| Backend  | CLEAN / ISSUES_FOUND / SKIPPED | N | ... |
+| Security | CLEAN / WARNINGS / BLOCKED / SKIPPED | N | ... |
+
+[List any High or Critical findings from layer reviews that warrant attention]
+```
+
+### Decision Influence
+
+Add a rule to the "Rules" section:
+
+> If a layer reviewer reports High severity findings, include them in the "Issues Fixed" or "Issues Found" section of your report. You may attempt to fix High-severity layer findings if they are straightforward (e.g., adding a missing `alt` attribute, adding a missing `LIMIT` to a query). Flag Critical or complex findings for human review — do NOT attempt to fix them automatically.
+
+---
+
+## Pipeline Changes (`templates/commands/implement.md`)
+
+### Phase 4b Rewrite
+
+The current Phase 4b launches a single reviewer agent. After this change, Phase 4b is split into two steps:
+
+**Step 1: Layer Classification (orchestrator, no agent launch)**
+
+```
+FRONTEND_FILES = [files from MODIFIED_FILES_LIST matching frontend rules]
+BACKEND_FILES  = [files from MODIFIED_FILES_LIST matching backend rules]
+
+if FRONTEND_FILES is empty: FRONTEND_REVIEW_REPORT = "SKIPPED"
+if BACKEND_FILES is empty: BACKEND_REVIEW_REPORT = "SKIPPED"
+```
+
+**Step 2: Launch Layer Reviewers in Parallel**
+
+For each non-empty layer:
+- Launch `frontend-reviewer` with `FRONTEND_FILES_LIST` and `PIPELINE_CONTEXT` (`run_in_background: true`)
+- Launch `backend-reviewer` with `BACKEND_FILES_LIST` and `PIPELINE_CONTEXT` (`run_in_background: true`)
+- The security-reviewer (currently in Phase 4b-sec) is moved to run in parallel with the other layer reviewers in this step
+
+Wait for all layer reviewers to complete. Parse their status lines.
+
+**Step 3: Launch Generalist Reviewer**
+
+Construct the generalist reviewer's invocation prompt with layer reports injected:
+- `FRONTEND_REVIEW_REPORT`: full output of frontend-reviewer (or "SKIPPED")
+- `BACKEND_REVIEW_REPORT`: full output of backend-reviewer (or "SKIPPED")
+- `SECURITY_REVIEW_REPORT`: full output of security-reviewer
+
+Launch the generalist reviewer (foreground, waits for completion).
+
+**Phase 4b-sec is removed.** The security-reviewer is now launched in parallel at Step 2 above. The `SECURITY_BLOCKED` gate logic moves from Phase 4b-sec into Phase 4c (after the generalist reviewer completes), where it already belongs logically.
+
+### Pipeline Report Table Update
+
+The Phase 4e report table currently has a "Security" column. It gains two new columns:
+
+```
+| Area | Feature | Change Name | Architect | Developer | Tests | Docs | Reviewer | Frontend | Backend | Security | CI | Status |
+```
+
+---
+
+## Template Placeholder Reference
+
+### `frontend-reviewer.md` placeholders
+
+| Placeholder | Source | Example value |
+|-------------|--------|---------------|
+| `{{FRONTEND_STACK}}` | `/setup` codebase analysis | `React 18 + TypeScript + Vite` |
+| `{{MEMORY_PATH}}` | `/setup` standard | `.claude/agent-memory/frontend-reviewer` |
+
+### `backend-reviewer.md` placeholders
+
+| Placeholder | Source | Example value |
+|-------------|--------|---------------|
+| `{{BACKEND_STACK}}` | `/setup` codebase analysis | `Node.js 20 + PostgreSQL 15` |
+| `{{MEMORY_PATH}}` | `/setup` standard | `.claude/agent-memory/backend-reviewer` |
+
+### `reviewer.md` runtime injections (NOT `/setup` placeholders)
+
+These tokens appear in reviewer.md but are substituted by the orchestrator at runtime, not by `/setup`. They must use a distinct notation to avoid confusion with template placeholders. The convention is to use all-caps variable names surrounded by `--- BEGIN/END ---` blocks rather than `{{...}}` syntax. See T3 for the exact notation decision.
+
+---
+
+## Design Decisions and Rationale
+
+**Decision 1: Layer reviewers are scan-only, generalist reviewer fixes.**
+
+Keeping fixing in one place (the generalist reviewer) ensures there is a single pass of CI verification after any modifications. If each layer reviewer could fix code independently, we would need to re-run CI after each one, and the order of fixes could create conflicts.
+
+**Decision 2: Layer reviewers run in parallel with each other and with the security-reviewer.**
+
+All three layer reviewers are stateless readers — they scan files and produce reports. No write ordering is required. Parallelism reduces total pipeline time by the time of the slowest layer reviewer (typically security, which scans the full modified file set).
+
+**Decision 3: Security-reviewer moves from Phase 4b-sec to Phase 4b parallel step.**
+
+The sequential positioning of the security-reviewer (run after the generalist reviewer) was an implementation detail of early pipeline versions, not a logical requirement. Moving it to run in parallel with the other layer reviewers reduces pipeline latency and simplifies Phase 4b-sec into a no-op that can be removed.
+
+**Decision 4: Layer classification is heuristic, not configuration-driven.**
+
+Configuration-driven classification (e.g., a `specrails.yaml` that maps directories to layers) adds friction for target repos. Heuristic classification based on file extensions and directory names covers 90%+ of real-world project structures without setup. Edge cases produce at most an unnecessary layer reviewer run (cost: a few seconds), not incorrect classification.
+
+**Decision 5: `{{FRONTEND_STACK}}` and `{{BACKEND_STACK}}` are the only new `/setup` placeholders.**
+
+The stack descriptions are the only per-repo facts needed. Everything else in the layer reviewer templates is domain knowledge that does not vary by repo. This keeps the `/setup` analysis burden minimal.
+
+---
+
+## Risks
+
+**False positives in layer classification:** A TypeScript file in `src/utils/` containing both frontend and backend logic will be classified as backend only (since it lacks frontend path markers). Findings from backend-reviewer about it may seem irrelevant. Mitigation: the generalist reviewer can dismiss irrelevant findings.
+
+**Layer reviewer prompt length:** Injecting all three layer reports into the generalist reviewer's prompt increases token usage. For large changesets with many findings, this could approach context limits. Mitigation: truncate each layer report to its findings tables only (omit the skipped files log) when injecting into the generalist reviewer.
+
+**`{{BACKEND_STACK}}` and `{{FRONTEND_STACK}}` detection accuracy:** The `/setup` command must correctly identify the stack. If it produces a generic or wrong value, the layer reviewer prompts are slightly less accurate (they name a different stack) but still function — the checks are pattern-based, not stack-dependent.

--- a/openspec/changes/archive/2026-03-14-specialized-layer-reviewers/proposal.md
+++ b/openspec/changes/archive/2026-03-14-specialized-layer-reviewers/proposal.md
@@ -1,0 +1,68 @@
+---
+change: specialized-layer-reviewers
+type: feature
+status: proposed
+github_issue: 40
+vpc_fit: 78%
+---
+
+# Proposal: Specialized Layer Reviewers
+
+## Problem
+
+The current reviewer agent (`templates/agents/reviewer.md`) is a generalist. It runs CI checks, applies broad code quality rules, and produces a pass/fail decision — but it reviews all code through a single lens. This works well for catching CI failures and obvious quality issues, but it systematically misses problems that require deep domain expertise.
+
+Three categories of issues consistently escape generalist review:
+
+**Security:** Subtle vulnerabilities — SQL injection through ORM misuse, JWT algorithm confusion, path traversal in utility functions — require pattern-matching knowledge that goes beyond checking for hardcoded secrets. The existing `security-reviewer` agent covers secrets and basic OWASP patterns, but it is positioned as an add-on rather than an integrated gate.
+
+**Frontend:** Bundle size regressions, accessibility failures (missing ARIA roles, insufficient color contrast), and render-blocking resource patterns are invisible to a reviewer that runs the same CI checks as the backend. Frontend code quality is defined by metrics the generalist cannot compute.
+
+**Backend:** N+1 query patterns, connection pool exhaustion, missing database indexes, and unbounded pagination are architectural problems that appear in perfectly CI-passing code. A generalist reviewer has no framework for recognizing these patterns specifically.
+
+The result: code ships that is green in CI, passes the generalist reviewer, and later causes a production incident or accessibility audit failure.
+
+## Solution
+
+Extend the `/implement` pipeline to dispatch specialized layer reviews in parallel before the generalist reviewer makes its pass/fail decision.
+
+Three new agent templates are introduced:
+
+- `templates/agents/frontend-reviewer.md` — reviews frontend-layer changes for bundle size, accessibility (WCAG 2.1 AA), and render performance.
+- `templates/agents/backend-reviewer.md` — reviews backend-layer changes for N+1 query patterns, connection pool usage, pagination safety, and missing indexes.
+- `templates/agents/security-reviewer.md` — the existing agent is promoted and standardized to integrate as a first-class parallel reviewer rather than a sequential afterthought.
+
+The generalist reviewer (`reviewer.md`) is updated to receive and synthesize the outputs from all three layer reviewers before making its final pass/fail decision. This synthesis step is purely additive — the generalist still runs CI and applies its own checks, but now has specialist findings as input.
+
+Layer classification is the key design decision. Each file in the modified set is classified by file extension and directory path. Classification is heuristic-based and runs inside the generalist reviewer's dispatch step — no separate classification agent is needed.
+
+## Non-Goals
+
+- This does not add a new `/review` command. Layer reviews are integrated into the existing `/implement` pipeline only.
+- This does not require agents to fix issues they find. Frontend and backend reviewers are scan-and-report only (matching the security-reviewer pattern). Only the generalist reviewer fixes issues.
+- This does not introduce per-layer pass/fail gates that can independently block the pipeline. Only the generalist reviewer sets the final pass/fail. Layer reviewer findings are advisory inputs.
+- This does not change the security-reviewer's SECURITY_STATUS protocol. Its output contract is unchanged.
+- This does not add configuration for which layers to enable. All three run whenever relevant files are detected. If no files match a layer, the reviewer is skipped.
+
+## Scope
+
+Files created:
+
+1. `templates/agents/frontend-reviewer.md` — new agent template
+2. `templates/agents/backend-reviewer.md` — new agent template
+
+Files modified:
+
+3. `templates/agents/reviewer.md` — adds a dispatch section for layer reviewers and a synthesis section for their reports
+4. `templates/commands/implement.md` — Phase 4b updated to launch layer reviewers in parallel before the generalist reviewer
+5. `.claude/commands/implement.md` — synchronized with template change (resolved version in specrails' own installation)
+
+## Success Criteria
+
+- After a frontend-only change, the frontend-reviewer runs and its findings appear in the reviewer's final report.
+- After a backend-only change, the backend-reviewer runs; frontend-reviewer is skipped with a "no frontend files" notice.
+- After a mixed change, all three layer reviewers run in parallel.
+- The generalist reviewer's final report includes a "Layer Review Findings" section summarizing each specialist's output.
+- The generalist reviewer's pass/fail decision is informed by layer findings: a Critical frontend or backend finding causes the reviewer to flag the issue prominently (but the generalist still decides whether to block).
+- No `{{PLACEHOLDER}}` tokens remain unresolved in installed agent files after `/setup` runs.
+- The change is backward-compatible: target repos with no frontend or backend files continue to work correctly (layer reviewers are skipped, not errored).

--- a/openspec/changes/archive/2026-03-14-specialized-layer-reviewers/tasks.md
+++ b/openspec/changes/archive/2026-03-14-specialized-layer-reviewers/tasks.md
@@ -1,0 +1,400 @@
+---
+change: specialized-layer-reviewers
+type: tasks
+---
+
+# Tasks: Specialized Layer Reviewers
+
+Tasks are ordered sequentially unless stated otherwise. Each task depends on the one before it unless a different dependency is stated.
+
+---
+
+## T1 — Create `templates/agents/frontend-reviewer.md` skeleton [templates]
+
+**Description:**
+Create the file with frontmatter, identity statement, inputs section, and section headings for the three checks (Bundle Size, Accessibility, Render Performance). Do not fill in check logic yet — establish structure only. The skeleton must be a valid Claude Code agent file that can be loaded without errors.
+
+**Files:**
+- Create: `templates/agents/frontend-reviewer.md`
+
+**Acceptance criteria:**
+- File exists at correct path
+- YAML frontmatter present with: `name: frontend-reviewer`, `description`, `model: sonnet`, `color: blue`, `memory: project`
+- `description` field instructs orchestrator when to use this agent: "Use when frontend files have been modified. Scan-and-report only."
+- Inputs section lists: `FRONTEND_FILES_LIST`, `PIPELINE_CONTEXT`
+- Placeholders present and documented: `{{FRONTEND_STACK}}`, `{{MEMORY_PATH}}`
+- Section headings present: `## Bundle Size`, `## Accessibility`, `## Render Performance`, `## Output Format`, `## Rules`, `## Persistent Agent Memory`
+- File ends with the persistent agent memory section (matching pattern in `security-reviewer.md`)
+- No `{{PLACEHOLDER}}` tokens other than `{{FRONTEND_STACK}}` and `{{MEMORY_PATH}}`
+
+**Dependencies:** none
+
+---
+
+## T2 — Implement Bundle Size and Render Performance checks in `frontend-reviewer.md` [templates]
+
+**Description:**
+Fill in the `## Bundle Size` and `## Render Performance` sections with specific patterns to detect, as defined in `design.md`. Include a finding severity table for each section.
+
+**Files:**
+- Modify: `templates/agents/frontend-reviewer.md`
+
+**Acceptance criteria:**
+- `## Bundle Size` section covers all four patterns from `design.md`: dynamic imports without chunk naming, large static assets without compression, heavy library synchronous imports, unused CSS classes
+- Each pattern has a stated severity (High or Medium)
+- `## Render Performance` section covers all four patterns: render-blocking scripts, synchronous data fetching in useEffect, missing key props on list renders, missing memo/useMemo on hot-path derived values
+- Each pattern has a stated severity
+- Prose is in second-person imperative: "Look for...", "Flag if...", "Scan..."
+- No invented patterns beyond those in `design.md`
+
+**Dependencies:** T1
+
+---
+
+## T3 — Implement Accessibility check in `frontend-reviewer.md` [templates]
+
+**Description:**
+Fill in the `## Accessibility` section with the full WCAG 2.1 AA check table from `design.md`. Include file type scope (which file extensions each rule applies to).
+
+**Files:**
+- Modify: `templates/agents/frontend-reviewer.md`
+
+**Acceptance criteria:**
+- Accessibility section contains a table with columns: Rule | What to look for | File types | Severity
+- All seven rules from `design.md` are present: missing alt text, missing form labels, non-semantic interactive elements, missing ARIA roles, low contrast (static), missing landmark regions, missing page title
+- File type scope is stated for each rule (e.g., "`.html`, `.jsx`, `.tsx`, `.vue`")
+- Severities match `design.md`: missing alt, missing labels, non-semantic interactive = High; rest = Medium
+- Low contrast rule is correctly marked as "flag for manual review" (not auto-detectable)
+
+**Dependencies:** T2
+
+---
+
+## T4 — Implement output format and rules in `frontend-reviewer.md` [templates]
+
+**Description:**
+Fill in the `## Output Format` section with the exact report structure from `design.md`, and fill in the `## Rules` section. The output format must include the `FRONTEND_REVIEW_STATUS:` terminal line protocol.
+
+**Files:**
+- Modify: `templates/agents/frontend-reviewer.md`
+
+**Acceptance criteria:**
+- Output format matches `design.md` exactly: three finding tables (Bundle Size, Accessibility, Render Performance) followed by `FRONTEND_REVIEW_STATUS:` line
+- `FRONTEND_REVIEW_STATUS: ISSUES_FOUND` condition stated: any High or Medium finding
+- `FRONTEND_REVIEW_STATUS: CLEAN` condition stated: no findings
+- Rules section states: "Never fix code. Never suggest code changes. Scan and report only."
+- Rules section states: "The `FRONTEND_REVIEW_STATUS:` line MUST be the very last line of output. Nothing may follow it."
+- Rules section states: "Never ask for clarification. Complete the scan with available information."
+- Memory section follows the exact pattern from `security-reviewer.md` (what to save, guidelines)
+- What to save in memory: "false positive patterns for this repo's frontend stack", "file paths or naming patterns that commonly trigger false positives"
+
+**Dependencies:** T3
+
+---
+
+## T5 — Create `templates/agents/backend-reviewer.md` skeleton [templates]
+
+**Description:**
+Create the file with frontmatter, identity statement, inputs section, and section headings for the four checks (N+1 Queries, Connection Pool Safety, Pagination Safety, Missing Indexes). Establish structure only — do not fill check logic yet.
+
+**Files:**
+- Create: `templates/agents/backend-reviewer.md`
+
+**Acceptance criteria:**
+- File exists at correct path
+- YAML frontmatter: `name: backend-reviewer`, `description`, `model: sonnet`, `color: purple`, `memory: project`
+- `description` instructs orchestrator: "Use when backend files have been modified. Scan-and-report only."
+- Inputs section lists: `BACKEND_FILES_LIST`, `PIPELINE_CONTEXT`
+- Placeholders documented: `{{BACKEND_STACK}}`, `{{MEMORY_PATH}}`
+- Section headings: `## N+1 Queries`, `## Connection Pool Safety`, `## Pagination Safety`, `## Missing Indexes`, `## Output Format`, `## Rules`, `## Persistent Agent Memory`
+- No `{{PLACEHOLDER}}` tokens other than `{{BACKEND_STACK}}` and `{{MEMORY_PATH}}`
+
+**Dependencies:** none (can run in parallel with T1)
+
+---
+
+## T6 — Implement N+1 Queries and Connection Pool checks in `backend-reviewer.md` [templates]
+
+**Description:**
+Fill in the `## N+1 Queries` and `## Connection Pool Safety` sections with the patterns and severity tables from `design.md`.
+
+**Files:**
+- Modify: `templates/agents/backend-reviewer.md`
+
+**Acceptance criteria:**
+- N+1 section contains a table: Pattern | Languages | Severity
+- All five N+1 patterns from `design.md` are present (ORM inside loop, await inside async loop, sequential SELECTs, missing select_related Django, missing includes Rails)
+- Connection Pool section covers all three patterns: connections not released in error paths, connections passed as function arguments, pool size not configured
+- Severities match `design.md`
+- Prose is second-person imperative
+
+**Dependencies:** T5
+
+---
+
+## T7 — Implement Pagination Safety and Missing Indexes checks in `backend-reviewer.md` [templates]
+
+**Description:**
+Fill in the `## Pagination Safety` and `## Missing Indexes` sections from `design.md`.
+
+**Files:**
+- Modify: `templates/agents/backend-reviewer.md`
+
+**Acceptance criteria:**
+- Pagination section covers all three patterns: unbounded queries without LIMIT, missing total count, offset pagination on large tables without index
+- Missing Indexes section covers all three patterns: FK constraints without index, WHERE clause columns without index, unique constraints without explicit unique index
+- Each finding has a stated severity
+- Missing Indexes section notes to "cross-reference migration files" for WHERE clause pattern
+
+**Dependencies:** T6
+
+---
+
+## T8 — Implement output format and rules in `backend-reviewer.md` [templates]
+
+**Description:**
+Fill in `## Output Format` and `## Rules` in the backend-reviewer template. Mirror the status-line protocol from frontend-reviewer and security-reviewer for consistency.
+
+**Files:**
+- Modify: `templates/agents/backend-reviewer.md`
+
+**Acceptance criteria:**
+- Output format matches `design.md`: four finding tables followed by `BACKEND_REVIEW_STATUS:` line
+- `BACKEND_REVIEW_STATUS: ISSUES_FOUND` / `BACKEND_REVIEW_STATUS: CLEAN` conditions stated
+- Rules section matches frontend-reviewer rules pattern: never fix, never ask for clarification, status line must be last
+- Memory section follows same conventions as other reviewer agents
+- What to save in memory: "false positive patterns for this repo's backend stack", "ORM/framework-specific patterns that produce false positives"
+
+**Dependencies:** T7
+
+---
+
+## T9 — Update `templates/agents/reviewer.md` with layer input section [templates]
+
+**Description:**
+Add a new section to `reviewer.md` that documents the three layer report inputs the orchestrator injects at runtime. Use a notation that is visually distinct from `/setup`-time `{{PLACEHOLDER}}` tokens to avoid confusion.
+
+The runtime injection convention uses a delimited block at the top of the agent's "What You Receive" context (or a new "Layer Review Findings" section if that section does not exist):
+
+```
+## Layer Review Findings (injected at runtime by orchestrator)
+
+The following specialist reports have been completed before you launched.
+A value of "SKIPPED" means no files of that layer type were in the changeset.
+
+FRONTEND_REVIEW_REPORT:
+[injected]
+
+BACKEND_REVIEW_REPORT:
+[injected]
+
+SECURITY_REVIEW_REPORT:
+[injected]
+```
+
+The bracketed `[injected]` markers are replaced by the actual report text at orchestrator launch time. This notation is explicitly NOT `{{PLACEHOLDER}}` syntax to avoid `/setup` mishandling.
+
+**Files:**
+- Modify: `templates/agents/reviewer.md`
+
+**Acceptance criteria:**
+- New `## Layer Review Findings` section added to `reviewer.md`
+- Section explains that `[injected]` is replaced by the orchestrator at runtime
+- Section clearly states: "These are NOT `/setup` placeholders. They use `[injected]` notation, not `{{...}}` notation."
+- Three named slots present: `FRONTEND_REVIEW_REPORT`, `BACKEND_REVIEW_REPORT`, `SECURITY_REVIEW_REPORT`
+- Existing content of `reviewer.md` is preserved unchanged
+- Placement: immediately after the existing `## CI/CD Pipeline Equivalence` section, before `## Review Checklist`
+
+**Dependencies:** T4, T8 (both new agents must be designed before documenting their output slots)
+
+---
+
+## T10 — Update `templates/agents/reviewer.md` output format and rules [templates]
+
+**Description:**
+Add the "Layer Review Summary" table to the output format section, and add the layer-finding rule to the Rules section.
+
+**Files:**
+- Modify: `templates/agents/reviewer.md`
+
+**Acceptance criteria:**
+- Output format section now includes `### Layer Review Summary` table after `### Issues Fixed`:
+  - Columns: Layer | Status | Finding Count | Notable Issues
+  - Rows: Frontend, Backend, Security
+  - Status values documented: CLEAN, ISSUES_FOUND, SKIPPED (and for Security: CLEAN, WARNINGS, BLOCKED, SKIPPED)
+- Rules section gains one new rule: "If a layer reviewer reports High severity findings, include them in your Issues Fixed or Issues Found section. Attempt to fix High-severity layer findings that are straightforward. Flag Critical or architecturally complex findings for human review — do NOT attempt to fix them automatically."
+- All other rules in the existing Rules section are preserved
+
+**Dependencies:** T9
+
+---
+
+## T11 — Update `templates/commands/implement.md` Phase 4b: layer classification [templates]
+
+**Description:**
+Rewrite Phase 4b in `templates/commands/implement.md` to add Step 1 (layer classification) before the reviewer launch. Classification logic must exactly match the normative rules in `delta-spec.md`.
+
+**Files:**
+- Modify: `templates/commands/implement.md`
+
+**Acceptance criteria:**
+- Phase 4b now begins with `### Step 1: Layer Classification` before any agent launch
+- Frontend classification rules enumerated exactly as in `delta-spec.md` section 4
+- Backend classification rules enumerated exactly as in `delta-spec.md` section 4
+- Overlap rule stated: a file can appear in both lists
+- Empty list behavior stated: "if `FRONTEND_FILES` is empty, set `FRONTEND_REVIEW_REPORT = "SKIPPED"` and skip frontend-reviewer launch"
+- Same empty list rule for backend
+
+**Dependencies:** T10
+
+---
+
+## T12 — Update `templates/commands/implement.md` Phase 4b: parallel layer launch [templates]
+
+**Description:**
+Add Step 2 to Phase 4b: parallel launch of all applicable layer reviewers (including security-reviewer, which moves here from Phase 4b-sec). Document the status line parsing for each reviewer.
+
+**Files:**
+- Modify: `templates/commands/implement.md`
+
+**Acceptance criteria:**
+- Step 2 explicitly states: "Launch all applicable layer reviewers in parallel (`run_in_background: true`)"
+- frontend-reviewer launch: passes `FRONTEND_FILES_LIST` and `PIPELINE_CONTEXT`
+- backend-reviewer launch: passes `BACKEND_FILES_LIST` and `PIPELINE_CONTEXT`
+- security-reviewer launch: passes `MODIFIED_FILES_LIST`, `PIPELINE_CONTEXT`, exemptions path (unchanged from current Phase 4b-sec spec)
+- "Wait for all layer reviewers to complete before proceeding to Step 3" stated
+- Status line parsing specified for each:
+  - `FRONTEND_REVIEW_STATUS: ISSUES_FOUND` or `CLEAN` → set `FRONTEND_STATUS`
+  - `BACKEND_REVIEW_STATUS: ISSUES_FOUND` or `CLEAN` → set `BACKEND_STATUS`
+  - `SECURITY_STATUS: BLOCKED | WARNINGS | CLEAN` → set `SECURITY_BLOCKED` (true if BLOCKED)
+- Phase 4b-sec heading is removed (or explicitly marked as "Removed — see Phase 4b Step 2")
+
+**Dependencies:** T11
+
+---
+
+## T13 — Update `templates/commands/implement.md` Phase 4b: generalist reviewer launch [templates]
+
+**Description:**
+Add Step 3 to Phase 4b: launch the generalist reviewer with layer reports injected. Document how each layer report is passed in the prompt construction.
+
+**Files:**
+- Modify: `templates/commands/implement.md`
+
+**Acceptance criteria:**
+- Step 3 states: "Construct the generalist reviewer's invocation prompt with layer reports injected"
+- Prompt construction shows how `FRONTEND_REVIEW_REPORT`, `BACKEND_REVIEW_REPORT`, and `SECURITY_REVIEW_REPORT` are set (full report text or "SKIPPED")
+- Reviewer launch is foreground (no `run_in_background`)
+- `SECURITY_BLOCKED` gate logic: moved from Phase 4b-sec to Phase 4c. A comment or note in Phase 4b Step 3 states: "The security gate (blocking ship on SECURITY_STATUS: BLOCKED) is enforced in Phase 4c."
+- Note about prompt length: "If total layer report length exceeds reasonable prompt size, truncate each layer report to its findings tables only (omit skipped-file logs)"
+
+**Dependencies:** T12
+
+---
+
+## T14 — Update `templates/commands/implement.md` Phase 4e report table [templates]
+
+**Description:**
+Update the Phase 4e report table to include the two new layer review columns (Frontend and Backend). Update column documentation.
+
+**Files:**
+- Modify: `templates/commands/implement.md`
+
+**Acceptance criteria:**
+- Phase 4e table header updated to: `| ... | Reviewer | Frontend | Backend | Security | CI | Status |`
+- Column value legend updated: Frontend and Backend columns show `CLEAN`, `ISSUES`, or `SKIPPED`
+- No other changes to Phase 4e
+
+**Dependencies:** T13
+
+---
+
+## T15 — Sync `.claude/commands/implement.md` with template changes [core]
+
+**Description:**
+The specrails repo maintains its own resolved copy of `implement.md` at `.claude/commands/implement.md`. Apply the same Phase 4b, Phase 4b-sec, and Phase 4e changes made to the template in T11–T14 to the resolved copy. This is the version specrails uses to develop itself.
+
+**Files:**
+- Modify: `.claude/commands/implement.md`
+
+**Acceptance criteria:**
+- `.claude/commands/implement.md` contains the same Phase 4b restructuring as `templates/commands/implement.md`
+- Phase 4b-sec is removed
+- Phase 4e table includes Frontend and Backend columns
+- No `/setup` placeholder tokens remain unresolved (this file is already resolved)
+- Diff between resolved and template is only the expected placeholder substitutions (no structural divergence)
+
+**Dependencies:** T14
+
+---
+
+## T16 — Manual verification: frontend-reviewer in specrails repo [templates]
+
+**Description:**
+Verify the frontend-reviewer agent template works by running it manually against a sample set of frontend files. Since specrails itself has minimal frontend code, create a small test fixture with intentional issues and scan it.
+
+**Verification steps:**
+1. Create `test-fixtures/frontend-sample/Button.jsx` with: a missing `alt` attribute on an `<img>`, a `<div onClick={...}>` without `role`, and a `moment` import
+2. Launch the `frontend-reviewer` agent (via Claude Code) with `FRONTEND_FILES_LIST` pointing to the fixture file
+3. Verify the report includes: one High accessibility finding (missing alt), one High accessibility finding (non-semantic interactive), one Medium bundle size finding (moment import)
+4. Verify the last line of output is `FRONTEND_REVIEW_STATUS: ISSUES_FOUND`
+5. Delete test fixtures
+
+**Files:**
+- Create (temporary): `test-fixtures/frontend-sample/Button.jsx`
+
+**Acceptance criteria:**
+- All three findings detected (2 High accessibility, 1 Medium bundle)
+- `FRONTEND_REVIEW_STATUS: ISSUES_FOUND` is the last line
+- No `{{PLACEHOLDER}}` tokens appear in agent output (stack description is filled in)
+- Agent does not attempt to fix the code
+
+**Dependencies:** T4
+
+---
+
+## T17 — Manual verification: backend-reviewer in specrails repo [templates]
+
+**Description:**
+Verify the backend-reviewer agent template works by running it against a test fixture with intentional N+1 and pagination issues.
+
+**Verification steps:**
+1. Create `test-fixtures/backend-sample/users.js` with: a `for` loop containing `await db.query('SELECT ...')`, and a `findAll()` call without `LIMIT`
+2. Launch the `backend-reviewer` agent with `BACKEND_FILES_LIST` pointing to the fixture
+3. Verify report includes: one High N+1 finding, one High pagination finding
+4. Verify last line is `BACKEND_REVIEW_STATUS: ISSUES_FOUND`
+5. Delete test fixtures
+
+**Files:**
+- Create (temporary): `test-fixtures/backend-sample/users.js`
+
+**Acceptance criteria:**
+- Both findings detected
+- `BACKEND_REVIEW_STATUS: ISSUES_FOUND` is the last line
+- Agent does not fix the code
+
+**Dependencies:** T8
+
+---
+
+## T18 — Manual verification: full Phase 4b pipeline integration [core]
+
+**Description:**
+Verify the updated `/implement` pipeline correctly dispatches layer reviewers in parallel and injects their reports into the generalist reviewer.
+
+**Verification steps:**
+1. Run `/implement` with a dry-run on a test feature that touches both a `.jsx` file and a `.js` file in an `api/` path
+2. Confirm Phase 4b Step 1 log shows both `FRONTEND_FILES` and `BACKEND_FILES` non-empty
+3. Confirm Phase 4b Step 2 shows three agents launched in parallel
+4. Confirm Phase 4b Step 3 shows generalist reviewer launched with layer reports in its prompt
+5. Confirm Phase 4e report table includes Frontend and Backend columns with correct values
+
+**Files:** none (verification only)
+
+**Acceptance criteria:**
+- All three layer reviewers appear in pipeline output as parallel launches
+- Generalist reviewer prompt contains layer report content (visible in agent output)
+- Phase 4e table has 5 review columns (Reviewer, Frontend, Backend, Security, CI)
+- `SECURITY_BLOCKED` gate still works: a BLOCKED security finding prevents Phase 4c
+
+**Dependencies:** T15, T16, T17

--- a/templates/agents/backend-reviewer.md
+++ b/templates/agents/backend-reviewer.md
@@ -1,0 +1,139 @@
+---
+name: backend-reviewer
+description: "Use this agent when backend files have been modified. Scan-and-report only. Scans for N+1 query patterns, connection pool safety issues, pagination safety problems, and missing database indexes. Do NOT use this agent to fix issues — it scans and reports only.
+
+Examples:
+
+- Example 1:
+  user: (orchestrator) Backend files were modified. Run backend layer review.
+  assistant: \"Launching the backend-reviewer agent to scan modified backend files for N+1, connection pool, pagination, and index issues.\"
+
+- Example 2:
+  user: (orchestrator) Phase 4b Step 2: launch layer reviewers in parallel.
+  assistant: \"I'll launch the backend-reviewer agent to perform the backend layer scan.\""
+model: sonnet
+color: purple
+memory: project
+---
+
+You are a backend code auditor specializing in {{BACKEND_STACK}}. You scan backend files for N+1 query patterns, connection pool safety issues, pagination safety problems, and missing database indexes. You produce a structured findings report — you never fix code, never suggest code changes, and never ask for clarification.
+
+## Your Mission
+
+- Scan every file in BACKEND_FILES_LIST for the issues defined below
+- Produce a structured report with a finding table per check category
+- Set BACKEND_REVIEW_STATUS as the final line of your output
+
+## What You Receive
+
+The orchestrator injects two inputs into your invocation prompt:
+
+- **BACKEND_FILES_LIST**: the list of backend files created or modified during this implementation run. Scan every file in this list.
+- **PIPELINE_CONTEXT**: a brief description of what was implemented — feature names and change names. Use this for context when assessing findings.
+
+## N+1 Queries
+
+Look for patterns where queries are issued inside loops or per-item resolution. These cause exponential database load under real traffic.
+
+| Pattern | Languages | Severity |
+|---------|-----------|----------|
+| ORM `.find()`, `.get()`, `.filter()`, or `.findOne()` calls inside `for`, `forEach`, or `.map()` loops | Python/Django, Ruby/Rails, JavaScript/TypeScript | High |
+| `await db.query()` or `await Model.find()` inside an `async` `for` loop or `for...of` loop | Node.js/TypeScript | High |
+| Multiple sequential `SELECT` statements where a `JOIN` or `IN (...)` would suffice (look for comment patterns or variable names like `userIds.forEach` followed by individual selects) | SQL context | High |
+| Missing `.select_related()` or `.prefetch_related()` on a relationship that is accessed in a loop (Django ORM) | Python | Medium |
+| Missing `.includes()` on a relationship that is accessed in a loop (Rails/ActiveRecord) | Ruby | Medium |
+
+## Connection Pool Safety
+
+Scan for patterns where database connections may be leaked or held longer than necessary.
+
+| Pattern | What to look for | Severity |
+|---------|-----------------|----------|
+| Connection not released in error paths | `conn = db.connect()` or equivalent without a corresponding `conn.close()` or `conn.release()` in a `finally` block or `with` statement | High |
+| Connection passed as function argument | Connection objects passed as parameters across function boundaries, increasing the risk of holding connections across `await` points | Medium |
+| Pool size not configured | A new database client or pool is instantiated without explicit pool size configuration (e.g., `new Pool()` without `max` option) | Medium |
+
+## Pagination Safety
+
+Scan API handlers and data access functions for queries that could return unbounded result sets.
+
+| Pattern | What to look for | Severity |
+|---------|-----------------|----------|
+| Unbounded queries | `findAll()`, `.all()`, `SELECT *`, or equivalent without a `LIMIT`/`OFFSET` or cursor in a context that is exposed via an API handler or returns data to a client | High |
+| Missing total count | Paginated responses that lack a total count field, preventing clients from knowing how many pages exist | Medium |
+| Offset pagination without index | Offset-based pagination (`OFFSET N`) on large tables where the sort column lacks an index (cross-reference migration files to check for index presence) | Medium |
+
+## Missing Indexes
+
+Scan migration files and raw SQL for index omissions that will cause full table scans under load.
+
+| Pattern | What to look for | Severity |
+|---------|-----------------|----------|
+| FK constraint without index | `FOREIGN KEY` constraint added on a referencing column that has no corresponding index | High |
+| WHERE clause column without index | Columns used in `WHERE` clauses in new queries that lack an index — cross-reference migration files to confirm whether an index exists | Medium |
+| Unique constraint without unique index | A unique constraint added in a migration that omits the corresponding explicit unique index (flag if DB migration syntax may not auto-create one) | Medium |
+
+## Output Format
+
+Produce exactly this report structure:
+
+```
+## Backend Review Results
+
+### N+1 Queries
+| File | Line | Pattern | Severity |
+|------|------|---------|----------|
+(rows or "None")
+
+### Connection Pool Safety
+| File | Finding | Severity |
+|------|---------|----------|
+(rows or "None")
+
+### Pagination Safety
+| File | Finding | Severity |
+|------|---------|----------|
+(rows or "None")
+
+### Missing Indexes
+| File | Finding | Severity |
+|------|---------|----------|
+(rows or "None")
+
+---
+BACKEND_REVIEW_STATUS: ISSUES_FOUND
+```
+
+Set the `BACKEND_REVIEW_STATUS:` value as follows:
+- `ISSUES_FOUND` — one or more High or Medium findings exist across any category
+- `CLEAN` — no findings in any category
+
+The status line MUST be the very last line of your output. Nothing may follow it.
+
+## Rules
+
+- Never fix code. Never suggest code changes. Scan and report only.
+- Never ask for clarification. Complete the scan with available information.
+- Always scan every file in BACKEND_FILES_LIST.
+- Always emit the `BACKEND_REVIEW_STATUS:` line as the very last line of output.
+- The `BACKEND_REVIEW_STATUS:` line MUST be the very last line of your output. Nothing may follow it.
+
+# Persistent Agent Memory
+
+You have a persistent agent memory directory at `{{MEMORY_PATH}}`. Its contents persist across conversations.
+
+As you work, consult your memory files to build on previous experience.
+
+Guidelines:
+- `MEMORY.md` is always loaded — keep it under 200 lines
+- Create separate topic files for detailed notes and link to them from MEMORY.md
+- Update or remove memories that turn out to be wrong or outdated
+
+What to save:
+- False positive patterns you discovered in this repo's backend stack (patterns that look like N+1 or connection issues but are intentional or safe)
+- ORM or framework-specific patterns that produce false positives (e.g., lazy loading that is actually safe in this codebase's context)
+- Migration conventions specific to this repo that affect index detection
+
+## MEMORY.md
+
+Your MEMORY.md is currently empty.

--- a/templates/agents/frontend-reviewer.md
+++ b/templates/agents/frontend-reviewer.md
@@ -1,0 +1,132 @@
+---
+name: frontend-reviewer
+description: "Use this agent when frontend files have been modified. Scan-and-report only. Scans for bundle size regressions, accessibility violations (WCAG 2.1 AA), and render performance issues. Do NOT use this agent to fix issues — it scans and reports only.
+
+Examples:
+
+- Example 1:
+  user: (orchestrator) Frontend files were modified. Run frontend layer review.
+  assistant: \"Launching the frontend-reviewer agent to scan modified frontend files for bundle, accessibility, and render issues.\"
+
+- Example 2:
+  user: (orchestrator) Phase 4b Step 2: launch layer reviewers in parallel.
+  assistant: \"I'll launch the frontend-reviewer agent to perform the frontend layer scan.\""
+model: sonnet
+color: blue
+memory: project
+---
+
+You are a frontend code auditor specializing in {{FRONTEND_STACK}}. You scan frontend files for bundle size regressions, accessibility violations, and render performance problems. You produce a structured findings report — you never fix code, never suggest code changes, and never ask for clarification.
+
+## Your Mission
+
+- Scan every file in FRONTEND_FILES_LIST for the issues defined below
+- Produce a structured report with a finding table per check category
+- Set FRONTEND_REVIEW_STATUS as the final line of your output
+
+## What You Receive
+
+The orchestrator injects two inputs into your invocation prompt:
+
+- **FRONTEND_FILES_LIST**: the list of frontend files created or modified during this implementation run. Scan every file in this list.
+- **PIPELINE_CONTEXT**: a brief description of what was implemented — feature names and change names. Use this for context when assessing findings.
+
+## Bundle Size
+
+Look for signals of bundle size regression in the modified files.
+
+| Pattern | What to look for | Severity |
+|---------|-----------------|----------|
+| Dynamic imports without chunk naming | New `import()` calls that lack a `/* webpackChunkName: "..." */` hint | Medium |
+| Large static assets without compression | Images or fonts added without evidence of compression or lazy loading | Medium |
+| Heavy library synchronous imports | New synchronous imports of moment.js, full lodash (without tree-shaking path like `lodash/get`), or similarly large libraries in components in the critical rendering path | High |
+| Unused CSS classes | A class defined in a modified CSS/SCSS file that is not referenced in any modified component file in this changeset | Medium |
+
+Severity: High if a known heavy library (moment.js, full lodash, etc.) is added synchronously. Medium for all other bundle signals.
+
+## Accessibility
+
+Scan all `.html`, `.htm`, `.jsx`, `.tsx`, `.vue`, and `.svelte` files for WCAG 2.1 AA violations.
+
+| Rule | What to look for | File types | Severity |
+|------|-----------------|------------|----------|
+| Missing alt text | `<img>` tags without an `alt` attribute | `.html`, `.htm`, `.jsx`, `.tsx`, `.vue`, `.svelte` | High |
+| Missing form labels | `<input>` elements without an associated `<label>` element or `aria-label` attribute | `.html`, `.htm`, `.jsx`, `.tsx`, `.vue`, `.svelte` | High |
+| Non-semantic interactive elements | `<div>` or `<span>` with an `onClick` handler but no `role` attribute and no `tabIndex` | `.jsx`, `.tsx`, `.vue`, `.svelte` | High |
+| Missing ARIA roles | Custom interactive patterns (sliders, dropdowns, modals) without appropriate ARIA attributes | `.html`, `.htm`, `.jsx`, `.tsx`, `.vue`, `.svelte` | Medium |
+| Low contrast (static) | Hard-coded color pairs where the contrast ratio is estimably below 4.5:1 — flag for manual review, not auto-detectable with certainty | `.css`, `.scss`, `.sass`, `.less` | Medium |
+| Missing landmark regions | Pages or top-level components that lack `<main>`, `<nav>`, `<header>`, or equivalent ARIA landmark roles | `.html`, `.htm`, `.jsx`, `.tsx`, `.vue`, `.svelte` | Medium |
+| Missing page title | `<title>` absent or empty in modified HTML files or page-level components | `.html`, `.htm`, `.jsx`, `.tsx` | Medium |
+
+For the low contrast rule: flag the color pair and note "requires manual review" — do not assert a violation without confirmation.
+
+## Render Performance
+
+Scan modified files for patterns that degrade rendering speed.
+
+| Pattern | What to look for | Severity |
+|---------|-----------------|----------|
+| Render-blocking scripts | `<script>` tags in `<head>` without `async` or `defer` attributes | High |
+| Synchronous data fetching in render path | `useEffect` with an empty dependency array (`[]`) that `await`s an API call without throttling or debouncing | Medium |
+| Missing key props on list renders | `.map()` calls in JSX/TSX/Vue templates that render elements without a `key` prop | High |
+| Missing memoization on hot-path derived values | Expensive computed values (filtering, sorting, transforming large arrays) in component render scope without `memo`, `useMemo`, or `computed` | Medium |
+
+## Output Format
+
+Produce exactly this report structure:
+
+```
+## Frontend Review Results
+
+### Bundle Size
+| File | Finding | Severity |
+|------|---------|----------|
+(rows or "None")
+
+### Accessibility
+| File | Line | Rule | Severity |
+|------|------|------|----------|
+(rows or "None")
+
+### Render Performance
+| File | Finding | Severity |
+|------|---------|----------|
+(rows or "None")
+
+---
+FRONTEND_REVIEW_STATUS: ISSUES_FOUND
+```
+
+Set the `FRONTEND_REVIEW_STATUS:` value as follows:
+- `ISSUES_FOUND` — one or more High or Medium findings exist across any category
+- `CLEAN` — no findings in any category
+
+The status line MUST be the very last line of your output. Nothing may follow it.
+
+## Rules
+
+- Never fix code. Never suggest code changes. Scan and report only.
+- Never ask for clarification. Complete the scan with available information.
+- Always scan every file in FRONTEND_FILES_LIST.
+- Always emit the `FRONTEND_REVIEW_STATUS:` line as the very last line of output.
+- The `FRONTEND_REVIEW_STATUS:` line MUST be the very last line of your output. Nothing may follow it.
+
+# Persistent Agent Memory
+
+You have a persistent agent memory directory at `{{MEMORY_PATH}}`. Its contents persist across conversations.
+
+As you work, consult your memory files to build on previous experience.
+
+Guidelines:
+- `MEMORY.md` is always loaded — keep it under 200 lines
+- Create separate topic files for detailed notes and link to them from MEMORY.md
+- Update or remove memories that turn out to be wrong or outdated
+
+What to save:
+- False positive patterns you discovered in this repo's frontend stack (patterns that look like violations but are not)
+- File paths or naming patterns that commonly trigger false positives in this repo
+- Framework-specific idioms that are safe but resemble the patterns flagged by accessibility or performance checks
+
+## MEMORY.md
+
+Your MEMORY.md is currently empty.

--- a/templates/agents/reviewer.md
+++ b/templates/agents/reviewer.md
@@ -28,6 +28,23 @@ These are the most common reasons code passes locally but fails in CI:
 
 {{CI_KNOWN_GAPS}}
 
+## Layer Review Findings (injected at runtime by orchestrator)
+
+The orchestrator runs specialized layer reviewers in parallel before you launch. Their reports are injected here. A value of `"SKIPPED"` means no files of that layer type were in the changeset.
+
+**These are NOT `/setup` placeholders. They use `[injected]` notation, not `{{...}}` notation.** The `[injected]` markers below are replaced by the actual report text when the orchestrator launches you.
+
+FRONTEND_REVIEW_REPORT:
+[injected]
+
+BACKEND_REVIEW_REPORT:
+[injected]
+
+SECURITY_REVIEW_REPORT:
+[injected]
+
+---
+
 ## Review Checklist
 
 After running CI checks, also review for:
@@ -93,6 +110,15 @@ When done, produce this report:
 ### Issues Fixed
 - [list of issues found and how they were fixed]
 
+### Layer Review Summary
+| Layer | Status | Finding Count | Notable Issues |
+|-------|--------|--------------|----------------|
+| Frontend | CLEAN / ISSUES_FOUND / SKIPPED | N | ... |
+| Backend | CLEAN / ISSUES_FOUND / SKIPPED | N | ... |
+| Security | CLEAN / WARNINGS / BLOCKED / SKIPPED | N | ... |
+
+[List any High or Critical findings from layer reviews that warrant attention]
+
 ### Files Modified by Reviewer
 - [list of files the reviewer had to touch]
 ```
@@ -103,6 +129,7 @@ When done, produce this report:
 - Always run ALL checks, even if you think nothing changed in a layer.
 - When fixing lint errors, understand the rule before applying a fix — don't just suppress with disable comments.
 - If a test fails, read the test AND the implementation to understand the root cause before fixing.
+- If a layer reviewer reports High severity findings, include them in your Issues Fixed or Issues Found section. Attempt to fix High-severity layer findings that are straightforward (e.g., adding a missing `alt` attribute, adding a missing `LIMIT` to a query). Flag Critical or architecturally complex findings for human review — do NOT attempt to fix them automatically.
 
 ## Explain Your Work
 

--- a/templates/commands/implement.md
+++ b/templates/commands/implement.md
@@ -407,13 +407,77 @@ git worktree remove <worktree-path> --force
 
 Pass `MERGE_REPORT` to the Phase 4b reviewer agent prompt, listing any files in `requires_resolution`.
 
-### 4b. Launch Reviewer agent
+### 4b. Layer Dispatch and Review
 
-Launch a single **reviewer** agent to validate ALL merged changes. Include:
+#### Step 1: Layer Classification
+
+Before launching any reviewer, classify `MODIFIED_FILES_LIST` into layer-specific file sets.
+
+**Frontend files** — a file is frontend if any of these conditions match:
+- Extension is one of: `.jsx`, `.tsx`, `.vue`, `.svelte`, `.css`, `.scss`, `.sass`, `.less`, `.html`, `.htm`
+- Extension is `.js` or `.ts` AND path contains one of: `components/`, `pages/`, `views/`, `ui/`, `client/`, `frontend/`, `app/`
+- Path starts with: `public/`, `static/`, `assets/`
+
+Set `FRONTEND_FILES` = files matching frontend rules.
+
+**Backend files** — a file is backend if any of these conditions match:
+- Extension is one of: `.py`, `.go`, `.java`, `.rb`, `.php`, `.rs`, `.cs`, `.sql`
+- Extension is `.js` or `.ts` AND path contains one of: `server/`, `api/`, `routes/`, `controllers/`, `services/`, `models/`, `db/`, `backend/`
+- Path is under: `migrations/`, `alembic/`, `db/migrate/`
+
+Set `BACKEND_FILES` = files matching backend rules.
+
+**Overlap rule:** a file may appear in both `FRONTEND_FILES` and `BACKEND_FILES` (e.g., a Next.js API route at `pages/api/`). Both reviewers will scan it independently.
+
+If `FRONTEND_FILES` is empty: set `FRONTEND_REVIEW_REPORT = "SKIPPED"` and skip frontend-reviewer launch. Note: "No frontend files detected."
+If `BACKEND_FILES` is empty: set `BACKEND_REVIEW_REPORT = "SKIPPED"` and skip backend-reviewer launch. Note: "No backend files detected."
+
+#### Step 2: Launch Layer Reviewers in Parallel
+
+Launch all applicable layer reviewers in parallel (`run_in_background: true`):
+
+**frontend-reviewer** (if `FRONTEND_FILES` is non-empty):
+- Pass `FRONTEND_FILES_LIST`: the list of files in `FRONTEND_FILES`
+- Pass `PIPELINE_CONTEXT`: brief description of what was implemented
+
+**backend-reviewer** (if `BACKEND_FILES` is non-empty):
+- Pass `BACKEND_FILES_LIST`: the list of files in `BACKEND_FILES`
+- Pass `PIPELINE_CONTEXT`: brief description of what was implemented
+
+**security-reviewer** (always):
+- Pass `MODIFIED_FILES_LIST`: the complete list of all files created or modified during this run
+- Pass `PIPELINE_CONTEXT`: brief description of what was implemented
+- Pass the exemptions config path: `.claude/security-exemptions.yaml`
+
+Wait for all launched layer reviewers to complete before proceeding to Step 3.
+
+Parse status lines from each completed reviewer:
+- `FRONTEND_REVIEW_STATUS: ISSUES_FOUND` or `CLEAN` → set `FRONTEND_STATUS`
+- `BACKEND_REVIEW_STATUS: ISSUES_FOUND` or `CLEAN` → set `BACKEND_STATUS`
+- `SECURITY_STATUS: BLOCKED | WARNINGS | CLEAN` → set `SECURITY_BLOCKED=true` if `BLOCKED`, otherwise `false`
+
+If a layer reviewer fails or times out: set the relevant report variable to `"ERROR: reviewer did not complete"` and continue.
+
+#### Step 3: Launch Generalist Reviewer
+
+Construct the generalist reviewer's invocation prompt with layer reports injected. Set each variable to the full output of the corresponding reviewer, or to the string `"SKIPPED"` if that reviewer was not launched:
+
+- `FRONTEND_REVIEW_REPORT`: full output of frontend-reviewer (or `"SKIPPED"`)
+- `BACKEND_REVIEW_REPORT`: full output of backend-reviewer (or `"SKIPPED"`)
+- `SECURITY_REVIEW_REPORT`: full output of security-reviewer
+
+Include in the reviewer prompt:
 - Full CI commands
 - Cross-feature merge issue checks
-- Record learnings to `common-fixes.md`
-- Archive completed changes via OpenSpec
+- Instruction to record learnings to `common-fixes.md`
+- Instruction to archive completed changes via OpenSpec
+- The three layer report variables substituted into the `[injected]` slots in the reviewer agent template
+
+Note: if total layer report length is very large, truncate each layer report to its findings tables only (omit skipped-file logs) to stay within prompt limits.
+
+**The security gate (blocking ship on `SECURITY_STATUS: BLOCKED`) is enforced in Phase 4c.** Do not apply it here.
+
+Launch the **reviewer** agent (foreground, `run_in_background: false`). Wait for it to complete.
 
 **If `DRY_RUN=true`**, add the following to the reviewer agent prompt:
 
@@ -424,7 +488,7 @@ Launch a single **reviewer** agent to validate ALL merged changes. Include:
 
 ### 4b-conf. Confidence Gate
 
-After the reviewer agent completes, evaluate the confidence score before launching the security reviewer.
+After the generalist reviewer agent completes, evaluate the confidence score before proceeding to Phase 4c.
 
 **In multi-feature mode (worktrees):** run this gate once per feature immediately after that feature's reviewer completes. Each feature is evaluated independently — a block on one feature does not prevent another feature's gate from running.
 
@@ -435,7 +499,7 @@ Path: `openspec/changes/<name>/confidence-score.json`
 - If the file does not exist:
   - Set `CONFIDENCE_STATUS=MISSING`
   - Print: `[confidence] Warning: confidence-score.json not found. Proceeding without gate.`
-  - Continue to Phase 4b-sec.
+  - Continue to Phase 4c.
 
 #### Step 2 — Read config
 
@@ -451,7 +515,7 @@ Path: `.claude/confidence-config.json`
 - If `enabled: false` in the config:
   - Print: `[confidence] Gate disabled. Skipping.`
   - Set `CONFIDENCE_STATUS=DISABLED`
-  - Continue to Phase 4b-sec.
+  - Continue to Phase 4c.
 
 #### Step 3 — Compare scores
 
@@ -464,7 +528,7 @@ Path: `.claude/confidence-config.json`
 **If no breaches:**
 - Print: `[confidence] All scores meet thresholds. Proceeding.`
 - Set `CONFIDENCE_STATUS=PASS`
-- Continue to Phase 4b-sec.
+- Continue to Phase 4c.
 
 **If breaches exist and `on_breach: "block"`:**
 
@@ -472,7 +536,7 @@ Path: `.claude/confidence-config.json`
    - If `CONFIDENCE_OVERRIDE_REASON` is non-empty and `override_allowed: true` in the config:
      - Print: `[confidence] Override accepted. Reason: <CONFIDENCE_OVERRIDE_REASON>. Proceeding with gate bypassed.`
      - Set `CONFIDENCE_STATUS=OVERRIDE`
-     - Continue to Phase 4b-sec.
+     - Continue to Phase 4c.
    - If `CONFIDENCE_OVERRIDE_REASON` is non-empty but `override_allowed: false` in the config:
      - Print: `[confidence] Override is disabled in confidence-config.json.`
      - (Fall through to block below.)
@@ -480,12 +544,12 @@ Path: `.claude/confidence-config.json`
      - Print the Breach Report (see format below).
      - Set `CONFIDENCE_BLOCKED=true`
      - Set `CONFIDENCE_STATUS=BLOCKED`
-     - **Halt: do not proceed to Phase 4b-sec or Phase 4c.**
+     - **Halt: do not proceed to Phase 4c.**
 
 **If breaches exist and `on_breach: "warn"`:**
 - Print the Breach Report.
 - Set `CONFIDENCE_STATUS=WARN`
-- Continue to Phase 4b-sec.
+- Continue to Phase 4c.
 
 #### Breach Report Format
 
@@ -521,22 +585,8 @@ Pipeline halted. No git operations have been performed.
 
 When `DRY_RUN=true`, the reviewer still writes `confidence-score.json` (it is an OpenSpec artifact, not a git artifact). Phase 4b-conf still evaluates the score. If `CONFIDENCE_BLOCKED=true`, add to `.cache-manifest.json` under `skipped_operations`:
 ```
-"confidence-gate: blocked — Phase 4c and 4b-sec skipped"
+"confidence-gate: blocked — Phase 4c skipped"
 ```
-
-### 4b-sec. Launch Security Reviewer agent
-
-After the reviewer agent completes, launch a **security-reviewer** agent (`subagent_type: security-reviewer`).
-
-Construct the agent invocation prompt to include:
-- **MODIFIED_FILES_LIST**: the complete list of files created or modified during this implementation run
-- **PIPELINE_CONTEXT**: brief description — feature names and change names implemented
-- The exemptions config path: `.claude/security-exemptions.yaml`
-
-Wait for the security-reviewer to complete. Parse the final line of its output:
-- `SECURITY_STATUS: BLOCKED` → set `SECURITY_BLOCKED=true`
-- `SECURITY_STATUS: WARNINGS` → set `SECURITY_BLOCKED=false`, capture warning summary
-- `SECURITY_STATUS: CLEAN` → set `SECURITY_BLOCKED=false`
 
 ### 4c. Ship — Git & backlog updates
 
@@ -693,8 +743,8 @@ rm -rf .claude/.dry-run/<feature-name>/
 **Otherwise**, show the standard pipeline table:
 
 ```
-| Area | Feature | Change Name | Architect | Developer | Tests | Docs | Reviewer | Confidence | Security | CI | Status |
-|------|---------|-------------|-----------|-----------|-------|------|----------|------------|----------|----|--------|
+| Area | Feature | Change Name | Architect | Developer | Tests | Docs | Reviewer | Frontend | Backend | Confidence | Security | CI | Status |
+|------|---------|-------------|-----------|-----------|-------|------|----------|----------|---------|------------|----------|----|--------|
 ```
 
 Confidence column values:
@@ -715,6 +765,11 @@ If `CONFIDENCE_OVERRIDE_REASON` is non-empty, append a `### Confidence Override`
 
 **Reason:** <CONFIDENCE_OVERRIDE_REASON>
 ```
+
+Column values:
+- **Frontend**: `CLEAN`, `ISSUES`, or `SKIPPED` (no frontend files in changeset)
+- **Backend**: `CLEAN`, `ISSUES`, or `SKIPPED` (no backend files in changeset)
+- **Security**: `CLEAN`, `WARNINGS`, `BLOCKED`, or `SKIPPED`
 
 If `MERGE_REPORT.requires_resolution` is non-empty, print an additional section:
 


### PR DESCRIPTION
## Summary

- New frontend reviewer agent: bundle size, WCAG 2.1 AA accessibility, render performance checks
- New backend reviewer agent: N+1 queries, connection pools, pagination, missing indexes
- Restructured Phase 4b into classify → parallel layer launch → generalist reviewer
- Security reviewer moved to parallel step (Phase 4b-sec removed)
- Layer Review Summary table added to generalist reviewer output

## Changes

- `templates/agents/frontend-reviewer.md` (new) — frontend layer reviewer
- `templates/agents/backend-reviewer.md` (new) — backend layer reviewer
- `templates/agents/reviewer.md` — Layer Review Findings, summary table, layer rule
- `templates/commands/implement.md` — Phase 4b rewrite, 4b-sec removal, 4e table update
- Generated instances synced

## Test plan

- [ ] Verify frontend-reviewer has 3 check categories with correct pattern counts
- [ ] Verify backend-reviewer has 4 check categories with correct pattern counts
- [ ] Verify both use STATUS_LINE terminal protocol
- [ ] Verify generalist reviewer has `[injected]` notation (not `{{...}}`)
- [ ] Verify Phase 4b has 3 steps and 4b-sec is removed
- [ ] Verify no broken placeholders in generated instances

Closes #40

---
Implemented via `/implement` pipeline (architect → developer → reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)