### PR TITLE
feat: add backlog sync conflict detection

### DIFF
--- a/.claude/agent-memory/architect/openspec_artifact_conventions.md
+++ b/.claude/agent-memory/architect/openspec_artifact_conventions.md
@@ -65,20 +65,24 @@ When a feature adds a new provider or mode alongside an existing one (e.g., addi
 
 ## Phase Numbering in implement.md
 
-Current phase map as of 2026-03-13:
+Current phase map as of 2026-03-14:
 - Phase -1: Environment Setup
 - Phase 0: Parse input and determine mode
+  - NEW (backlog-sync-conflict): snapshot capture + gitignore advisory after BACKLOG_VIEW_CMD
 - Phase 1: Explore (parallel)
 - Phase 2: Select
+- Phase 3a.0: Pre-architect conflict check — NEW (backlog-sync-conflict)
 - Phase 3a: Architect
 - Phase 3b: Implement (developer)
 - Phase 3c: Write Tests (test-writer) — added by automated-test-writer change
+- Phase 3d: Doc Sync
 - Phase 4: Merge & Review
   - 4a: Merge worktrees
   - 4b: Reviewer
   - 4b-sec: Security Reviewer
+  - 4c.0: Pre-ship conflict check — NEW (backlog-sync-conflict)
   - 4c: Ship
   - 4d: Monitor CI
   - 4e: Report
 
-**Why:** Always check the current implement.md before assigning a new phase number — phases have been inserted between existing ones (3b → 3c) and between sub-phases (4b → 4b-sec).
+**Why:** Always check the current implement.md before assigning a new phase number — phases have been inserted between existing ones (3b → 3c) and between sub-phases (4b → 4b-sec). Sub-phases use decimal notation (3a.0, 4c.0) for guards that run before the named phase.

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -102,6 +102,10 @@ If none of these flags is present: `DRY_RUN=false`, `APPLY_MODE=false`, `CONFIDE
 
 Note: `CACHE_DIR` for `--dry-run` is finalized after the feature name is derived from the remaining input. All subsequent phases that reference `CACHE_DIR` have access to it.
 
+Initialize conflict-tracking variables:
+- `SNAPSHOTS_CAPTURED=false` — set to true in Phase 0 if issue snapshots are successfully written.
+- `CONFLICT_OVERRIDES=[]` — list of conflict records where the user chose to continue; appended by Phase 3a.0 and Phase 4c.0.
+
 ---
 
 **If the user passed a text description** (e.g. `"add feature X"`):
@@ -117,6 +121,72 @@ Note: `CACHE_DIR` for `--dry-run` is finalized after the feature name is derived
 - Extract area, value, effort, and feature details from each issue body.
 - If only 1 issue: set `SINGLE_MODE = true`.
 - **Skip Phase 1 and Phase 2** — go directly to confirmation table.
+
+#### Phase 0 snapshot capture
+
+After fetching issue refs, capture a baseline snapshot for conflict detection.
+
+**If `GH_AVAILABLE=true` and the input mode was issue numbers:**
+
+For each resolved issue number, run:
+
+```bash
+gh issue view {number} --json number,title,state,assignees,labels,body,updatedAt
+```
+
+Build a snapshot object for each issue:
+- `number`: integer issue number
+- `title`: issue title string
+- `state`: `"open"` or `"closed"`
+- `assignees`: array of assignee login names, sorted alphabetically
+- `labels`: array of label names, sorted alphabetically
+- `body_sha`: SHA-256 of the raw body string — compute with:
+  ```bash
+  echo -n "{body}" | sha256sum | cut -d' ' -f1
+  ```
+  If `sha256sum` is not available, fall back to `openssl dgst -sha256 -r` or `shasum -a 256`.
+- `updated_at`: the `updatedAt` value from the GitHub API response
+- `captured_at`: current local time in ISO 8601 format
+
+Write the following JSON to `.claude/backlog-cache.json` (overwrite fully — this establishes a fresh baseline for this run):
+
+```json
+{
+  "schema_version": "1",
+  "provider": "github",
+  "last_updated": "<ISO 8601 timestamp>",
+  "written_by": "implement",
+  "issues": {
+    "<number>": { <snapshot object> },
+    ...
+  }
+}
+```
+
+If the write succeeds: set `SNAPSHOTS_CAPTURED=true`.
+
+If the write fails (e.g., `.claude/` directory does not exist): print `[backlog-cache] Warning: could not write cache. Conflict detection disabled for this run.` and set `SNAPSHOTS_CAPTURED=false`. Do NOT abort the pipeline.
+
+**If `GH_AVAILABLE=false` or input was not issue numbers:**
+
+Set `SNAPSHOTS_CAPTURED=false`. Print: `[conflict-check] Snapshot skipped — GH unavailable or non-issue input.`
+
+#### Gitignore advisory
+
+If `SNAPSHOTS_CAPTURED=true`, check whether `.gitignore` already covers the cache file:
+
+```bash
+grep -q "backlog-cache" .gitignore 2>/dev/null || \
+grep -q "\.claude/" .gitignore 2>/dev/null
+```
+
+If neither pattern is found, print:
+
+```
+[backlog-cache] Suggestion: add '.claude/backlog-cache.json' to .gitignore to avoid committing ephemeral cache state.
+```
+
+This advisory is non-blocking and suppressed when `.gitignore` already covers the file.
 
 **If the user passed area names**:
 - Check for open backlog issues. If found, filter and pick top 3.
@@ -137,6 +207,67 @@ Wait for all to complete. Read their output.
 **Only runs if Phase 1 ran.**
 
 Pick the single idea with the best impact/effort ratio from each exploration. Present to user and wait for confirmation.
+
+## Phase 3a.0: Pre-architect conflict check
+
+**Guard:** If `SNAPSHOTS_CAPTURED=false` OR `DRY_RUN=true`, print `[conflict-check] Skipped — SNAPSHOTS_CAPTURED=false (or dry-run mode).` and proceed directly to Phase 3a.
+
+Otherwise, re-fetch each issue in scope and diff against the Phase 0 snapshot:
+
+For each issue number in `ISSUE_REFS`:
+
+```bash
+gh issue view {number} --json number,title,state,assignees,labels,body,updatedAt
+```
+
+If the `gh` command returns non-zero (issue deleted or inaccessible): treat as a CRITICAL conflict — field `"state"`, was `<cached state>`, now `"deleted"`.
+
+Otherwise, reconstruct a current snapshot (same shape as Phase 0: sort `assignees` and `labels`, compute `body_sha`).
+
+**Short-circuit:** If `current.updatedAt == cached.updated_at`, mark the issue as clean and skip field comparison.
+
+**Field comparison** (only when `updatedAt` differs):
+
+| Field | Conflict if... | Severity |
+|-------|----------------|----------|
+| `state` | value differs (`open` → `closed`) | CRITICAL |
+| `state` | value differs (`closed` → `open`) | WARNING |
+| `title` | string differs | WARNING |
+| `assignees` | sorted array differs | WARNING |
+| `labels` | sorted array differs | INFO |
+| `body_sha` | SHA differs | WARNING |
+
+Collect all conflicts across all issues. If none: print `[conflict-check] All issues clean (Phase 3a.0). Proceeding.` and continue to Phase 3a.
+
+**If conflicts exist**, print the following report and await user input:
+
+```
+## Backlog Conflict Detected
+
+The following issues changed since Phase 0 snapshot (captured at <captured_at>):
+
+| Issue | Field | Severity | Was | Now |
+|-------|-------|----------|-----|-----|
+| #N    | state | CRITICAL | open | closed |
+| #N    | body  | WARNING  | <sha-prefix> | <sha-prefix> |
+
+How would you like to proceed?
+  [A] Abort — stop the pipeline and exit cleanly
+  [C] Continue — proceed despite the conflicts (logged)
+
+Enter A or C:
+```
+
+For `body_sha` rows in the table, display only the first 8 characters of each SHA as the "Was" and "Now" values.
+
+**Input handling:**
+- Accept `A`, `a` (abort) or `C`, `c` (continue).
+- Re-prompt on any other input, up to 3 times total.
+- After 3 invalid inputs: print `[conflict-abort] Defaulting to abort after 3 invalid inputs.` and abort.
+
+**On abort:** Print `[conflict-abort] Pipeline aborted. Re-run /implement after resolving the issues.` and exit. No git state is left behind.
+
+**On continue:** Print `[conflict-override] Continuing. N conflict(s) logged.` Append each conflict to `CONFLICT_OVERRIDES` as `{phase: "3a.0", issue: "#N", field: "<field>", severity: "<severity>", was: "<was>", now: "<now>"}`. Proceed to Phase 3a.
 
 ## Phase 3a: Architect (parallel, in main repo)
 
@@ -592,6 +723,30 @@ When `DRY_RUN=true`, the reviewer still writes `confidence-score.json` (it is an
 "confidence-gate: blocked — Phase 4c skipped"
 ```
 
+### Phase 4c.0: Pre-ship conflict check
+
+**Guard:** If `SNAPSHOTS_CAPTURED=false` OR `DRY_RUN=true`, print `[conflict-check] Skipped — SNAPSHOTS_CAPTURED=false (or dry-run mode).` and proceed directly to Phase 4c.
+
+This check is independent of Phase 3a.0. Even if the user chose to continue through a conflict at Phase 3a.0, this gate re-checks all in-scope issues against the Phase 0 snapshot. It is the final gate before any code reaches git.
+
+Re-fetch each issue in `ISSUE_REFS` and diff against `.claude/backlog-cache.json` using the same algorithm as Phase 3a.0:
+
+```bash
+gh issue view {number} --json number,title,state,assignees,labels,body,updatedAt
+```
+
+If the cache file is missing or malformed JSON at this point: log `[conflict-check] Warning: cache file missing or unreadable. Skipping diff for this run.` and proceed to Phase 4c (treat as clean).
+
+Apply the same short-circuit (`updatedAt` match → clean), field comparison, and severity classification as Phase 3a.0.
+
+If all issues are clean: print `[conflict-check] All issues clean (Phase 4c.0). Proceeding.` and continue.
+
+If conflicts exist: print the same conflict report format as Phase 3a.0 (with `Phase 4c.0` context) and await `A`/`C` input (same re-prompt and default-abort logic).
+
+**On abort:** Print `[conflict-abort] Pipeline aborted. Re-run /implement after resolving the issues.` and exit. No git operations have been performed at this point.
+
+**On continue:** Print `[conflict-override] Continuing. N conflict(s) logged.` Append each conflict to `CONFLICT_OVERRIDES` as `{phase: "4c.0", issue: "#N", field: "<field>", severity: "<severity>", was: "<was>", now: "<now>"}`. Proceed to Phase 4c.
+
 ### 4c. Ship — Git & backlog updates
 
 **Security gate:** If `SECURITY_BLOCKED=true`:
@@ -721,8 +876,8 @@ rm -rf .claude/.dry-run/<feature-name>/
 **Otherwise**, show the standard pipeline table:
 
 ```
-| Area | Feature | Change Name | Architect | Developer | Tests | Docs | Reviewer | Frontend | Backend | Confidence | Security | CI | Status |
-|------|---------|-------------|-----------|-----------|-------|------|----------|----------|---------|------------|----------|----|--------|
+| Area | Feature | Change Name | Architect | Developer | Tests | Docs | Reviewer | Frontend | Backend | Confidence | Security | CI | Conflicts | Status |
+|------|---------|-------------|-----------|-----------|-------|------|----------|----------|---------|------------|----------|----|-----------|--------|
 ```
 
 Confidence column values:
@@ -749,6 +904,11 @@ Column values:
 - **Backend**: `CLEAN`, `ISSUES`, or `SKIPPED` (no backend files in changeset)
 - **Security**: `CLEAN`, `WARNINGS`, `BLOCKED`, or `SKIPPED`
 
+The `Conflicts` column values:
+- `skipped` — `SNAPSHOTS_CAPTURED=false` (non-issue input or GH unavailable)
+- `clean` — both conflict checks ran and found no changes
+- `overridden (N)` — user chose Continue at one or both gates; N is the total number of conflict records in `CONFLICT_OVERRIDES`
+
 If `MERGE_REPORT.requires_resolution` is non-empty, print an additional section:
 
 ```
@@ -760,6 +920,20 @@ If `MERGE_REPORT.requires_resolution` is non-empty, print an additional section:
 
 Fix these conflicts (search for `<<<<<<<` in each file), then commit the resolved files.
 ```
+
+If `CONFLICT_OVERRIDES` is non-empty, print:
+
+```
+## Conflict Overrides
+
+The following backlog conflicts were detected but overridden by the user:
+
+| Phase | Issue | Field | Severity | Was | Now |
+|-------|-------|-------|----------|-----|-----|
+| 3a.0  | #42   | state | CRITICAL | open | closed |
+```
+
+If `CONFLICT_OVERRIDES` is empty or `SNAPSHOTS_CAPTURED=false`: omit the `## Conflict Overrides` section entirely. Do not print an empty table or a "No conflict overrides" line.
 
 Include PR URL, CI status, and backlog updates made.
 

--- a/.claude/commands/product-backlog.md
+++ b/.claude/commands/product-backlog.md
@@ -158,3 +158,38 @@ The product-analyst receives this prompt:
     ```
     No product-driven backlog issues found. Run `/update-product-driven-backlog` to generate feature ideas.
     ```
+
+7. **[Orchestrator]** After the product-analyst completes, write issue snapshots to `.claude/backlog-cache.json`.
+
+   **Guard:** If `GH_AVAILABLE=false` (from Phase 0 pre-flight), print `[backlog-cache] Skipped — GH unavailable.` and return. Do not attempt the write.
+
+   **Fetch all open backlog issues in one call:**
+
+   ```bash
+   gh issue list --label "product-driven-backlog" --state open --json number,title,state,assignees,labels,body,updatedAt
+   ```
+
+   For each issue in the result, build a snapshot object:
+   - `number`: integer issue number
+   - `title`: issue title string
+   - `state`: `"open"` or `"closed"`
+   - `assignees`: array of assignee login names, sorted alphabetically
+   - `labels`: array of label names, sorted alphabetically
+   - `body_sha`: SHA-256 of the raw body string — compute with:
+     ```bash
+     echo -n "{body}" | sha256sum | cut -d' ' -f1
+     ```
+     If `sha256sum` is not available, fall back to `openssl dgst -sha256 -r` or `shasum -a 256`.
+   - `updated_at`: the `updatedAt` value from the GitHub API response
+   - `captured_at`: current local time in ISO 8601 format
+
+   **Merge strategy:** If `.claude/backlog-cache.json` already exists and is valid JSON, read it and merge: new snapshot entries overwrite existing entries by issue number key; entries for issue numbers not in the current fetch are preserved (they may be needed by an in-progress `/implement` run). If the file does not exist or is malformed, create it fresh.
+
+   Write the merged result back to `.claude/backlog-cache.json` with:
+   - `schema_version`: `"1"`
+   - `provider`: `"github"`
+   - `last_updated`: current ISO 8601 timestamp
+   - `written_by`: `"product-backlog"`
+   - `issues`: the merged map keyed by string issue number
+
+   If the write fails (e.g., `.claude/` directory does not exist): print `[backlog-cache] Warning: could not write cache. Continuing.` Do not abort.

--- a/openspec/changes/archive/2026-03-14-backlog-sync-conflict/context-bundle.md
+++ b/openspec/changes/archive/2026-03-14-backlog-sync-conflict/context-bundle.md
@@ -1,0 +1,220 @@
+---
+change: backlog-sync-conflict
+type: context-bundle
+---
+
+# Context Bundle: Backlog Sync Conflict Detection
+
+Everything a developer needs to implement this feature. No other file needs to be read first.
+
+---
+
+## What You Are Building
+
+Two inline conflict-check gates inside the `/implement` pipeline, plus a lightweight cache write in `/product-backlog`. The goal is to detect when GitHub Issues are modified externally while an implementation is in progress and give the user a chance to abort before shipping stale work.
+
+There are no new agents, no new commands, no new architecture. This is purely additive modification to two existing command templates.
+
+---
+
+## Files to Change
+
+| File | Change type | Notes |
+|------|-------------|-------|
+| `templates/commands/implement.md` | **Modify** | Add Phase 0 snapshot, Phase 3a.0, Phase 4c.0, Phase 4e section |
+| `templates/commands/product-backlog.md` | **Modify** | Add post-display snapshot write |
+
+**Do NOT modify:**
+- `install.sh` — no change needed; template changes are picked up automatically
+- `openspec/specs/implement.md` — this is the spec, not the implementation
+- Any file in `.claude/commands/` — those are generated, not source
+
+**New file created at runtime (not committed):**
+- `.claude/backlog-cache.json` — written by `/implement` Phase 0 and `/product-backlog`; never committed to git
+
+---
+
+## Current State of the Relevant Templates
+
+```
+templates/commands/
+├── implement.md               # Full pipeline — ADD Phase 3a.0, 4c.0, Phase 0 snapshot, 4e section
+├── product-backlog.md         # Backlog viewer — ADD post-display snapshot write
+└── update-product-driven-backlog.md  # Unrelated — do not touch
+```
+
+---
+
+## Where to Insert Each Change in `implement.md`
+
+Read `templates/commands/implement.md` in full before making any edits. The file is long. Here is the insertion map:
+
+| New block | Insert after... | Insert before... |
+|-----------|----------------|-----------------|
+| Phase 0 snapshot capture + gitignore advisory | The `BACKLOG_VIEW_CMD` block and issue-fetch loop in Phase 0 | The confirmation table that the user sees before Phase 1 |
+| `SNAPSHOTS_CAPTURED` and `CONFLICT_OVERRIDES` variable declarations | The flag-detection variable declarations in Phase 0 | The "If the user passed a text description" block |
+| Phase 3a.0 block | End of Phase 0 / confirmation table | The `## Phase 3a: Architect (parallel, in main repo)` heading |
+| Phase 4c.0 block | End of Phase 4b-sec (security reviewer output parsing) | The `### Dry-Run Gate` block in Phase 4c |
+| Conflict Overrides section in Phase 4e | The standard pipeline table in Phase 4e | The shipping mode notes at the end of Phase 4e |
+
+---
+
+## Where to Insert the Change in `product-backlog.md`
+
+Read `templates/commands/product-backlog.md` in full. It is short. The file ends after step 6 (the "no issues" fallback). Insert the snapshot write as a new final step (step 7) in the Execution section, after the product-analyst agent's output, framed as an orchestrator action (not inside the agent prompt):
+
+```
+7. **[Orchestrator]** After the product-analyst completes, write issue snapshots to `.claude/backlog-cache.json`:
+
+   [snapshot write instructions here]
+```
+
+---
+
+## The Cache File Schema
+
+`.claude/backlog-cache.json` — full schema:
+
+```json
+{
+  "schema_version": "1",
+  "provider": "github",
+  "last_updated": "2026-03-14T10:23:00Z",
+  "written_by": "implement",
+  "issues": {
+    "42": {
+      "number": 42,
+      "title": "Backlog Sync Conflict Detection",
+      "state": "open",
+      "assignees": ["alice"],
+      "labels": ["area:Commands", "product-driven-backlog"],
+      "body_sha": "a3f5...c9d1",
+      "updated_at": "2026-03-13T18:00:00Z",
+      "captured_at": "2026-03-14T10:23:00Z"
+    }
+  }
+}
+```
+
+Key points:
+- `issues` is a map keyed by string issue number (not integer).
+- `assignees` and `labels` are always sorted alphabetically before storage.
+- `body_sha` is SHA-256 of the raw body string: `echo -n "{body}" | sha256sum | cut -d' ' -f1`
+- `updated_at` comes from the GitHub API; `captured_at` is the local wall-clock time of the snapshot.
+
+---
+
+## The Diff Algorithm
+
+At each conflict-check phase:
+
+```
+for each issue_ref in ISSUE_REFS:
+    fresh = gh issue view {number} --json number,title,state,assignees,labels,body,updatedAt
+    cached = .claude/backlog-cache.json["issues"][str(number)]
+
+    if cached is missing:
+        log warning "no baseline for #{number}, skipping diff"
+        continue
+
+    if fresh.updatedAt == cached.updated_at:
+        # GitHub API says nothing changed — skip field comparison
+        mark issue as clean
+        continue
+
+    # Something changed — compare fields
+    conflicts = []
+    if fresh.state != cached.state:          conflicts += {field: "state", severity: ...}
+    if fresh.title != cached.title:          conflicts += {field: "title", severity: "WARNING"}
+    if sort(fresh.assignees) != cached.assignees:  conflicts += {field: "assignees", severity: "WARNING"}
+    if sort(fresh.labels) != cached.labels:  conflicts += {field: "labels", severity: "INFO"}
+
+    fresh_body_sha = sha256(fresh.body)
+    if fresh_body_sha != cached.body_sha:    conflicts += {field: "body", severity: "WARNING"}
+```
+
+Severity for `state`:
+- `open` → `closed`: CRITICAL
+- `closed` → `open`: WARNING
+
+---
+
+## The Conflict Report Format
+
+```
+## Backlog Conflict Detected
+
+The following issues changed since Phase 0 snapshot (captured at 2026-03-14T10:23:00Z):
+
+| Issue | Field | Severity | Was | Now |
+|-------|-------|----------|-----|-----|
+| #42   | state | CRITICAL | open | closed |
+| #42   | body  | WARNING  | a3f5...c9d1 | 9b2e...a7f0 |
+
+How would you like to proceed?
+  [A] Abort — stop the pipeline and exit cleanly
+  [C] Continue — proceed despite the conflicts (logged)
+
+Enter A or C:
+```
+
+User input rules:
+- Accept `A`, `a`, `C`, `c`.
+- Re-prompt on anything else, up to 3 times.
+- After 3 invalid inputs: default to abort and print `[conflict-abort] Defaulting to abort after 3 invalid inputs.`
+
+---
+
+## Guard Conditions Summary
+
+Conflict checks are skipped entirely when:
+1. `SNAPSHOTS_CAPTURED=false` — input was not issue numbers, or GH was unavailable at Phase 0.
+2. `DRY_RUN=true` — no live backlog operations in dry-run mode.
+
+When skipped, print: `[conflict-check] Skipped — SNAPSHOTS_CAPTURED=false (or dry-run mode).`
+
+---
+
+## Variable Summary
+
+New variables introduced by this change:
+
+| Variable | Type | Set in | Description |
+|----------|------|--------|-------------|
+| `SNAPSHOTS_CAPTURED` | boolean | Phase 0 | True when issue snapshots were successfully written to cache |
+| `CONFLICT_OVERRIDES` | list | Phase 3a.0 / 4c.0 | Conflict records where user chose Continue |
+
+---
+
+## Existing Pipeline Variables This Feature Reads
+
+| Variable | Defined in | Usage |
+|----------|-----------|-------|
+| `GH_AVAILABLE` | Phase -1 | Gates all snapshot and conflict-check logic |
+| `DRY_RUN` | Phase 0 | Skips conflict checks when true |
+| `SINGLE_MODE` | Phase 0 | Does NOT skip conflict checks; issue-based single mode still runs checks |
+
+---
+
+## Edge Cases to Handle
+
+| Scenario | How to handle |
+|----------|--------------|
+| `gh issue view` returns non-zero (issue deleted) | Treat as CRITICAL conflict: "Issue #N no longer exists on GitHub." |
+| Cache file missing at conflict-check time | Log warning, skip diff for that issue, treat as clean |
+| Cache file is malformed JSON | Treat as missing; log warning, skip diff |
+| `sha256sum` not available on system | Fall back to `openssl dgst -sha256` or `shasum -a 256`. Document both fallbacks in the phase prose. |
+| User has `.claude/` in `.gitignore` already | Gitignore advisory is suppressed (grep matches) |
+| Multiple issues, only some conflicted | Report only conflicted issues; clean issues not mentioned |
+| Phase 4c.0 sees same conflict user already continued through at Phase 3a.0 | Still report it — checks are independent |
+
+---
+
+## Template Conventions to Follow
+
+- Use inline variable names (e.g., `SNAPSHOTS_CAPTURED`) in prose, not `{{PLACEHOLDER}}` syntax — runtime variables are not template placeholders.
+- Only `{{UPPER_SNAKE_CASE}}` tokens that are substituted at `/setup` time should use the placeholder syntax.
+- New phases follow the same heading style as existing phases: `## Phase 3a.0: Pre-architect conflict check`.
+- Bash code blocks use triple backticks with `bash` annotation.
+- Prose is imperative: "Run the following", "Print:", "Set X=".
+- The `product-backlog.md` orchestrator step is labeled `[Orchestrator]` in a bold prefix to distinguish it from agent-prompt instructions.

--- a/openspec/changes/archive/2026-03-14-backlog-sync-conflict/delta-spec.md
+++ b/openspec/changes/archive/2026-03-14-backlog-sync-conflict/delta-spec.md
@@ -1,0 +1,119 @@
+---
+change: backlog-sync-conflict
+type: delta-spec
+---
+
+# Delta Spec: Backlog Sync Conflict Detection
+
+This document describes the normative changes to existing specs that this feature introduces.
+
+---
+
+## Spec: `/implement` Command (`openspec/specs/implement.md`)
+
+### Addition: Phase 0 — Issue snapshot capture
+
+Add the following sub-section after the existing Phase 0 flag detection and issue-fetch logic, within the block that handles `BACKLOG_VIEW_CMD`:
+
+**New behavior (normative):**
+
+> **If `GH_AVAILABLE=true` AND input mode is issue numbers:**
+>
+> After fetching each issue's metadata, capture a snapshot of each issue into `.claude/backlog-cache.json`. The snapshot MUST include: `number`, `title`, `state`, `assignees` (sorted), `labels` (sorted), `body_sha` (SHA-256 of body string), `updated_at` (from GitHub API), `captured_at` (local ISO 8601 timestamp).
+>
+> Set `SNAPSHOTS_CAPTURED=true`.
+>
+> If `GH_AVAILABLE=false` or input is not issue numbers: set `SNAPSHOTS_CAPTURED=false`. Skip snapshot capture silently.
+
+### Addition: Phase 3a.0 — Pre-architect conflict check
+
+Insert a new sub-phase `3a.0` immediately before Phase 3a (architect launch). This sub-phase MUST run after Phase 0 and before any architect agent is launched.
+
+**New behavior (normative):**
+
+> **Phase 3a.0: Pre-architect conflict check**
+>
+> Guard: if `SNAPSHOTS_CAPTURED=false` OR `DRY_RUN=true`: print `[conflict-check] Skipped.` and continue to Phase 3a.
+>
+> For each issue ref in scope:
+> 1. Re-fetch current state: `gh issue view {number} --json number,title,state,assignees,labels,body,updatedAt`
+> 2. Diff against `.claude/backlog-cache.json` snapshot using the algorithm defined in `design.md`.
+> 3. Collect all conflicts.
+>
+> If no conflicts: print `[conflict-check] All issues clean. Proceeding to Phase 3a.` and continue.
+>
+> If conflicts exist: print the conflict report (format defined in `design.md`). Await user input `[A]bort` or `[C]ontinue`. On abort: exit cleanly. On continue: log overrides and proceed.
+
+### Addition: Phase 4c.0 — Pre-ship conflict check
+
+Insert a new sub-phase `4c.0` immediately before Phase 4c (shipping). This sub-phase MUST run after Phase 4b (reviewer) completes and before any git operation.
+
+**New behavior (normative):**
+
+> **Phase 4c.0: Pre-ship conflict check**
+>
+> Guard: same as Phase 3a.0. If `SNAPSHOTS_CAPTURED=false` OR `DRY_RUN=true`: print `[conflict-check] Skipped.` and continue to Phase 4c.
+>
+> Repeat the same re-fetch, diff, and halt-or-continue flow as Phase 3a.0.
+>
+> Note: a conflict seen at Phase 3a.0 where the user chose Continue MUST still be reported at Phase 4c.0 if it persists. The Phase 4c.0 check is independent.
+
+### Addition: Variable Reference table
+
+Add the following rows to the Variable Reference table in `openspec/specs/implement.md`:
+
+| Variable | Type | Set when | Description |
+|----------|------|----------|-------------|
+| `SNAPSHOTS_CAPTURED` | boolean | Phase 0, issue-ref input mode | `true` if issue snapshots were written to `.claude/backlog-cache.json` |
+| `CONFLICT_OVERRIDES` | list | Phase 3a.0 or 4c.0, user chose Continue | List of `{phase, issue, field, severity}` objects for the Phase 4e report |
+
+### Addition: Phase 4e report — Conflict Overrides section
+
+When `CONFLICT_OVERRIDES` is non-empty, the Phase 4e final report MUST include an additional section:
+
+```
+## Conflict Overrides
+
+The following backlog conflicts were detected but overridden by the user:
+
+| Phase | Issue | Field | Severity | Was | Now |
+|-------|-------|-------|----------|-----|-----|
+| 3a.0  | #42   | state | CRITICAL | open | closed |
+```
+
+If `CONFLICT_OVERRIDES` is empty or `SNAPSHOTS_CAPTURED=false`: omit this section entirely.
+
+### Addition: Edge Cases section
+
+Add to the existing Edge Cases section:
+
+- **Cache missing at conflict-check time**: Re-fetch and build a fresh snapshot; skip diff (treat as clean); log `[conflict-check] Warning: no baseline snapshot found. Skipping diff.`
+- **Issue deleted between snapshot and check**: `gh issue view` returns non-zero. Treat as CRITICAL conflict: "Issue #N no longer exists on GitHub."
+- **All issues clean at both check points**: No user interaction required; pipeline runs entirely non-interactively.
+
+---
+
+## Spec: `/product-backlog` Command (no formal spec yet — behavioral spec addition)
+
+No existing spec file covers `/product-backlog`. This delta creates the behavioral requirement.
+
+**New behavior (normative):**
+
+After the product-analyst agent displays the backlog, the command MUST write issue snapshots to `.claude/backlog-cache.json` for every issue fetched, using the same snapshot schema as `/implement` Phase 0.
+
+Rules:
+- If `.claude/backlog-cache.json` already exists: merge new snapshots in by issue number. Do not delete entries for issues not in the current fetch.
+- `written_by` field MUST be `"product-backlog"`.
+- If write fails: print a warning and continue. The cache write MUST NOT block the command.
+- If `GH_AVAILABLE=false`: skip silently.
+
+---
+
+## Storage Convention Addition
+
+`.claude/backlog-cache.json` is a new conventional file location established by this change. Its schema is defined in `design.md`. The file:
+
+- Is written by `/implement` (Phase 0) and `/product-backlog` (post-display).
+- Is read by `/implement` (Phases 3a.0 and 4c.0).
+- MUST NOT be committed to version control (add to `.gitignore`).
+- Is not required to exist — all readers handle missing-file gracefully.

--- a/openspec/changes/archive/2026-03-14-backlog-sync-conflict/design.md
+++ b/openspec/changes/archive/2026-03-14-backlog-sync-conflict/design.md
@@ -1,0 +1,237 @@
+---
+change: backlog-sync-conflict
+type: design
+---
+
+# Technical Design: Backlog Sync Conflict Detection
+
+## Overview
+
+The design introduces two inline conflict-check points within the existing `/implement` pipeline and a lightweight JSON cache file that persists issue state snapshots. No new agents, no background processes, no external dependencies.
+
+The approach is conservative by default: a single changed field on any in-scope issue triggers a halt. The user decides whether to proceed. The system never overrides that decision.
+
+---
+
+## Architecture
+
+```
+/implement
+     |
+     v
+Phase 0: Parse input
+  NEW: Capture issue snapshots -> .claude/backlog-cache.json
+     |
+     v
+Phase 3a.0: Pre-architect conflict check  [NEW]
+  - Re-fetch all in-scope issues
+  - Diff against Phase 0 snapshot
+  - If conflict: halt, report, await [A]bort/[C]ontinue
+     |
+     v
+Phase 3a ... Phase 4b: (unchanged)
+     |
+     v
+Phase 4c.0: Pre-ship conflict check  [NEW]
+  - Re-fetch all in-scope issues
+  - Diff against Phase 0 snapshot
+  - If conflict: halt, report, await [A]bort/[C]ontinue
+     |
+     v
+Phase 4c: Ship (unchanged)
+
+/product-backlog
+     |
+     v
+After fetching issues:
+  NEW: Write snapshots -> .claude/backlog-cache.json
+```
+
+---
+
+## Cache File: `.claude/backlog-cache.json`
+
+### Location
+
+`.claude/backlog-cache.json` in the target repo root. This file is written by both `/implement` (Phase 0) and `/product-backlog` (after fetching). It is not committed to git — add to `.gitignore` if the target repo does not already exclude `.claude/`.
+
+### Schema
+
+```json
+{
+  "schema_version": "1",
+  "provider": "github",
+  "last_updated": "<ISO 8601 timestamp>",
+  "written_by": "implement | product-backlog",
+  "issues": {
+    "42": {
+      "number": 42,
+      "title": "Feature name",
+      "state": "open",
+      "assignees": ["username"],
+      "labels": ["area:Commands", "product-driven-backlog"],
+      "body_sha": "<sha256 of body string>",
+      "updated_at": "<ISO 8601 timestamp from GitHub>",
+      "captured_at": "<ISO 8601 timestamp of snapshot>"
+    }
+  }
+}
+```
+
+### Field Descriptions
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `schema_version` | string | Always `"1"` in this version. Increment if schema changes. |
+| `provider` | string | `"github"` — enables future extension for JIRA, Linear, etc. |
+| `last_updated` | string | ISO 8601 timestamp when the file was last written |
+| `written_by` | string | Which command last wrote the file: `"implement"` or `"product-backlog"` |
+| `issues` | object | Map of issue number (string) to snapshot object |
+| `issues[N].number` | integer | GitHub issue number |
+| `issues[N].title` | string | Issue title at snapshot time |
+| `issues[N].state` | string | `"open"` or `"closed"` |
+| `issues[N].assignees` | array | Sorted list of assignee login names |
+| `issues[N].labels` | array | Sorted list of label names |
+| `issues[N].body_sha` | string | SHA-256 hex digest of the issue body string. Used to detect body edits without storing the full body. |
+| `issues[N].updated_at` | string | `updated_at` field from the GitHub API response |
+| `captured_at` | string | Local timestamp when this snapshot was taken |
+
+### Snapshot Construction
+
+When capturing a snapshot, run:
+
+```bash
+gh issue view {number} --json number,title,state,assignees,labels,body,updatedAt
+```
+
+Compute `body_sha`:
+```bash
+echo -n "{body}" | sha256sum | cut -d' ' -f1
+```
+
+Assignees and labels are sorted alphabetically before storage so that order changes in the API response do not produce false positives.
+
+---
+
+## Diff Algorithm
+
+The diff runs at each conflict-check point. For each issue in scope:
+
+1. Re-fetch current state via `gh issue view {number} --json number,title,state,assignees,labels,body,updatedAt`.
+2. Reconstruct a current snapshot object (same shape as the cache entry).
+3. Compare the following fields against the cached snapshot:
+
+| Field | Conflict if... |
+|-------|---------------|
+| `state` | value differs (`"open"` → `"closed"` or vice versa) |
+| `title` | string differs |
+| `assignees` | sorted array differs |
+| `labels` | sorted array differs |
+| `body_sha` | SHA differs |
+
+`updated_at` from GitHub is used as a quick short-circuit: if `updated_at` is identical to the cached value, skip field-by-field comparison and mark the issue as clean. This avoids unnecessary SHA computation on unchanged issues.
+
+### Conflict Classification
+
+Each detected difference is classified by severity:
+
+| Conflict type | Severity | Explanation |
+|---------------|----------|-------------|
+| `state: open -> closed` | CRITICAL | Issue was closed — implementation may be cancelled |
+| `state: closed -> open` | WARNING | Issue was reopened — may have new scope |
+| `title` changed | WARNING | Scope or framing changed |
+| `assignees` changed | WARNING | Ownership transferred |
+| `labels` changed | INFO | Priority or area reclassified |
+| `body` changed | WARNING | Requirements may have changed |
+
+CRITICAL conflicts always halt. WARNING and INFO conflicts also halt by default (conservative). The user sees severity in the report.
+
+---
+
+## Conflict Report Format
+
+When conflicts are detected, the pipeline prints:
+
+```
+## Backlog Conflict Detected
+
+The following issues changed since Phase 0 snapshot (captured at <timestamp>):
+
+| Issue | Field | Severity | Was | Now |
+|-------|-------|----------|-----|-----|
+| #42   | state | CRITICAL | open | closed |
+| #42   | body  | WARNING  | <sha-prefix> | <sha-prefix> |
+| #71   | assignees | WARNING | [] | ["alice"] |
+
+How would you like to proceed?
+  [A] Abort — stop the pipeline and exit cleanly
+  [C] Continue — proceed despite the conflicts (logged)
+
+Enter A or C:
+```
+
+If the user chooses `[C]`:
+- Print: `[conflict-override] Continuing with N conflict(s) logged. Check issue state before merging.`
+- Append conflict details to the pipeline's Phase 4e final report under a `## Conflict Overrides` section.
+
+If the user chooses `[A]`:
+- Print: `[conflict-abort] Pipeline aborted due to backlog conflicts. Re-run /implement after resolving the issues.`
+- Exit cleanly (no git state left behind, no partial commits).
+
+---
+
+## Guard Conditions
+
+Conflict checks are **skipped entirely** when any of the following is true:
+
+| Condition | Reason |
+|-----------|--------|
+| `GH_AVAILABLE=false` | Cannot re-fetch issues |
+| `DRY_RUN=true` | No live backlog operations in dry-run mode |
+| Input was a text description (not issue numbers) | No issue to track |
+| Input was area names with no resolved issues | No issue to track |
+
+When skipped, print a single line:
+```
+[conflict-check] Skipped — GH_AVAILABLE=false (or dry-run mode / no issue refs).
+```
+
+---
+
+## `/product-backlog` Integration
+
+After the product-analyst agent completes its fetch and display, the `/product-backlog` command writes snapshots for every fetched issue to `.claude/backlog-cache.json`.
+
+This is additive: if the file already exists, merge new snapshots in (overwrite by issue number). Do not delete snapshots for issues not in the current fetch — they may be needed by an in-progress `/implement` run.
+
+The write happens after the display step so the user always sees the backlog before any file I/O side effect. If the write fails (e.g., `.claude/` does not exist), print a warning and continue — the cache is advisory, not blocking.
+
+---
+
+## Interaction with Existing Pipeline Variables
+
+| Variable | Usage |
+|----------|-------|
+| `GH_AVAILABLE` | Set in Phase -1; gates all conflict-check logic |
+| `DRY_RUN` | Set in Phase 0; skips conflict checks |
+| `SINGLE_MODE` | Does not affect conflict checks; issue-based single-mode still checks |
+| `ISSUE_REFS` | The set of issue numbers in scope; drives snapshot capture and re-fetch |
+
+---
+
+## File Placement and Gitignore
+
+`.claude/backlog-cache.json` should not be committed. The file is ephemeral machine state. The `/implement` command should check whether `.gitignore` contains `.claude/backlog-cache.json` or `.claude/*.json` or `.claude/` and print a one-time suggestion to add it if not found. The suggestion is non-blocking.
+
+---
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Issue deleted on GitHub between snapshot and check | `gh issue view` returns non-zero. Treat as CRITICAL conflict: issue no longer exists. |
+| Cache file missing at conflict-check time | Re-fetch and build a fresh snapshot; skip diff (treat as clean); log a warning that no baseline existed. |
+| Cache file malformed JSON | Treat as missing; proceed as above. |
+| Multiple issues, some clean some conflicted | Report only conflicted issues. Clean issues are not mentioned. |
+| User inputs `A` or `C` in lowercase | Accept both cases. Treat anything other than `a`/`A`/`c`/`C` as invalid input and re-prompt (up to 3 times, then default to abort). |
+| Conflict check at Phase 4c finds same conflict already seen at Phase 3a.0 and user chose Continue | Still report the conflict at Phase 4c. Do not suppress — the field may have changed again, and the second check is the final gate before shipping. |

--- a/openspec/changes/archive/2026-03-14-backlog-sync-conflict/proposal.md
+++ b/openspec/changes/archive/2026-03-14-backlog-sync-conflict/proposal.md
@@ -1,0 +1,54 @@
+---
+change: backlog-sync-conflict
+type: feature
+status: proposed
+github_issue: 41
+vpc_fit: ~
+---
+
+# Proposal: Backlog Sync Conflict Detection
+
+## Problem
+
+The `/implement` pipeline fetches issue state once at startup and then operates blindly for however long implementation takes. On a feature that takes 30–60 minutes to implement, an external actor — a colleague, a product manager, an automated bot — can close the issue, reassign it, change its labels, or edit its description while the pipeline is mid-flight. The developer receives no signal of this. They ship an implementation of a feature that was already cancelled, reassigned to someone else, or materially changed in scope.
+
+This is not a hypothetical. Backlogs are shared artefacts. In any active team, issue state changes continuously. The `/product-backlog` command surfaces a ranked view at a point in time, and `/implement` snapshots that state at invocation. Nothing checks whether that snapshot is still valid by the time code is committed.
+
+The cost of shipping a stale implementation is high: wasted developer time, reviewer confusion, potential rework of already-merged code, and product–engineering trust erosion when a closed feature appears in a PR.
+
+## Solution
+
+Add conflict detection to the `/implement` pipeline.
+
+At two points in the pipeline — just before architect agents launch (Phase 3a) and again just before shipping (Phase 4c) — the pipeline re-fetches the current state of every in-scope GitHub Issue and compares it against the state captured at Phase 0. A persisted cache file, `.claude/backlog-cache.json`, stores the snapshots.
+
+If a conflict is detected, the pipeline halts and presents the user with a clear conflict report and a binary choice: abort or continue. The continue path is explicit and intentional — the user may know about the change and want to proceed anyway.
+
+The cache file also serves a secondary use: `/product-backlog` can write to it when it fetches issues, so that `/implement` has a baseline to diff against even if it was not the one to read the issues initially.
+
+## Non-Goals
+
+- No continuous background polling. The issue notes a possible `/loop` integration, but a continuous background process adds complexity, race conditions, and terminal noise that outweigh the benefit for this use case. Point-in-time checks at meaningful pipeline gates are sufficient and predictable.
+- No JIRA or other backlog provider support in this change. GitHub Issues only. The cache schema is provider-aware so future providers can extend it.
+- No automatic conflict resolution. The user always decides.
+- No change to the dry-run or apply paths — conflict checks are skipped when `DRY_RUN=true` (no live backlog operations).
+- No new agent. The conflict checks run inline in the orchestrating command.
+
+## Scope
+
+Three files change:
+
+1. `templates/commands/implement.md` — two new inline conflict-check phases (3a.0 and 4c.0), and a cache write in Phase 0.
+2. `templates/commands/product-backlog.md` — writes issue snapshots to `.claude/backlog-cache.json` when it fetches issues.
+3. A new storage convention: `.claude/backlog-cache.json` stores the last-known state of each issue.
+
+## Success Criteria
+
+- When `/implement` is invoked with issue numbers and `GH_AVAILABLE=true`, the pipeline captures a JSON snapshot of each issue's state (number, title, state, assignees, labels, body SHA) into `.claude/backlog-cache.json` during Phase 0.
+- Before Phase 3a launches architect agents, the pipeline re-fetches each issue and diffs against the snapshot. If any conflict field changed, the pipeline pauses and displays a conflict report.
+- Before Phase 4c ships, the pipeline performs a second re-fetch and diff. Same halt-and-report behavior.
+- The conflict report clearly states: which issue, which field changed, old value, new value.
+- The user is offered: `[A]bort` or `[C]ontinue`. Abort exits cleanly. Continue proceeds with a log entry.
+- When `GH_AVAILABLE=false` or `DRY_RUN=true`, conflict checks are silently skipped (no error, no halt).
+- `/product-backlog` writes to `.claude/backlog-cache.json` after fetching issues, so a baseline exists even if the user viewed the backlog before running `/implement`.
+- No unresolved `{{PLACEHOLDER}}` tokens in the installed commands after `/setup` runs.

--- a/openspec/changes/archive/2026-03-14-backlog-sync-conflict/tasks.md
+++ b/openspec/changes/archive/2026-03-14-backlog-sync-conflict/tasks.md
@@ -1,0 +1,227 @@
+---
+change: backlog-sync-conflict
+type: tasks
+---
+
+# Tasks: Backlog Sync Conflict Detection
+
+Tasks are ordered sequentially. Each task depends on the one before it unless stated otherwise.
+
+---
+
+## T1 — Add Phase 0 snapshot capture to `implement.md` [templates]
+
+**Description:**
+In `templates/commands/implement.md`, add a snapshot-capture step at the end of the Phase 0 issue-fetch block. This step runs only when `GH_AVAILABLE=true` and the input mode is issue numbers.
+
+The step must:
+1. For each resolved issue ref, run: `gh issue view {number} --json number,title,state,assignees,labels,body,updatedAt`
+2. Sort `assignees` and `labels` alphabetically.
+3. Compute `body_sha`: `echo -n "{body}" | sha256sum | cut -d' ' -f1`
+4. Write the snapshot map into `.claude/backlog-cache.json` using the schema from `design.md`. Overwrite the file fully (not merge — Phase 0 always owns a fresh baseline for this run).
+5. Set `SNAPSHOTS_CAPTURED=true`.
+
+When `GH_AVAILABLE=false` or input is not issue numbers: set `SNAPSHOTS_CAPTURED=false`. Print `[conflict-check] Snapshot skipped — GH unavailable or non-issue input.`
+
+Add `SNAPSHOTS_CAPTURED` and `CONFLICT_OVERRIDES` to the pipeline's variable tracking (as inline prose, consistent with how other variables are described in the command).
+
+**Files:**
+- Modify: `templates/commands/implement.md`
+
+**Acceptance criteria:**
+- The snapshot step appears after the `BACKLOG_VIEW_CMD` fetch block in Phase 0, before the confirmation table.
+- `SNAPSHOTS_CAPTURED=true` is set only when both `GH_AVAILABLE=true` and issue refs were the input mode.
+- `.claude/backlog-cache.json` written with `schema_version: "1"`, `provider: "github"`, `written_by: "implement"`, and a `issues` map keyed by string issue number.
+- `body_sha` is computed via `sha256sum` (not stored raw body).
+- `assignees` and `labels` are sorted before storage.
+- `CONFLICT_OVERRIDES` initialized to empty list.
+- If write fails (`.claude/` missing), print a warning and set `SNAPSHOTS_CAPTURED=false` — do not abort.
+
+**Dependencies:** none
+
+---
+
+## T2 — Add Phase 3a.0 pre-architect conflict check to `implement.md` [templates]
+
+**Description:**
+In `templates/commands/implement.md`, insert a new `Phase 3a.0` block immediately before the existing Phase 3a (architect agent launch). This is the first conflict gate.
+
+The phase must:
+1. Check guard: if `SNAPSHOTS_CAPTURED=false` OR `DRY_RUN=true`, print `[conflict-check] Skipped.` and proceed to Phase 3a.
+2. For each issue ref, re-fetch: `gh issue view {number} --json number,title,state,assignees,labels,body,updatedAt`
+3. Compute a fresh snapshot (same shape as Phase 0).
+4. Diff against `.claude/backlog-cache.json` entries using the diff algorithm from `design.md` (check `updated_at` first; if unchanged, mark clean; if changed, compare `state`, `title`, `assignees`, `labels`, `body_sha`).
+5. Collect all conflicts with their severity classification.
+6. If no conflicts: print `[conflict-check] All issues clean (Phase 3a.0). Proceeding.` and continue.
+7. If conflicts: print the conflict report table (format from `design.md`) and await user input.
+   - Accept `A`/`a` (abort) or `C`/`c` (continue). Re-prompt on invalid input, up to 3 times. Default to abort on third invalid.
+   - On abort: print `[conflict-abort] Pipeline aborted. Re-run /implement after resolving the issues.` and exit.
+   - On continue: print `[conflict-override] Continuing. N conflict(s) logged.` Append each conflict to `CONFLICT_OVERRIDES` with `{phase: "3a.0", issue, field, severity, was, now}`.
+
+**Files:**
+- Modify: `templates/commands/implement.md`
+
+**Acceptance criteria:**
+- Phase 3a.0 block appears between Phase 0 and Phase 3a in the document.
+- Guard conditions (`SNAPSHOTS_CAPTURED=false`, `DRY_RUN=true`) are checked at the top of the phase.
+- `updated_at` short-circuit is present: if `updated_at` matches, skip field comparison.
+- All five conflictable fields are checked: `state`, `title`, `assignees`, `labels`, `body_sha`.
+- Severity classification matches `design.md` table exactly.
+- Conflict report table format matches `design.md` "Conflict Report Format" section.
+- Invalid input re-prompts up to 3 times, then defaults to abort.
+- Abort exits without any git state changes.
+- Continue appends to `CONFLICT_OVERRIDES`; pipeline proceeds to Phase 3a.
+
+**Dependencies:** T1
+
+---
+
+## T3 — Add Phase 4c.0 pre-ship conflict check to `implement.md` [templates]
+
+**Description:**
+In `templates/commands/implement.md`, insert a new `Phase 4c.0` block immediately before Phase 4c (the shipping phase). This is the final conflict gate — the last check before code reaches git.
+
+The phase is structurally identical to Phase 3a.0. It MUST NOT skip the check just because the user continued through Phase 3a.0. Each check is independent.
+
+The phase must follow the same pattern as T2 (guard check, re-fetch, diff, report, await A/C input) with `phase: "4c.0"` in conflict override entries.
+
+Also add the Dry-Run Gate note: when `DRY_RUN=true`, this phase is skipped (consistent with all Phase 4c behavior).
+
+**Files:**
+- Modify: `templates/commands/implement.md`
+
+**Acceptance criteria:**
+- Phase 4c.0 block appears between Phase 4b-sec (security reviewer) and the Dry-Run Gate in Phase 4c.
+- Same guard, re-fetch, diff, report, and A/C input logic as Phase 3a.0.
+- Conflicts from Phase 3a.0 that the user continued through are still reported if they persist.
+- `phase: "4c.0"` used in `CONFLICT_OVERRIDES` entries for this check.
+- On abort: no git operations have been performed (this check runs before any git op in Phase 4c).
+
+**Dependencies:** T2
+
+---
+
+## T4 — Add Conflict Overrides section to Phase 4e report in `implement.md` [templates]
+
+**Description:**
+In `templates/commands/implement.md`, add a `## Conflict Overrides` section to the Phase 4e final report block. This section appears only when `CONFLICT_OVERRIDES` is non-empty.
+
+The section format:
+```
+## Conflict Overrides
+
+The following backlog conflicts were detected but overridden by the user:
+
+| Phase | Issue | Field | Severity | Was | Now |
+|-------|-------|-------|----------|-----|-----|
+| 3a.0  | #42   | state | CRITICAL | open | closed |
+```
+
+If `CONFLICT_OVERRIDES` is empty or `SNAPSHOTS_CAPTURED=false`: omit the section entirely. Do not print an empty table or a "No conflict overrides" line — simply omit.
+
+Update the standard pipeline table in Phase 4e to note whether conflict checks ran: add a `Conflicts` column with value `clean`, `overridden (N)`, or `skipped`.
+
+**Files:**
+- Modify: `templates/commands/implement.md`
+
+**Acceptance criteria:**
+- `## Conflict Overrides` section is present in Phase 4e report prose with conditional logic.
+- Section is omitted when `CONFLICT_OVERRIDES` is empty.
+- Table columns: Phase, Issue, Field, Severity, Was, Now.
+- Standard pipeline table has a `Conflicts` column.
+- `Conflicts` column values: `clean` (no conflicts detected), `overridden (N)` (user chose Continue N times), `skipped` (guard condition was met).
+
+**Dependencies:** T3
+
+---
+
+## T5 — Add snapshot write to `product-backlog.md` [templates]
+
+**Description:**
+In `templates/commands/product-backlog.md`, add a snapshot-write step after the product-analyst agent's display output completes.
+
+The step runs in the orchestrating command (not inside the agent prompt). It:
+1. Checks `GH_AVAILABLE` — if false, skip and print `[backlog-cache] Skipped — GH unavailable.`
+2. For each issue the product-analyst fetched, write a snapshot to `.claude/backlog-cache.json` using the same schema from `design.md`.
+3. Merge strategy: if the file already exists, read it, merge new entries by issue number (new entries overwrite old by number key), write back. If the file does not exist, create it.
+4. Set `written_by: "product-backlog"` and update `last_updated`.
+5. If write fails: print `[backlog-cache] Warning: could not write cache. Continuing.` Do not abort.
+
+Note: The product-analyst agent already fetches issues via `BACKLOG_FETCH_CMD`. The command needs the raw issue data (number, title, state, assignees, labels, body, updatedAt) to build snapshots. Add a bash step after the agent completes that re-fetches each issue in the result set for snapshot purposes, OR — preferably — instruct the product-analyst to output a machine-readable issue list at the end of its response that the command can parse.
+
+Design decision: use a re-fetch approach for simplicity and reliability. After the agent displays its output, the command runs `gh issue list --label "product-driven-backlog" --state open --json number,title,state,assignees,labels,body,updatedAt` to get all issues in one call, then writes snapshots for each. This is one additional API call and avoids parsing agent output.
+
+**Files:**
+- Modify: `templates/commands/product-backlog.md`
+
+**Acceptance criteria:**
+- Snapshot write step appears after the product-analyst agent completes, before the command returns.
+- Uses `gh issue list --label "product-driven-backlog" --state open --json number,title,state,assignees,labels,body,updatedAt` for the batch fetch.
+- Merge logic: existing entries preserved for issue numbers not in current fetch; new/updated entries overwrite by number key.
+- `written_by: "product-backlog"` set in the file.
+- Write failure is non-fatal — warning printed, command continues.
+- `GH_AVAILABLE=false` guard skips silently.
+- The step is invisible to the user on the happy path (no output unless there's a warning).
+
+**Dependencies:** none (independent of T1–T4)
+
+---
+
+## T6 — Add `.gitignore` advisory for `.claude/backlog-cache.json` [templates]
+
+**Description:**
+In `templates/commands/implement.md`, add a one-time gitignore check immediately after the snapshot write in Phase 0 (T1's step). If the snapshot was captured, check whether `.gitignore` covers `backlog-cache.json`:
+
+```bash
+grep -q "backlog-cache" .gitignore 2>/dev/null || \
+grep -q "\.claude/" .gitignore 2>/dev/null
+```
+
+If neither pattern is found, print:
+```
+[backlog-cache] Suggestion: add '.claude/backlog-cache.json' to .gitignore to avoid committing ephemeral cache state.
+```
+
+This is a one-time advisory. It MUST NOT block the pipeline. It MUST NOT re-print on every run if the user has already added the entry.
+
+**Files:**
+- Modify: `templates/commands/implement.md`
+
+**Acceptance criteria:**
+- `.gitignore` check appears after the cache write in Phase 0, only when `SNAPSHOTS_CAPTURED=true`.
+- Check is non-blocking — passes whether or not `.gitignore` is updated.
+- Advisory prints only when neither `backlog-cache` nor `.claude/` is found in `.gitignore`.
+- Advisory message matches the format above exactly.
+
+**Dependencies:** T1
+
+---
+
+## T7 — Manual end-to-end verification [core]
+
+**Description:**
+Verify the complete conflict detection flow works end-to-end using the specrails repo as a test bed.
+
+**Verification steps:**
+
+1. Identify a real open GitHub Issue in the specrails repo (or use a test issue).
+2. Run `/implement #<number>` and confirm Phase 0 writes `.claude/backlog-cache.json`. Inspect the file: validate JSON is well-formed, `schema_version: "1"` is present, `body_sha` is a 64-char hex string, `assignees` and `labels` are sorted arrays.
+3. While the pipeline is in Phase 3a (architect running), manually close the issue via `gh issue close <number>`. Wait for architect to complete.
+4. Confirm Phase 3a.0 re-fetch detects the close and prints the conflict report with `state: CRITICAL`.
+5. Choose `[A]bort` — verify the pipeline exits cleanly with no git state left behind.
+6. Reopen the issue. Re-run `/implement #<number>`.
+7. At Phase 3a.0, all issues should be clean — confirm `[conflict-check] All issues clean (Phase 3a.0). Proceeding.` is printed.
+8. At Phase 4c.0, confirm the second clean check runs and prints cleanly.
+9. Run `/product-backlog` and confirm `.claude/backlog-cache.json` is updated with `written_by: "product-backlog"`.
+10. Run `/implement` with `--dry-run` — confirm both conflict check phases print `[conflict-check] Skipped.`
+
+**Files:** none (verification only)
+
+**Acceptance criteria:**
+- All 10 steps pass without errors.
+- `.claude/backlog-cache.json` is valid JSON on inspection (verify with `jq . .claude/backlog-cache.json`).
+- Abort path leaves no git branches, commits, or staged changes.
+- Dry-run path produces no conflict check output beyond the skip line.
+- No unresolved `{{PLACEHOLDER}}` tokens in any output.
+
+**Dependencies:** T1, T2, T3, T4, T5, T6

--- a/templates/commands/implement.md
+++ b/templates/commands/implement.md
@@ -96,6 +96,10 @@ If none of these flags is present: `DRY_RUN=false`, `APPLY_MODE=false`, `CONFIDE
 
 Note: `CACHE_DIR` for `--dry-run` is finalized after the feature name is derived from the remaining input. All subsequent phases that reference `CACHE_DIR` have access to it.
 
+Initialize conflict-tracking variables:
+- `SNAPSHOTS_CAPTURED=false` — set to true in Phase 0 if issue snapshots are successfully written.
+- `CONFLICT_OVERRIDES=[]` — list of conflict records where the user chose to continue; appended by Phase 3a.0 and Phase 4c.0.
+
 ---
 
 **If the user passed a text description** (e.g. `"add feature X"`):
@@ -111,6 +115,72 @@ Note: `CACHE_DIR` for `--dry-run` is finalized after the feature name is derived
 - Extract area, value, effort, and feature details from each issue body.
 - If only 1 issue: set `SINGLE_MODE = true`.
 - **Skip Phase 1 and Phase 2** — go directly to confirmation table.
+
+#### Phase 0 snapshot capture
+
+After fetching issue refs, capture a baseline snapshot for conflict detection.
+
+**If `GH_AVAILABLE=true` and the input mode was issue numbers:**
+
+For each resolved issue number, run:
+
+```bash
+gh issue view {number} --json number,title,state,assignees,labels,body,updatedAt
+```
+
+Build a snapshot object for each issue:
+- `number`: integer issue number
+- `title`: issue title string
+- `state`: `"open"` or `"closed"`
+- `assignees`: array of assignee login names, sorted alphabetically
+- `labels`: array of label names, sorted alphabetically
+- `body_sha`: SHA-256 of the raw body string — compute with:
+  ```bash
+  echo -n "{body}" | sha256sum | cut -d' ' -f1
+  ```
+  If `sha256sum` is not available, fall back to `openssl dgst -sha256 -r` or `shasum -a 256`.
+- `updated_at`: the `updatedAt` value from the GitHub API response
+- `captured_at`: current local time in ISO 8601 format
+
+Write the following JSON to `.claude/backlog-cache.json` (overwrite fully — this establishes a fresh baseline for this run):
+
+```json
+{
+  "schema_version": "1",
+  "provider": "github",
+  "last_updated": "<ISO 8601 timestamp>",
+  "written_by": "implement",
+  "issues": {
+    "<number>": { <snapshot object> },
+    ...
+  }
+}
+```
+
+If the write succeeds: set `SNAPSHOTS_CAPTURED=true`.
+
+If the write fails (e.g., `.claude/` directory does not exist): print `[backlog-cache] Warning: could not write cache. Conflict detection disabled for this run.` and set `SNAPSHOTS_CAPTURED=false`. Do NOT abort the pipeline.
+
+**If `GH_AVAILABLE=false` or input was not issue numbers:**
+
+Set `SNAPSHOTS_CAPTURED=false`. Print: `[conflict-check] Snapshot skipped — GH unavailable or non-issue input.`
+
+#### Gitignore advisory
+
+If `SNAPSHOTS_CAPTURED=true`, check whether `.gitignore` already covers the cache file:
+
+```bash
+grep -q "backlog-cache" .gitignore 2>/dev/null || \
+grep -q "\.claude/" .gitignore 2>/dev/null
+```
+
+If neither pattern is found, print:
+
+```
+[backlog-cache] Suggestion: add '.claude/backlog-cache.json' to .gitignore to avoid committing ephemeral cache state.
+```
+
+This advisory is non-blocking and suppressed when `.gitignore` already covers the file.
 
 **If the user passed area names**:
 - Check for open backlog issues. If found, filter and pick top 3.
@@ -131,6 +201,67 @@ Wait for all to complete. Read their output.
 **Only runs if Phase 1 ran.**
 
 Pick the single idea with the best impact/effort ratio from each exploration. Present to user and wait for confirmation.
+
+## Phase 3a.0: Pre-architect conflict check
+
+**Guard:** If `SNAPSHOTS_CAPTURED=false` OR `DRY_RUN=true`, print `[conflict-check] Skipped — SNAPSHOTS_CAPTURED=false (or dry-run mode).` and proceed directly to Phase 3a.
+
+Otherwise, re-fetch each issue in scope and diff against the Phase 0 snapshot:
+
+For each issue number in `ISSUE_REFS`:
+
+```bash
+gh issue view {number} --json number,title,state,assignees,labels,body,updatedAt
+```
+
+If the `gh` command returns non-zero (issue deleted or inaccessible): treat as a CRITICAL conflict — field `"state"`, was `<cached state>`, now `"deleted"`.
+
+Otherwise, reconstruct a current snapshot (same shape as Phase 0: sort `assignees` and `labels`, compute `body_sha`).
+
+**Short-circuit:** If `current.updatedAt == cached.updated_at`, mark the issue as clean and skip field comparison.
+
+**Field comparison** (only when `updatedAt` differs):
+
+| Field | Conflict if... | Severity |
+|-------|----------------|----------|
+| `state` | value differs (`open` → `closed`) | CRITICAL |
+| `state` | value differs (`closed` → `open`) | WARNING |
+| `title` | string differs | WARNING |
+| `assignees` | sorted array differs | WARNING |
+| `labels` | sorted array differs | INFO |
+| `body_sha` | SHA differs | WARNING |
+
+Collect all conflicts across all issues. If none: print `[conflict-check] All issues clean (Phase 3a.0). Proceeding.` and continue to Phase 3a.
+
+**If conflicts exist**, print the following report and await user input:
+
+```
+## Backlog Conflict Detected
+
+The following issues changed since Phase 0 snapshot (captured at <captured_at>):
+
+| Issue | Field | Severity | Was | Now |
+|-------|-------|----------|-----|-----|
+| #N    | state | CRITICAL | open | closed |
+| #N    | body  | WARNING  | <sha-prefix> | <sha-prefix> |
+
+How would you like to proceed?
+  [A] Abort — stop the pipeline and exit cleanly
+  [C] Continue — proceed despite the conflicts (logged)
+
+Enter A or C:
+```
+
+For `body_sha` rows in the table, display only the first 8 characters of each SHA as the "Was" and "Now" values.
+
+**Input handling:**
+- Accept `A`, `a` (abort) or `C`, `c` (continue).
+- Re-prompt on any other input, up to 3 times total.
+- After 3 invalid inputs: print `[conflict-abort] Defaulting to abort after 3 invalid inputs.` and abort.
+
+**On abort:** Print `[conflict-abort] Pipeline aborted. Re-run /implement after resolving the issues.` and exit. No git state is left behind.
+
+**On continue:** Print `[conflict-override] Continuing. N conflict(s) logged.` Append each conflict to `CONFLICT_OVERRIDES` as `{phase: "3a.0", issue: "#N", field: "<field>", severity: "<severity>", was: "<was>", now: "<now>"}`. Proceed to Phase 3a.
 
 ## Phase 3a: Architect (parallel, in main repo)
 
@@ -588,6 +719,30 @@ When `DRY_RUN=true`, the reviewer still writes `confidence-score.json` (it is an
 "confidence-gate: blocked — Phase 4c skipped"
 ```
 
+### Phase 4c.0: Pre-ship conflict check
+
+**Guard:** If `SNAPSHOTS_CAPTURED=false` OR `DRY_RUN=true`, print `[conflict-check] Skipped — SNAPSHOTS_CAPTURED=false (or dry-run mode).` and proceed directly to Phase 4c.
+
+This check is independent of Phase 3a.0. Even if the user chose to continue through a conflict at Phase 3a.0, this gate re-checks all in-scope issues against the Phase 0 snapshot. It is the final gate before any code reaches git.
+
+Re-fetch each issue in `ISSUE_REFS` and diff against `.claude/backlog-cache.json` using the same algorithm as Phase 3a.0:
+
+```bash
+gh issue view {number} --json number,title,state,assignees,labels,body,updatedAt
+```
+
+If the cache file is missing or malformed JSON at this point: log `[conflict-check] Warning: cache file missing or unreadable. Skipping diff for this run.` and proceed to Phase 4c (treat as clean).
+
+Apply the same short-circuit (`updatedAt` match → clean), field comparison, and severity classification as Phase 3a.0.
+
+If all issues are clean: print `[conflict-check] All issues clean (Phase 4c.0). Proceeding.` and continue.
+
+If conflicts exist: print the same conflict report format as Phase 3a.0 (with `Phase 4c.0` context) and await `A`/`C` input (same re-prompt and default-abort logic).
+
+**On abort:** Print `[conflict-abort] Pipeline aborted. Re-run /implement after resolving the issues.` and exit. No git operations have been performed at this point.
+
+**On continue:** Print `[conflict-override] Continuing. N conflict(s) logged.` Append each conflict to `CONFLICT_OVERRIDES` as `{phase: "4c.0", issue: "#N", field: "<field>", severity: "<severity>", was: "<was>", now: "<now>"}`. Proceed to Phase 4c.
+
 ### 4c. Ship — Git & backlog updates
 
 **Security gate:** If `SECURITY_BLOCKED=true`:
@@ -743,8 +898,8 @@ rm -rf .claude/.dry-run/<feature-name>/
 **Otherwise**, show the standard pipeline table:
 
 ```
-| Area | Feature | Change Name | Architect | Developer | Tests | Docs | Reviewer | Frontend | Backend | Confidence | Security | CI | Status |
-|------|---------|-------------|-----------|-----------|-------|------|----------|----------|---------|------------|----------|----|--------|
+| Area | Feature | Change Name | Architect | Developer | Tests | Docs | Reviewer | Frontend | Backend | Confidence | Security | CI | Conflicts | Status |
+|------|---------|-------------|-----------|-----------|-------|------|----------|----------|---------|------------|----------|----|-----------|--------|
 ```
 
 Confidence column values:
@@ -771,6 +926,11 @@ Column values:
 - **Backend**: `CLEAN`, `ISSUES`, or `SKIPPED` (no backend files in changeset)
 - **Security**: `CLEAN`, `WARNINGS`, `BLOCKED`, or `SKIPPED`
 
+The `Conflicts` column values:
+- `skipped` — `SNAPSHOTS_CAPTURED=false` (non-issue input or GH unavailable)
+- `clean` — both conflict checks ran and found no changes
+- `overridden (N)` — user chose Continue at one or both gates; N is the total number of conflict records in `CONFLICT_OVERRIDES`
+
 If `MERGE_REPORT.requires_resolution` is non-empty, print an additional section:
 
 ```
@@ -782,6 +942,20 @@ If `MERGE_REPORT.requires_resolution` is non-empty, print an additional section:
 
 Fix these conflicts (search for `<<<<<<<` in each file), then commit the resolved files.
 ```
+
+If `CONFLICT_OVERRIDES` is non-empty, print:
+
+```
+## Conflict Overrides
+
+The following backlog conflicts were detected but overridden by the user:
+
+| Phase | Issue | Field | Severity | Was | Now |
+|-------|-------|-------|----------|-----|-----|
+| 3a.0  | #42   | state | CRITICAL | open | closed |
+```
+
+If `CONFLICT_OVERRIDES` is empty or `SNAPSHOTS_CAPTURED=false`: omit the `## Conflict Overrides` section entirely. Do not print an empty table or a "No conflict overrides" line.
 
 Include the shipping mode in the report:
 - If automatic: show PR URL, CI status, backlog updates made

--- a/templates/commands/product-backlog.md
+++ b/templates/commands/product-backlog.md
@@ -158,3 +158,38 @@ The product-analyst receives this prompt:
     ```
     No product-driven backlog issues found. Run `/update-product-driven-backlog` to generate feature ideas.
     ```
+
+7. **[Orchestrator]** After the product-analyst completes, write issue snapshots to `.claude/backlog-cache.json`.
+
+   **Guard:** If `GH_AVAILABLE=false` (from Phase 0 pre-flight), print `[backlog-cache] Skipped — GH unavailable.` and return. Do not attempt the write.
+
+   **Fetch all open backlog issues in one call:**
+
+   ```bash
+   gh issue list --label "product-driven-backlog" --state open --json number,title,state,assignees,labels,body,updatedAt
+   ```
+
+   For each issue in the result, build a snapshot object:
+   - `number`: integer issue number
+   - `title`: issue title string
+   - `state`: `"open"` or `"closed"`
+   - `assignees`: array of assignee login names, sorted alphabetically
+   - `labels`: array of label names, sorted alphabetically
+   - `body_sha`: SHA-256 of the raw body string — compute with:
+     ```bash
+     echo -n "{body}" | sha256sum | cut -d' ' -f1
+     ```
+     If `sha256sum` is not available, fall back to `openssl dgst -sha256 -r` or `shasum -a 256`.
+   - `updated_at`: the `updatedAt` value from the GitHub API response
+   - `captured_at`: current local time in ISO 8601 format
+
+   **Merge strategy:** If `.claude/backlog-cache.json` already exists and is valid JSON, read it and merge: new snapshot entries overwrite existing entries by issue number key; entries for issue numbers not in the current fetch are preserved (they may be needed by an in-progress `/implement` run). If the file does not exist or is malformed, create it fresh.
+
+   Write the merged result back to `.claude/backlog-cache.json` with:
+   - `schema_version`: `"1"`
+   - `provider`: `"github"`
+   - `last_updated`: current ISO 8601 timestamp
+   - `written_by`: `"product-backlog"`
+   - `issues`: the merged map keyed by string issue number
+
+   If the write fails (e.g., `.claude/` directory does not exist): print `[backlog-cache] Warning: could not write cache. Continuing.` Do not abort.


### PR DESCRIPTION
## Summary

- Two conflict check gates (Phase 3a.0 and 4c.0) detect externally modified issues during pipeline execution
- Issue snapshots stored in `.claude/backlog-cache.json` with SHA-256 body digests
- Severity classification: CRITICAL (closed/reassigned), WARNING (scope change), INFO (label change)
- `/product-backlog` also writes cache after display for baseline availability
- Conflicts column and Conflict Overrides section added to Phase 4e report

## Changes

- `templates/commands/implement.md` — Phase 0 snapshot, 3a.0/4c.0 gates, 4e updates, gitignore advisory
- `templates/commands/product-backlog.md` — post-display cache write step
- Generated instances synced

## Test plan

- [ ] Verify Phase 0 writes `.claude/backlog-cache.json` with correct schema
- [ ] Verify Phase 3a.0 detects closed issue and halts
- [ ] Verify Phase 4c.0 runs independently of 3a.0 result
- [ ] Verify Continue adds entry to CONFLICT_OVERRIDES
- [ ] Verify Phase 4e shows Conflicts column and optional Overrides section
- [ ] Verify `/product-backlog` writes cache after display

Closes #41

---
Implemented via `/implement` pipeline (architect → developer → reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)