### PR TITLE
fix: detect when update.sh runs from specrails source repo

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -71,6 +71,34 @@ if [[ -n "$CUSTOM_ROOT_DIR" ]]; then
     fi
 fi
 
+# Detect if running from within the specrails source repo itself
+if [[ -z "$CUSTOM_ROOT_DIR" && -f "$SCRIPT_DIR/install.sh" && -d "$SCRIPT_DIR/templates" && "$SCRIPT_DIR" == "$REPO_ROOT"* ]]; then
+    # We're inside the specrails source — ask for target repo
+    echo ""
+    echo -e "${YELLOW}⚠${NC}  You're running the updater from inside the specrails source repo."
+    echo -e "   specrails updates a ${BOLD}target${NC} repository, not itself."
+    echo ""
+    read -p "   Enter the path to the target repo (or 'q' to quit): " TARGET_PATH
+    if [[ "$TARGET_PATH" == "q" || -z "$TARGET_PATH" ]]; then
+        echo "   Aborted. No changes made."
+        exit 0
+    fi
+    # Expand ~ and resolve path
+    TARGET_PATH="${TARGET_PATH/#\~/$HOME}"
+    REPO_ROOT="$(cd "$TARGET_PATH" 2>/dev/null && pwd)" || {
+        echo "Error: path does not exist or is not accessible: $TARGET_PATH" >&2
+        exit 1
+    }
+    if [[ ! -d "$REPO_ROOT/.git" ]]; then
+        echo -e "${YELLOW}⚠${NC}  Warning: $REPO_ROOT does not appear to be a git repository."
+        read -p "   Continue anyway? (y/n): " CONTINUE_NOGIT
+        if [[ "$CONTINUE_NOGIT" != "y" && "$CONTINUE_NOGIT" != "Y" ]]; then
+            echo "   Aborted. No changes made."
+            exit 0
+        fi
+    fi
+fi
+
 # ─────────────────────────────────────────────
 # Helpers
 # ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds source repo detection to `update.sh`, mirroring the existing logic in `install.sh`
- When run from inside the specrails source repo, warns the user and prompts for the target repository path
- Validates the target path exists and is a git repository before proceeding

Closes #53

## Test plan
- [ ] Run `./update.sh` from inside the specrails repo — should prompt for target path
- [ ] Enter a valid target repo path — should proceed with update
- [ ] Enter 'q' or empty — should abort gracefully
- [ ] Enter a non-git directory — should warn and ask to continue

🤖 Generated with [Claude Code](https://claude.com/claude-code)