### PR TITLE
fix: Quick install creates backlog config + fix propose-spec fallback

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -979,6 +979,36 @@ if [[ "$TIER" == "quick" ]]; then
         ok "Installed integration-contract.json"
     fi
 
+    # --- Backlog config (default: local provider) ---
+    _backlog_cfg="${REPO_ROOT}/.specrails/backlog-config.json"
+    if [[ ! -f "$_backlog_cfg" ]]; then
+        mkdir -p "${REPO_ROOT}/.specrails"
+        cat > "$_backlog_cfg" <<'BCEOF'
+{
+  "provider": "local",
+  "write_access": true,
+  "git_auto": true
+}
+BCEOF
+        ok "Created .specrails/backlog-config.json (provider: local, git_auto: true)"
+    fi
+
+    # --- Local tickets store ---
+    _tickets_file="${REPO_ROOT}/.specrails/local-tickets.json"
+    if [[ ! -f "$_tickets_file" ]]; then
+        _now="$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")"
+        cat > "$_tickets_file" <<LTEOF
+{
+  "schema_version": "1.0",
+  "revision": 0,
+  "last_updated": "${_now}",
+  "next_id": 1,
+  "tickets": {}
+}
+LTEOF
+        ok "Created .specrails/local-tickets.json"
+    fi
+
     # --- Skills (OpenSpec) ---
     if [[ -d "$_templates/skills" ]]; then
         mkdir -p "${REPO_ROOT}/${SPECRAILS_DIR}/skills"
@@ -1033,6 +1063,8 @@ if [[ "$TIER" == "quick" ]]; then
     echo "  Installed:"
     echo "    ${_installed_agents} agent(s)    → ${SPECRAILS_DIR}/agents/"
     echo "    ${_installed_commands} command(s)  → ${SPECRAILS_DIR}/commands/specrails/"
+    echo "    .specrails/backlog-config.json   (provider: local)"
+    echo "    .specrails/local-tickets.json"
     echo "    .specrails/specrails-version"
     echo "    .specrails/specrails-manifest.json"
     echo ""

--- a/specrails-plugin/skills/propose-spec/SKILL.md
+++ b/specrails-plugin/skills/propose-spec/SKILL.md
@@ -55,18 +55,11 @@ Output ONLY the following structured markdown. Do not add any preamble or explan
 
 After generating the proposal, read `.specrails/backlog-config.json` to determine `BACKLOG_PROVIDER` and `BACKLOG_WRITE`.
 
+If `.specrails/backlog-config.json` does not exist, default to `provider=local` and `write_access=true`. Initialize `.specrails/local-tickets.json` if it does not exist (empty store with `schema_version: "1.0"`, `revision: 0`, `next_id: 1`, `tickets: {}`).
+
 ### If provider=local — Create Local Ticket
 
-Create a local ticket from the proposal output:
-
-```
-If `BACKLOG_PROVIDER=github` and `BACKLOG_WRITE=true`:
-  ```bash
-  gh issue create --title "<TITLE>" --body "<BODY>" --label "product-driven-backlog"
-  ```
-If `BACKLOG_PROVIDER=local` and `BACKLOG_WRITE=true`: add entry to `.specrails/local-tickets.json`.
-If `BACKLOG_WRITE=false`: display the proposal only, do not create an issue.
-```
+Create a local ticket by adding an entry to `.specrails/local-tickets.json`. Use the advisory locking protocol: read file → set `id = next_id`, increment `next_id`, set all ticket fields, set `created_at` and `updated_at` to now, bump `revision`, update `last_updated` → write file.
 
 Set the following fields:
 - `title`: The Spec Title from the proposal
@@ -82,12 +75,7 @@ Print: `Created local ticket #{id}: {title}`
 ### If provider=github and BACKLOG_WRITE=true — Create GitHub Issue
 
 ```bash
-If `BACKLOG_PROVIDER=github` and `BACKLOG_WRITE=true`:
-  ```bash
-  gh issue create --title "<TITLE>" --body "<BODY>" --label "product-driven-backlog"
-  ```
-If `BACKLOG_PROVIDER=local` and `BACKLOG_WRITE=true`: add entry to `.specrails/local-tickets.json`.
-If `BACKLOG_WRITE=false`: display the proposal only, do not create an issue.
+gh issue create --title "<TITLE>" --body "<BODY>" --label "spec-proposal"
 ```
 
 Create a GitHub Issue with:

--- a/templates/commands/specrails/propose-spec.md
+++ b/templates/commands/specrails/propose-spec.md
@@ -49,6 +49,8 @@ Output ONLY the following structured markdown. Do not add any preamble or explan
 
 After generating the proposal, read `.specrails/backlog-config.json` to determine `BACKLOG_PROVIDER` and `BACKLOG_WRITE`.
 
+If `.specrails/backlog-config.json` does not exist, default to `provider=local` and `write_access=true`. Initialize `.specrails/local-tickets.json` if it does not exist (empty store with `schema_version: "1.0"`, `revision: 0`, `next_id: 1`, `tickets: {}`).
+
 ### If provider=local — Create Local Ticket
 
 Create a local ticket from the proposal output:


### PR DESCRIPTION
## Summary
- Quick tier install now auto-creates `.specrails/backlog-config.json` (provider: local, `git_auto: true`) and initializes `.specrails/local-tickets.json` so `/specrails:propose-spec` works out of the box
- Fixed garbled code blocks in propose-spec SKILL.md where local and GitHub sections both contained duplicate generic if/else logic
- Added fallback in propose-spec (template + SKILL) to default to local provider when backlog config is missing

## Test plan
- [ ] Run `install.sh --quick` on a fresh repo — verify `.specrails/backlog-config.json` and `.specrails/local-tickets.json` are created
- [ ] Run `/specrails:propose-spec` in a quick-installed repo — verify ticket is added to local-tickets.json
- [ ] Verify idempotency: re-running quick install does not overwrite existing backlog-config.json

Closes SPEA-750

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>