### PR TITLE
fix: add pipeline completion guards to implement and batch-implement

### DIFF
--- a/specrails-plugin/skills/batch-implement/SKILL.md
+++ b/specrails-plugin/skills/batch-implement/SKILL.md
@@ -158,7 +158,9 @@ Dependency graph:
 Proceed? (yes / no / edit-deps)
 ```
 
-Wait for user confirmation.
+**If `--yes` flag is present in `$ARGUMENTS`**: auto-proceed without asking. Skip this confirmation and continue to Phase 2 immediately.
+
+Otherwise, wait for user confirmation:
 
 - **`yes`**: proceed to Phase 2.
 - **`no`**: stop. Print `[batch-implement] Aborted by user.`
@@ -205,6 +207,7 @@ For each wave `W`:
      ```
    - Run invocations in the batch in parallel (`run_in_background: true`).
    - Wait for all in the batch to complete before starting the next batch.
+   - **COMPLETION GUARD**: Do not exit the wave loop early. Even if invocations take a long time or return errors, record outcomes and continue to the next batch/wave. Always reach Phase 3 (Batch Report).
 3. For each completed invocation, record outcome in `WAVE_RESULTS`:
    - `{ref, wave, status: "done" | "failed", error_summary: "..." | null}`
 

--- a/specrails-plugin/skills/implement/SKILL.md
+++ b/specrails-plugin/skills/implement/SKILL.md
@@ -444,6 +444,8 @@ For each entry in `DEVELOPER_ROUTING`, launch the assigned developer agent using
 
 Wait for all developers to complete.
 
+> **COMPLETION GUARD — MANDATORY:** Once all developer agents finish (success or failure), you MUST proceed through the remaining phases in order: Phase 3c (test writer) → Phase 3d (doc sync) → Phase 4a (merge worktrees) → Phase 4b (reviewer). NEVER exit after Phase 3b. The merge phase (4a) is non-negotiable — if a developer agent timed out or errored, still proceed to merge whatever files were written to the worktree. If context is running low, deprioritize Phase 3c and 3d but ALWAYS run Phase 4a before exiting.
+
 **Pipeline state:** update `developer` → `done`. Also update `implemented_files` in the state file with the complete list of files created or modified by the developer agent(s). If developer failed: update `developer` → `failed` with error context `"sr-developer failed: <exit code or error description>"`.
 
 ## Phase 3c: Write Tests


### PR DESCRIPTION
## Problem

The outer Claude session of `/specrails:implement` can exit cleanly (exit 0) after Phase 3b (developer agents complete) without running Phase 4a (merge worktrees). This leaves worktrees unmerged and changes orphaned. Observed in a real run where #10 developer took 10+ minutes and the outer session exited without merging.

## Fix

**`implement/SKILL.md`**: Add an explicit `COMPLETION GUARD` block immediately after "Wait for all developers to complete" stating:
- Must proceed through Phase 3c → 3d → 4a → 4b regardless of developer outcomes
- Phase 4a (merge) is non-negotiable even if developers timed out or errored
- If context is running low, deprioritize Phase 3c/3d but **always** run Phase 4a

**`batch-implement/SKILL.md`**:
- Auto-proceed past Phase 1 wave plan confirmation when `--yes` flag is present (prevents hanging in headless/pipeline mode)
- Add completion guard in the wave execution loop to always reach Phase 3 (Batch Report)

## Test plan

- [ ] Run `/specrails:implement` with two features where one developer takes a long time — verify merge phase runs
- [ ] Run `/specrails:batch-implement #A #B --yes` — verify it proceeds without asking for confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)