### PR TITLE
docs: refresh README — drop Claude plugin path, add Ko-fi Donate link

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,14 @@ Codex uses the scaffold method: `npx specrails-core@latest init --root-dir .`. S
 
 ---
 
+## Support
+
+If specrails-core is useful to you, you can donate on [Ko-fi](https://ko-fi.com/D1D81Y002C) ☕ to support ongoing development.
+
+[![Donate on Ko-fi](https://img.shields.io/badge/Donate-Ko--fi-FF5E5B?logo=kofi&logoColor=white&style=flat-square)](https://ko-fi.com/D1D81Y002C)
+
+---
+
 ## License
 
 MIT — [fjpulidop](https://github.com/fjpulidop)


### PR DESCRIPTION
## Summary

Two-in-one update to README.md:

### 1. Refresh + drop plugin references
The Claude Code plugin distribution is being retired. The README is now written around the `npx` scaffold flow as the single install path.

**Removed**
- All \`claude plugin install sr\` / \`claude plugin update sr\` mentions
- The Plugin vs Scaffold comparison table
- The "Plugin (logic — auto-updated)" install section
- Plugin-specific FAQ entries
- Stale "Product Hunt launch day" teaser

**Refreshed**
- Tagline: "agentic development team" (brand alignment with specrails-web)
- One-command install + tier picker (Quick / Full)
- \`What gets installed\` lists the real on-disk layout under \`.claude/\` + \`.specrails/\`
- Prerequisites table: Node 18+ is now required; Claude Code OR Codex phrased as alternatives
- FAQ: re-run instructions reflect the npx-only flow
- New \`Related\` section linking specrails-hub + specrails.dev
- Design principle renamed "Local by default" to emphasise no-cloud / no-telemetry

### 2. Ko-fi Donate link
Support section above License pointing at https://ko-fi.com/D1D81Y002C ☕.

## Test plan
- [x] \`grep -c "claude plugin" README.md\` → 0
- [ ] Manual read-through for copy tone
- [ ] Once merged, double-check the Ko-fi badge renders on the GitHub repo page

🤖 Generated with [Claude Code](https://claude.com/claude-code)