### PR TITLE
chore(codex): disable Codex install + add Coming Soon notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![npm downloads](https://img.shields.io/npm/dw/specrails-core.svg)](https://www.npmjs.com/package/specrails-core)
 [![Claude Code](https://img.shields.io/badge/Built%20for-Claude%20Code-blueviolet)](https://docs.anthropic.com/en/docs/claude-code)
-[![Codex](https://img.shields.io/badge/Built%20for-OpenAI%20Codex-412991)](https://github.com/openai/codex)
+[![Codex — Coming Soon](https://img.shields.io/badge/OpenAI%20Codex-Coming%20Soon%20(in%20lab)-lightgrey)](https://github.com/openai/codex)
 
 **Your agentic development team. From idea to production code.**
 
@@ -16,7 +16,9 @@ npx specrails-core@latest init   # install into the current repo
 /specrails:enrich                # optional: deep codebase analysis
 ```
 
-> **Requirements:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [Codex CLI](https://github.com/openai/codex) (one of them), git, Node 18+.
+> **Requirements:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code), git, Node 18+.
+>
+> **🧪 Codex (OpenAI) support — Coming Soon:** We are testing Codex integration in our lab. Installation is disabled for now, but the feature will be available shortly. Follow the repo for updates.
 
 ---
 
@@ -217,7 +219,8 @@ Each persona scores features 0–5. Features are ranked by score / effort ratio.
 
 | Tool | Required | Purpose |
 |------|----------|---------|
-| **Claude Code** or **Codex CLI** | Yes (one of them) | AI agent runtime |
+| **Claude Code** | Yes | AI agent runtime |
+| **Codex CLI** _(coming soon — in lab)_ | 🧪 Not yet | OpenAI Codex support is being tested in our lab and will be available shortly. |
 | **git** | Yes | Repository detection |
 | **Node 18+** | Yes | Needed for `npx specrails-core@latest init` |
 | **GitHub CLI** (`gh`) | Optional | Backlog sync to GitHub Issues, PR creation. Not needed with local tickets. |
@@ -268,10 +271,10 @@ Not simultaneously for the same project — backlog commands use one active prov
 A full `/specrails:implement` cycle for one feature typically costs a few dollars in Claude API usage. The sr-product-manager uses Opus; all other agents use Sonnet or Haiku.
 
 **Does it work with private repos?**
-Yes. Everything runs locally through Claude Code (or Codex). No external services beyond the model API.
+Yes. Everything runs locally through Claude Code. No external services beyond the model API.
 
 **How do I use specrails with Codex?**
-Same install path: `npx specrails-core@latest init --root-dir .`. The TUI detects Codex and adjusts the agent configuration. See [docs/user-docs/getting-started-codex.md](./docs/user-docs/getting-started-codex.md).
+🧪 **Coming Soon — in lab.** OpenAI Codex support is currently being tested in our lab and will be available shortly. The install path will remain the same (`npx specrails-core@latest init --root-dir .`) — the installer will detect Codex and adjust the agent configuration automatically. See [docs/user-docs/getting-started-codex.md](./docs/user-docs/getting-started-codex.md) for the preview documentation.
 
 ---
 

--- a/bin/tui-installer.mjs
+++ b/bin/tui-installer.mjs
@@ -185,9 +185,20 @@ async function run() {
   const specrailsDir = resolve(rootDir, '.specrails');
 
   // Auto-yes: write defaults and exit (no TUI needed)
+  //
+  // Codex (OpenAI) support is currently being tested in our lab ("Coming Soon").
+  // If only Codex is detected, bail out instead of silently picking it — Claude
+  // Code is the only runtime we can install for today.
   if (autoYes) {
     const { hasClaude, hasCodex } = detectProvider();
-    const provider = hasCodex && !hasClaude ? 'codex' : 'claude';
+    if (!hasClaude && hasCodex) {
+      console.error('');
+      console.error('  ⚠  Only Codex detected — Codex (OpenAI) support is coming soon (in lab).');
+      console.error('     Please install Claude Code to continue: https://claude.ai/download');
+      console.error('');
+      process.exit(1);
+    }
+    const provider = 'claude';
     writeDefaultConfig(specrailsDir, provider);
     console.log(`  ✓ Default config written to .specrails/install-config.yaml`);
     console.log(`  ✓ Provider: ${provider}, Tier: full, Agents: ${DEFAULT_SELECTED.size}/${ALL_AGENT_IDS.length}, Preset: balanced\n`);
@@ -217,6 +228,10 @@ async function run() {
   console.log(banner.join('\n'));
 
   // ── Step 1: Provider ────────────────────────────────────────────────────────
+  //
+  // Codex (OpenAI) is still being tested in our lab ("Coming Soon"). Until the
+  // feature ships, the TUI exposes only Claude Code as a runtime — Codex shows
+  // as a disabled "Coming Soon" option so users can see it's on the roadmap.
 
   const { hasClaude, hasCodex } = detectProvider();
   let provider;
@@ -226,12 +241,16 @@ async function run() {
       message: 'Which AI provider will you use?',
       choices: [
         { value: 'claude', name: 'Claude Code (recommended)' },
-        { value: 'codex',  name: 'Codex' },
+        { value: 'codex',  name: 'Codex — Coming Soon (in lab)', disabled: '🧪 coming soon' },
       ],
     });
   } else if (hasCodex) {
-    provider = 'codex';
-    console.log('  → Provider: codex (auto-detected)\n');
+    exitFullscreen();
+    console.error('');
+    console.error('  ⚠  Only Codex detected — Codex (OpenAI) support is coming soon (in lab).');
+    console.error('     Please install Claude Code to continue: https://claude.ai/download');
+    console.error('');
+    process.exit(1);
   } else {
     provider = 'claude';
     if (hasClaude) {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,7 @@
 # Deployment
 
+> **🧪 Codex (OpenAI) Support — Coming Soon (in Lab).** Any Codex-specific option or step below describes the planned behaviour. Codex installation is currently disabled; the installer will guide you to Claude Code instead.
+
 SpecRails runs locally — no cloud infrastructure required. Choose the setup that fits your workflow.
 
 ## Options at a glance

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,6 +15,8 @@ You need:
 - **Git** — your project must be a git repository
 - **[Claude Code](https://claude.ai/claude-code)** — Anthropic's CLI tool
 
+> **🧪 Codex (OpenAI) Support — Coming Soon (in Lab).** OpenAI Codex integration is currently being tested in our lab. The installer will only install with Claude Code for now — Codex support will ship shortly.
+
 Optional (recommended):
 
 - **[GitHub CLI](https://cli.github.com/)** (`gh`) — for automatic PR creation and issue tracking

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,15 +2,19 @@
 
 This guide covers the complete installation process in detail. For the quick version, see [Getting Started](getting-started.md).
 
+> ## 🧪 Codex (OpenAI) Support — Coming Soon (in Lab)
+>
+> OpenAI Codex integration is currently being **tested in our lab** and **cannot be installed yet**. The installer will refuse any attempt to install with `--provider codex` and will guide you to use Claude Code instead. Codex-specific sections below describe the **planned behaviour** and will be activated when the feature ships.
+
 ## Installation methods
 
-SpecRails supports three distribution channels:
+SpecRails supports two distribution channels today, with a third coming soon:
 
 | Method | Command | Best for |
 |--------|---------|----------|
 | **Claude Code plugin** (recommended) | `claude plugin install sr` | Most projects — no Node.js required, auto-updates |
-| **Claude Code scaffold** | `npx specrails-core@latest init` | Full offline control, Codex users, custom agent edits |
-| **Codex project** | `npx specrails-core@latest init` | OpenAI Codex CLI users |
+| **Claude Code scaffold** | `npx specrails-core@latest init` | Full offline control, custom agent edits |
+| **Codex project** 🧪 _Coming Soon (in lab)_ | `npx specrails-core@latest init` | OpenAI Codex CLI users (not yet available) |
 
 ---
 

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -74,17 +74,19 @@ The scaffold copies the full agent+command set into `.claude/` — you own and v
 
 **Best for:** Teams that want to version the agent prompts themselves, or projects that need full offline control.
 
-### 3. Codex project
+### 3. Codex project 🧪 _Coming Soon (in Lab)_
+
+> **Codex installation is not yet available.** OpenAI Codex integration is being tested in our lab and will ship shortly. The block below describes the **planned behaviour** for when the feature is released.
 
 ```bash
-npx specrails-core@latest init --root-dir .   # same as scaffold
+npx specrails-core@latest init --root-dir .   # same as scaffold (Codex path — not yet available)
 codex                                          # open Codex
 /specrails:enrich                             # configure
 ```
 
-Codex does not support the Claude Code plugin system. Use the scaffold method.
+Codex does not support the Claude Code plugin system. When Codex support ships, use the scaffold method.
 
-**Best for:** OpenAI Codex CLI users.
+**Best for (when available):** OpenAI Codex CLI users.
 
 ## The `/specrails:enrich` wizard
 

--- a/docs/user-docs/cli-reference.md
+++ b/docs/user-docs/cli-reference.md
@@ -1,6 +1,8 @@
 # CLI Reference
 
-SpecRails commands are implemented as Skills (`SKILL.md` format) and run in both Claude Code and Codex. The command syntax is identical on both platforms.
+> **🧪 Codex (OpenAI) Support — Coming Soon (in Lab).** Codex-specific sections below describe the planned behaviour. Codex installation is currently disabled — only Claude Code is available today.
+
+SpecRails commands are implemented as Skills (`SKILL.md` format) and are designed to run in both Claude Code and Codex. The command syntax is identical on both platforms. Today only the Claude Code runtime is available; Codex support is being tested in our lab and will ship shortly.
 
 **Platform support key used in this reference:**
 

--- a/docs/user-docs/codex-vs-claude-code.md
+++ b/docs/user-docs/codex-vs-claude-code.md
@@ -1,6 +1,10 @@
 # Codex vs Claude Code
 
-SpecRails supports both **OpenAI Codex** and **Anthropic Claude Code** as AI agent runtimes. This page explains the differences so you can choose the right setup for your team.
+> # 🧪 Codex Support — Coming Soon (in Lab)
+>
+> OpenAI Codex integration is currently being **tested in our lab** and is not available for installation. The installer only accepts Claude Code at this time. This document describes the planned behaviour and will be activated when the feature ships.
+
+SpecRails supports **Anthropic Claude Code** as an AI agent runtime, with **OpenAI Codex** support coming soon. This page explains the differences so you can choose the right setup for your team when Codex ships.
 
 ---
 

--- a/docs/user-docs/getting-started-codex.md
+++ b/docs/user-docs/getting-started-codex.md
@@ -1,8 +1,12 @@
 # Getting Started with SpecRails + Codex
 
-This guide gets you running SpecRails using OpenAI Codex as your AI agent. If you are using Claude Code instead, see the [standard installation guide](installation.md).
+> # 🧪 Coming Soon — Currently in Lab
+>
+> **OpenAI Codex support is being tested in our lab and is not yet available for installation.** The installer will refuse to install Codex and will ask you to use Claude Code. This document describes the planned behaviour and will be activated when the feature ships.
+>
+> **Current status:** Preview / documentation only. For now, use [Claude Code](https://claude.ai/download) — see the [standard installation guide](installation.md).
 
-> **Beta**: Codex support is available in SpecRails 1.x as a beta feature. Core Skills work out of the box. See [Codex vs Claude Code](codex-vs-claude-code.md) for what is and is not supported.
+This guide gets you running SpecRails using OpenAI Codex as your AI agent. If you are using Claude Code instead, see the [standard installation guide](installation.md).
 
 ---
 

--- a/docs/user-docs/installation.md
+++ b/docs/user-docs/installation.md
@@ -2,7 +2,11 @@
 
 Install SpecRails into any git repository in two steps: install, then run `/specrails:enrich` inside your AI CLI.
 
-SpecRails supports both **Claude Code** and **OpenAI Codex**. The installer detects which CLI you have and configures accordingly. See [Codex vs Claude Code](codex-vs-claude-code.md) for a feature comparison.
+> ## 🧪 Codex (OpenAI) Support — Coming Soon (in Lab)
+>
+> OpenAI Codex integration is currently being **tested in our lab** and **cannot be installed yet**. The installer will refuse any attempt to install with `--provider codex` and will guide you to use Claude Code. Codex-specific sections below describe the **planned behaviour** for when the feature ships.
+
+SpecRails supports **Claude Code** today, with **OpenAI Codex** coming soon. The installer detects which CLI you have and configures accordingly. See [Codex vs Claude Code](codex-vs-claude-code.md) for a feature comparison of the upcoming Codex support.
 
 > **Looking for the comprehensive reference?** See [Installation & Setup](../installation.md) for full wizard phase details and advanced configuration.
 

--- a/docs/user-docs/quick-start.md
+++ b/docs/user-docs/quick-start.md
@@ -2,7 +2,7 @@
 
 Get SpecRails running in your project in under 10 minutes.
 
-> **Using OpenAI Codex?** See the [Codex getting started guide](getting-started-codex.md) — setup is slightly different.
+> **🧪 Using OpenAI Codex? — Coming Soon (in Lab).** Codex support is currently being tested in our lab and is not yet available for installation. The installer will refuse Codex installs and guide you to Claude Code. See the [Codex getting started guide](getting-started-codex.md) for a preview of the planned setup.
 
 ## Before you begin
 

--- a/install.sh
+++ b/install.sh
@@ -69,11 +69,18 @@ while [[ $# -gt 0 ]]; do
             ;;
         --provider)
             if [[ -z "${2:-}" ]]; then
-                echo "Error: --provider requires a value (claude or codex)." >&2
+                echo "Error: --provider requires a value (claude)." >&2
                 exit 1
             fi
-            if [[ "$2" != "claude" && "$2" != "codex" ]]; then
-                echo "Error: --provider value must be 'claude' or 'codex', got: $2" >&2
+            if [[ "$2" == "codex" ]]; then
+                echo "" >&2
+                echo "  ⚠  Codex (OpenAI) support: Coming Soon" >&2
+                echo "     Currently being tested in our lab. Please use --provider claude for now." >&2
+                echo "" >&2
+                exit 1
+            fi
+            if [[ "$2" != "claude" ]]; then
+                echo "Error: --provider value must be 'claude', got: $2" >&2
                 exit 1
             fi
             CLI_PROVIDER="$2"
@@ -108,7 +115,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         *)
             echo "Unknown argument: $1" >&2
-            echo "Usage: install.sh [--root-dir <path>] [--yes|-y] [--provider <claude|codex>] [--from-config [<path>]] [--agent-teams] [--quick] [--hub-json]" >&2
+            echo "Usage: install.sh [--root-dir <path>] [--yes|-y] [--provider <claude>] [--from-config [<path>]] [--agent-teams] [--quick] [--hub-json]" >&2
             exit 1
             ;;
     esac
@@ -308,8 +315,12 @@ if [[ "$FROM_CONFIG" == true ]]; then
         if [[ -z "$_cfg_provider" ]]; then
             fail "Invalid config: missing required 'provider' field"
             _config_errors=$(( _config_errors + 1 ))
-        elif [[ "$_cfg_provider" != "claude" && "$_cfg_provider" != "codex" ]]; then
-            fail "Invalid config: unsupported provider '$_cfg_provider' (expected: claude or codex)"
+        elif [[ "$_cfg_provider" == "codex" ]]; then
+            fail "Codex (OpenAI) support is coming soon — currently being tested in our lab."
+            fail "Please edit install-config.yaml and set: provider: claude"
+            _config_errors=$(( _config_errors + 1 ))
+        elif [[ "$_cfg_provider" != "claude" ]]; then
+            fail "Invalid config: unsupported provider '$_cfg_provider' (expected: claude)"
             _config_errors=$(( _config_errors + 1 ))
         fi
         if [[ "$_cfg_has_agents" -eq 0 ]]; then
@@ -368,42 +379,26 @@ if [[ "$FROM_CONFIG" != true ]]; then
         # --provider flag was set explicitly — skip interactive detection
         ok "Provider: $CLI_PROVIDER (--provider flag)"
     elif [ "$HAS_CLAUDE" = true ] && [ "$HAS_CODEX" = true ]; then
-        echo ""
-        echo -e "  ${BOLD}Both Claude Code and Codex detected.${NC}"
-        if [ "$AUTO_YES" = true ]; then
-            CLI_PROVIDER="claude"
-            info "Auto-selected Claude Code (--yes flag active)"
-        else
-            echo ""
-            echo "    Which provider would you like to use?"
-            echo "      1) Claude Code (claude)  → output to .claude/"
-            echo "      2) Codex (codex)         → output to .codex/"
-            echo ""
-            read -p "    Select provider (1 or 2, default: 1): " PROVIDER_CHOICE || PROVIDER_CHOICE="1"
-            PROVIDER_CHOICE="${PROVIDER_CHOICE:-1}"
-            if [[ "$PROVIDER_CHOICE" == "2" ]]; then
-                CLI_PROVIDER="codex"
-            else
-                CLI_PROVIDER="claude"
-            fi
-        fi
+        CLI_PROVIDER="claude"
+        info "Claude Code and Codex both detected — Codex support coming soon (in lab), using Claude Code."
         ok "Provider: $CLI_PROVIDER"
     elif [ "$HAS_CLAUDE" = true ]; then
         CLI_PROVIDER="claude"
         CLAUDE_VERSION=$(claude --version 2>/dev/null || echo "unknown")
         ok "Claude Code CLI: $CLAUDE_VERSION"
     elif [ "$HAS_CODEX" = true ]; then
-        CLI_PROVIDER="codex"
-        CODEX_VERSION=$(codex --version 2>/dev/null || echo "unknown")
-        ok "Codex CLI: $CODEX_VERSION"
+        fail "Only Codex detected — Codex (OpenAI) support is coming soon (currently in our lab)."
+        echo ""
+        echo "    Please install Claude Code to continue: https://claude.ai/download"
+        exit 1
     elif [[ "$SKIP_PREREQS" == "1" ]]; then
         CLI_PROVIDER="claude"
         warn "No AI CLI found (skipped — SPECRAILS_SKIP_PREREQS=1)"
     else
-        fail "No AI CLI found (claude or codex)."
+        fail "No AI CLI found (claude)."
         echo ""
         echo "    Install Claude Code: https://claude.ai/download"
-        echo "    Install Codex:       https://github.com/openai/codex"
+        echo "    Codex (OpenAI) support: coming soon — currently in our lab."
         exit 1
     fi
 fi

--- a/tests/test-codex-compat.sh
+++ b/tests/test-codex-compat.sh
@@ -146,7 +146,7 @@ test_codex_output_dir_created() {
     run_install_mocked "--provider codex" >/dev/null
     assert_dir_exists "$TEST_TMPDIR/target/.codex"
 }
-run_test "SPEA-506: codex provider → .codex/ directory created" test_codex_output_dir_created
+SKIP_REASON="Codex support gated — coming soon (in lab)" run_test "SPEA-506: codex provider → .codex/ directory created" test_codex_output_dir_created
 
 test_claude_instruction_file_created() {
     setup_mock_bin
@@ -172,7 +172,7 @@ test_codex_instruction_file_created() {
     assert_contains "$(cat "$detection")" '"instructions_file": "AGENTS.md"' \
         ".provider-detection.json should record AGENTS.md as instructions file"
 }
-run_test "SPEA-506: codex provider → AGENTS.md instruction file created" test_codex_instruction_file_created
+SKIP_REASON="Codex support gated — coming soon (in lab)" run_test "SPEA-506: codex provider → AGENTS.md instruction file created" test_codex_instruction_file_created
 
 # ─────────────────────────────────────────────
 # SPEA-507: Skills format
@@ -214,7 +214,7 @@ test_skills_exist_for_codex() {
             "SKILL.md should exist for skill: $skill (codex)"
     done
 }
-run_test "SPEA-507: all expected SKILL.md files created for codex provider" test_skills_exist_for_codex
+SKIP_REASON="Codex support gated — coming soon (in lab)" run_test "SPEA-507: all expected SKILL.md files created for codex provider" test_skills_exist_for_codex
 
 test_backward_compat_slash_commands() {
     setup_mock_bin
@@ -249,7 +249,7 @@ test_codex_config_toml_created() {
     # install.sh stages codex-config.toml in setup-templates/; /setup deploys it to .codex/config.toml
     assert_file_exists "$TEST_TMPDIR/target/.specrails/setup-templates/settings/codex-config.toml"
 }
-run_test "SPEA-508: codex provider → .codex/config.toml created" test_codex_config_toml_created
+SKIP_REASON="Codex support gated — coming soon (in lab)" run_test "SPEA-508: codex provider → .codex/config.toml created" test_codex_config_toml_created
 
 test_codex_starlark_rules_created() {
     setup_mock_bin
@@ -258,7 +258,7 @@ test_codex_starlark_rules_created() {
     # install.sh stages codex-rules.star in setup-templates/; /setup deploys it as .codex/rules/default.rules
     assert_file_exists "$TEST_TMPDIR/target/.specrails/setup-templates/settings/codex-rules.star"
 }
-run_test "SPEA-508: codex provider → .codex/rules/default.rules created" test_codex_starlark_rules_created
+SKIP_REASON="Codex support gated — coming soon (in lab)" run_test "SPEA-508: codex provider → .codex/rules/default.rules created" test_codex_starlark_rules_created
 
 # ─────────────────────────────────────────────
 # SPEA-509: Agent definitions
@@ -304,7 +304,7 @@ test_codex_agent_toml_files() {
     assert_contains "$(cat "$enrich_skill")" "toml" \
         "\$setup skill should contain TOML generation logic for codex"
 }
-run_test "SPEA-509: codex provider → sr-*.toml agents with TOML format" test_codex_agent_toml_files
+SKIP_REASON="Codex support gated — coming soon (in lab)" run_test "SPEA-509: codex provider → sr-*.toml agents with TOML format" test_codex_agent_toml_files
 
 test_agent_prompt_content_identical() {
     setup_mock_bin
@@ -416,7 +416,7 @@ test_switch_provider_claude_to_codex() {
     # .claude/ should still exist (we don't delete it)
     assert_dir_exists "$TEST_TMPDIR/target/.claude"
 }
-run_test "edge case: switching from claude to codex keeps both dirs intact" test_switch_provider_claude_to_codex
+SKIP_REASON="Codex support gated — coming soon (in lab)" run_test "edge case: switching from claude to codex keeps both dirs intact" test_switch_provider_claude_to_codex
 
 test_idempotent_reinstall_codex() {
     setup_mock_bin

--- a/tests/test-helpers.sh
+++ b/tests/test-helpers.sh
@@ -8,6 +8,7 @@ TEST_TMPDIR=""
 TESTS_RUN=0
 TESTS_PASSED=0
 TESTS_FAILED=0
+TESTS_SKIPPED=0
 FAILED_TESTS=()
 
 # Colors
@@ -108,6 +109,16 @@ run_test() {
     local test_fn="$2"
     TESTS_RUN=$(( TESTS_RUN + 1 ))
 
+    # Skip tests gated while a feature is in the lab. Callers mark a test as
+    # skipped by declaring SKIP_REASON="..." before calling run_test. The
+    # variable is consumed and cleared so it never leaks to the next test.
+    if [[ -n "${SKIP_REASON:-}" ]]; then
+        echo -e "  $test_name ... ${YELLOW:-\033[1;33m}SKIP${NC:-\033[0m} (${SKIP_REASON})"
+        TESTS_SKIPPED=$(( ${TESTS_SKIPPED:-0} + 1 ))
+        unset SKIP_REASON
+        return 0
+    fi
+
     setup_test_env
 
     echo -n "  $test_name ... "
@@ -127,7 +138,11 @@ print_summary() {
     local suite_name="$1"
     echo ""
     echo -e "${BOLD}─── $suite_name ───${NC}"
-    echo -e "  Total: $TESTS_RUN  ${GREEN}Passed: $TESTS_PASSED${NC}  ${RED}Failed: $TESTS_FAILED${NC}"
+    local skipped_label=""
+    if [[ "${TESTS_SKIPPED:-0}" -gt 0 ]]; then
+        skipped_label="  ${YELLOW:-\033[1;33m}Skipped: ${TESTS_SKIPPED}${NC:-\033[0m}"
+    fi
+    echo -e "  Total: $TESTS_RUN  ${GREEN}Passed: $TESTS_PASSED${NC}  ${RED}Failed: $TESTS_FAILED${NC}${skipped_label}"
     if [[ ${#FAILED_TESTS[@]} -gt 0 ]]; then
         echo ""
         echo -e "  ${RED}Failed tests:${NC}"


### PR DESCRIPTION
## Summary

- Block `install.sh` from installing with `--provider codex` or `provider: codex` in `install-config.yaml`; force Claude when both CLIs detected; fail with a clear "coming soon" message if only Codex is available.
- Add big **🧪 Coming Soon (in Lab)** banners across README and all user docs that mention Codex, so docs describe planned behaviour instead of available functionality.
- Preserve every Codex code path (templates, provider-aware branches, generated artefacts) — re-enabling Codex will be a matter of flipping the guards when the lab work ships.

## Test plan

- [x] `bash -n install.sh` passes
- [ ] Verify rejection: `./install.sh --provider codex` → prints Coming Soon + exits 1
- [ ] Verify rejection: `install-config.yaml` with `provider: codex` → fails config validation
- [ ] Verify fallback: only Claude detected → proceeds normally
- [ ] Verify fallback: both Claude + Codex detected → picks Claude with a Coming Soon info line
- [ ] Verify fallback: only Codex detected → fails with Coming Soon + install Claude hint
- [ ] Smoke-check every doc page renders with the new banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)