### PR TITLE
fix(release): unblock release-please by removing invalid version-txt updater

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,6 @@
     ".": {
       "release-type": "node",
       "include-component-in-tag": false,
-      "extra-files": [{ "type": "version-txt", "path": "VERSION" }],
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary

PR #242 introduced `"extra-files": [{ "type": "version-txt", "path": "VERSION" }]` in `release-please-config.json`, but `version-txt` is not a built-in release-please updater (the real ones are `json`, `yaml`, `xml`, `pom`, `toml`, `generic`) and no custom updater was wired up.

Every push to `main` since #242 merged has failed with:

```
##[error]release-please failed: unsupported extraFile type: version-txt
```

See the failed run: https://github.com/fjpulidop/specrails-core/actions/runs/24632749322/job/72023292210

This PR removes the broken entry so `release-please` runs with just the default `node` updater (package.json + CHANGELOG). The release pipeline starts working again immediately.

## Trade-off

`VERSION` will no longer be auto-synced to `package.json`. That is the same state the repo was in before #242 — `install.sh` still reads `VERSION` for the installed-version banner, and `package.json` is the source of truth for npm.

## Follow-up

A proper VERSION auto-sync can be added by either:
- Switching to `"type": "generic"` with an `# x-release-please-version` marker in `VERSION` (requires updating install.sh to parse the first whitespace-separated token).
- Adding a workflow step after the release-PR merge that writes `VERSION` from `package.json.version` and commits it back to `main`.

Neither is blocking the release, so they are out of scope here.

## Test plan

- [ ] Merge this PR.
- [ ] Confirm the next push-to-main `Release` workflow run succeeds (release-please creates or updates the release PR without the `unsupported extraFile type` error).
- [ ] When that release PR is merged, confirm `npm publish --provenance` runs and specrails-web receives the `specrails-core-released` dispatch event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)