### PR TITLE
fix(implement): emit final summary only after all parallel developers complete

### DIFF
--- a/templates/commands/specrails/implement.md
+++ b/templates/commands/specrails/implement.md
@@ -555,6 +555,24 @@ For each entry in `DEVELOPER_ROUTING`, launch the assigned developer agent using
 
 Wait for all developers to complete.
 
+**Summary timing (multi-feature mode):** When running multiple background developer agents, individual `task_notification` completions MUST NOT trigger a final Phase 3b summary. As each agent completes, emit only a brief one-line acknowledgment:
+```
+[phase-3b] Developer for <feature> ✓ (<N> tool uses, <duration>)
+```
+Only after the LAST background agent sends its completion notification, emit the consolidated summary:
+```
+## Phase 3b Complete
+
+| Feature | Agent | Tool uses | Duration |
+|---------|-------|-----------|----------|
+| <feature-a> | sr-developer | 64 | 8m 02s |
+| <feature-b> | sr-developer | 50 | 7m 35s |
+
+All N developers complete. Proceeding to Phase 3c.
+```
+
+This prevents stale "still waiting" text from appearing as the terminal result when the job completes.
+
 **Pipeline state:** update `developer` → `done`. Also update `implemented_files` in the state file with the complete list of files created or modified by the developer agent(s). If developer failed: update `developer` → `failed` with error context `"<agent-id> failed: <exit code or error description>"`.
 
 ## Phase 3c: Write Tests


### PR DESCRIPTION
## Summary

- The orchestrator emitted a status message when the **first** parallel developer completed, and that message became the terminal result text even though all agents completed successfully
- End result: hub showed _"Still waiting for X"_ as the final job status despite all agents completing cleanly
- Fix: Phase 3b now emits a one-line acknowledgment per agent completion, and only emits the full consolidated summary after the **last** background agent completes

## Root cause

Confirmed via diagnostic export (`job 54c1f5c7`, arkanoid project):
- Agent A (Power-Up #4) completed at 19:55:39
- Orchestrator immediately emitted full status text at 19:55:42: _"Power-up developer done — 210 tests passing, build clean. **Still waiting for elemental chain-reaction developer.**"_
- Agent B (Elemental Chain #6) completed at 19:56:29
- No new summary was emitted — the stale message became the final `result` field

## Change

`templates/commands/specrails/implement.md` — Phase 3b "Launch modes" section: added explicit **Summary timing** rule with example output format.

## Test plan

- [x] All 47 template/install-config/agent-selection tests pass
- [ ] Run `/specrails:implement #A #B` with two parallel features
- [ ] Verify each agent completion produces only a one-line `[phase-3b] Developer for X ✓` acknowledgment
- [ ] Verify the consolidated table appears only after the last agent completes
- [ ] Verify the diagnostic export's `result` field contains the full summary, not an intermediate "still waiting" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)