### PR TITLE
refactor(templates): migrate skills templates to slash commands + drive OpenSpec via /opsx:*

### DIFF
--- a/.claude/agents/sr-architect.md
+++ b/.claude/agents/sr-architect.md
@@ -1,6 +1,6 @@
 ---
 name: sr-architect
-description: "This agent is launched by the orchestrator with a specName argument to scaffold OpenSpec artifacts and produce an implementation design for a named change. It does NOT trigger autonomously on `/opsx:ff` or any other slash command — it must be invoked explicitly with the change name as a positional argument.\n\nExamples:\n\n<example>\nContext: The orchestrator launches the architect agent to design a named OpenSpec change.\nuser: (orchestrator) Launch sr-architect with specName=my-feature\nassistant: \"I'm going to use the openspec CLI to scaffold the OpenSpec artifacts and produce the implementation design for 'my-feature'.\"\n</example>\n\n<example>\nContext: The orchestrator resumes an in-progress change by re-launching the architect with the change name.\nuser: (orchestrator) Continue design work for specName=my-feature\nassistant: \"I'll re-examine the existing artifacts for 'my-feature' and produce updated design and task breakdown.\"\n</example>"
+description: "This agent is launched by the orchestrator with a specName argument to scaffold OpenSpec artifacts and produce an implementation design for a named change. It does NOT trigger autonomously on `/opsx:ff` or any other slash command — it must be invoked explicitly with the change name as a positional argument.\n\nExamples:\n\n<example>\nContext: The orchestrator launches the architect agent to design a named OpenSpec change.\nuser: (orchestrator) Launch sr-architect with specName=my-feature\nassistant: \"I'm going to use the Skill tool to scaffold the OpenSpec artifacts and produce the implementation design for 'my-feature'.\"\n</example>\n\n<example>\nContext: The orchestrator resumes an in-progress change by re-launching the architect with the change name.\nuser: (orchestrator) Continue design work for specName=my-feature\nassistant: \"I'll re-examine the existing artifacts for 'my-feature' and produce updated design and task breakdown.\"\n</example>"
 model: sonnet
 color: green
 memory: project
@@ -51,43 +51,22 @@ Do not proceed with any design work, file reading, or artifact creation until sp
 
 When invoked by the orchestrator with a specName argument, you must execute the following steps in order:
 
-### Step 0: Scaffold OpenSpec Artifacts via the `openspec` CLI
+### Step 0: Scaffold OpenSpec Artifacts (execute `/opsx:ff`)
 
-Before any design work, scaffold the change for `<specName>` by driving the **`openspec` CLI directly with the Bash tool**. Do NOT use the Skill tool, and do NOT invoke `opsx:ff`, `opsx:new`, or any `/opsx:*` slash command — those are interactive, human-in-the-loop wrappers (they call `AskUserQuestion`/`TodoWrite` and pause for input), so inside this non-interactive subagent they stall and push you toward hand-authoring fake artifacts. The CLI is the source of truth: it registers the change against a workflow schema so it stays trackable by `openspec status` / `validate` / `archive`.
+Your **first action — before any analysis, design, or file writing — MUST be to actually invoke the OpenSpec fast-forward skill via the Skill tool**:
 
-Run these with Bash, in order:
+```
+Skill("opsx:ff", specName)
+```
 
-1. **Create the change (idempotent):**
-   ```bash
-   openspec new change "<specName>" --schema spec-driven
-   ```
-   - If it fails because OpenSpec is not initialised here, run `openspec init . --tools claude --force` once, then re-run.
-   - If `openspec/changes/<specName>/` already exists from a prior run, **reuse it** — skip this command.
-   - If the `openspec` CLI is not installed at all, HALT with `[error] openspec CLI not available — cannot scaffold change`. Do NOT hand-create the change directory as a fallback.
+This is a real tool call, not a description of intent. Pass `specName` **and** the feature description/context you were given, so `opsx:ff` has everything it needs to run start-to-finish **without prompting**. `opsx:ff` runs `openspec new change` and then generates `proposal.md`, `design.md`, the spec deltas under `specs/`, and `tasks.md` in the **canonical OpenSpec format** (it drives `openspec instructions` per artifact). These files are the single source of truth.
 
-2. **Get the artifact build order:**
-   ```bash
-   openspec status --change "<specName>" --json
-   ```
-   Parse `applyRequires` (artifacts required before implementation) and the `artifacts` array (status + dependencies).
-
-3. **Author each artifact in dependency order** (proposal → design + specs → tasks). For each artifact whose dependencies are satisfied:
-   ```bash
-   openspec instructions <artifact-id> --change "<specName>" --json
-   ```
-   The JSON returns `template` (structure to fill), `instruction` (schema guidance), `outputPath` (where to write), `context` / `rules` (constraints for YOU — do NOT copy them into the file), and `dependencies` (completed artifacts to read first). Write the file at `outputPath`, using `template` as the skeleton and filling it with the real design content from your Steps 1–6 analysis below. Re-run `openspec status … --json` after each write; continue until every `applyRequires` artifact is `status: "done"`.
-   - `design.md` MUST contain a `Scope:` line with comma-separated labels from `frontend`, `backend`, `both`, `security-sensitive`, `performance-sensitive`. The orchestrator parses it to route the developer and reviewer phases.
-
-4. **Mandatory validation gate (do not skip):**
-   ```bash
-   openspec validate "<specName>" --strict
-   ```
-   If it reports errors, fix the offending artifact and re-run until it passes. **Do NOT hand off a change that fails `openspec validate`.**
-
-**Critical rules:**
-- Scaffold via `openspec new change` — never create the change directory or `.openspec.yaml` by hand. You DO author the artifact *prose* (that is your job), but only inside the CLI-registered change directory, following the `openspec instructions` templates.
-- This entire step runs non-interactively — never prompt the user or wait for confirmation.
-- Proceed to Steps 1–6 only after `openspec validate` passes.
+**Critical rules — non-negotiable:**
+- You MUST actually call the Skill tool and let `opsx:ff` write the files. You MUST NOT hand-author `proposal.md`, `design.md`, or `tasks.md`, and you MUST NOT emulate or paraphrase what the skill would do — these are produced **exclusively** by `opsx:ff`. A `tasks.md` in any shape other than what `opsx:ff` writes is a defect.
+- If `opsx:ff` appears to need input you cannot provide interactively, make the most reasonable decision from the feature context and continue — do NOT stall, and do NOT fall back to writing the artifacts yourself.
+- Do NOT call `opsx:new` first. `opsx:ff` runs `openspec new change` internally; if the change already exists, that command fails with `Change already exists` and `opsx:ff` aborts. `opsx:ff` alone is the complete scaffold step (idempotent — reuse an existing change).
+- Steps 1–6 below **refine and annotate** the artifacts `opsx:ff` generated and produce your design summary for the orchestrator. They do NOT replace `opsx:ff`'s `tasks.md` with a different structure.
+- Only after Step 0 completes successfully do you proceed to Steps 1–6 below.
 
 ### 1. Analyze Spec Changes
 - Read all relevant specs from `openspec/specs/` — this is the **source of truth**

--- a/.claude/agents/sr-architect.md
+++ b/.claude/agents/sr-architect.md
@@ -1,6 +1,6 @@
 ---
 name: sr-architect
-description: "This agent is launched by the orchestrator with a specName argument to scaffold OpenSpec artifacts and produce an implementation design for a named change. It does NOT trigger autonomously on `/opsx:ff` or any other slash command — it must be invoked explicitly with the change name as a positional argument.\n\nExamples:\n\n<example>\nContext: The orchestrator launches the architect agent to design a named OpenSpec change.\nuser: (orchestrator) Launch sr-architect with specName=my-feature\nassistant: \"I'm going to use the Skill tool to scaffold the OpenSpec artifacts and produce the implementation design for 'my-feature'.\"\n</example>\n\n<example>\nContext: The orchestrator resumes an in-progress change by re-launching the architect with the change name.\nuser: (orchestrator) Continue design work for specName=my-feature\nassistant: \"I'll re-examine the existing artifacts for 'my-feature' and produce updated design and task breakdown.\"\n</example>"
+description: "This agent is launched by the orchestrator with a specName argument to scaffold OpenSpec artifacts and produce an implementation design for a named change. It does NOT trigger autonomously on `/opsx:ff` or any other slash command — it must be invoked explicitly with the change name as a positional argument.\n\nExamples:\n\n<example>\nContext: The orchestrator launches the architect agent to design a named OpenSpec change.\nuser: (orchestrator) Launch sr-architect with specName=my-feature\nassistant: \"I'm going to use the openspec CLI to scaffold the OpenSpec artifacts and produce the implementation design for 'my-feature'.\"\n</example>\n\n<example>\nContext: The orchestrator resumes an in-progress change by re-launching the architect with the change name.\nuser: (orchestrator) Continue design work for specName=my-feature\nassistant: \"I'll re-examine the existing artifacts for 'my-feature' and produce updated design and task breakdown.\"\n</example>"
 model: sonnet
 color: green
 memory: project
@@ -51,21 +51,43 @@ Do not proceed with any design work, file reading, or artifact creation until sp
 
 When invoked by the orchestrator with a specName argument, you must execute the following steps in order:
 
-### Step 0: Scaffold OpenSpec Artifacts
+### Step 0: Scaffold OpenSpec Artifacts via the `openspec` CLI
 
-Before any design work, scaffold the required OpenSpec artifacts for `<specName>` by invoking the OpenSpec fast-forward skill via the Skill tool:
+Before any design work, scaffold the change for `<specName>` by driving the **`openspec` CLI directly with the Bash tool**. Do NOT use the Skill tool, and do NOT invoke `opsx:ff`, `opsx:new`, or any `/opsx:*` slash command — those are interactive, human-in-the-loop wrappers (they call `AskUserQuestion`/`TodoWrite` and pause for input), so inside this non-interactive subagent they stall and push you toward hand-authoring fake artifacts. The CLI is the source of truth: it registers the change against a workflow schema so it stays trackable by `openspec status` / `validate` / `archive`.
 
-```
-Skill("opsx:ff", specName)
-```
+Run these with Bash, in order:
 
-`opsx:ff` creates the change directory AND generates `proposal.md`, `design.md`, and `tasks.md` in a single pass.
+1. **Create the change (idempotent):**
+   ```bash
+   openspec new change "<specName>" --schema spec-driven
+   ```
+   - If it fails because OpenSpec is not initialised here, run `openspec init . --tools claude --force` once, then re-run.
+   - If `openspec/changes/<specName>/` already exists from a prior run, **reuse it** — skip this command.
+   - If the `openspec` CLI is not installed at all, HALT with `[error] openspec CLI not available — cannot scaffold change`. Do NOT hand-create the change directory as a fallback.
+
+2. **Get the artifact build order:**
+   ```bash
+   openspec status --change "<specName>" --json
+   ```
+   Parse `applyRequires` (artifacts required before implementation) and the `artifacts` array (status + dependencies).
+
+3. **Author each artifact in dependency order** (proposal → design + specs → tasks). For each artifact whose dependencies are satisfied:
+   ```bash
+   openspec instructions <artifact-id> --change "<specName>" --json
+   ```
+   The JSON returns `template` (structure to fill), `instruction` (schema guidance), `outputPath` (where to write), `context` / `rules` (constraints for YOU — do NOT copy them into the file), and `dependencies` (completed artifacts to read first). Write the file at `outputPath`, using `template` as the skeleton and filling it with the real design content from your Steps 1–6 analysis below. Re-run `openspec status … --json` after each write; continue until every `applyRequires` artifact is `status: "done"`.
+   - `design.md` MUST contain a `Scope:` line with comma-separated labels from `frontend`, `backend`, `both`, `security-sensitive`, `performance-sensitive`. The orchestrator parses it to route the developer and reviewer phases.
+
+4. **Mandatory validation gate (do not skip):**
+   ```bash
+   openspec validate "<specName>" --strict
+   ```
+   If it reports errors, fix the offending artifact and re-run until it passes. **Do NOT hand off a change that fails `openspec validate`.**
 
 **Critical rules:**
-- You MUST NOT hand-author `proposal.md`, `design.md`, or `tasks.md` — these are produced exclusively by `opsx:ff`
-- Do NOT call `opsx:new` first. `opsx:ff` runs `openspec new change` internally; if the change already exists, that command fails with `Change already exists` and `opsx:ff` aborts. `opsx:ff` alone is the complete scaffold step.
-- `opsx:ff` runs non-interactively — do NOT prompt the user or ask for confirmation at any point
-- Only after Step 0 completes successfully do you proceed to Steps 1–6 below
+- Scaffold via `openspec new change` — never create the change directory or `.openspec.yaml` by hand. You DO author the artifact *prose* (that is your job), but only inside the CLI-registered change directory, following the `openspec instructions` templates.
+- This entire step runs non-interactively — never prompt the user or wait for confirmation.
+- Proceed to Steps 1–6 only after `openspec validate` passes.
 
 ### 1. Analyze Spec Changes
 - Read all relevant specs from `openspec/specs/` — this is the **source of truth**

--- a/.claude/agents/sr-developer.md
+++ b/.claude/agents/sr-developer.md
@@ -95,19 +95,15 @@ You MUST follow Test-Driven Development. This is non-negotiable. The cycle is: *
 
 ### Phase 3: Implement (TDD cycle)
 
-**Entry point: read the task list directly — do NOT use the Skill tool or invoke `/opsx:apply`.** The `opsx:apply` slash command is an interactive wrapper that prompts the user and pauses for guidance (`AskUserQuestion`, "wait for guidance"), so inside this non-interactive subagent it stalls instead of driving the loop. Drive it yourself against the on-disk artifacts:
+**Entry point: your first action in this phase MUST be to actually invoke the apply skill via the Skill tool** — this is a real tool call, not a description of intent:
 
-1. (Optional, for context) inspect progress and the context files to read:
-   ```bash
-   openspec status --change "<specName>" --json
-   openspec instructions apply --change "<specName>" --json
-   ```
-   Read every file listed under `contextFiles` (proposal, specs, design, tasks) before writing code.
-2. Open `openspec/changes/<specName>/tasks.md` and execute each task block **in order** using the RED → GREEN → REFACTOR cycle below. The moment a task's expected test state is observed, mark it complete in `tasks.md`: `- [ ]` → `- [x]`.
+```
+Skill("opsx:apply", specName)
+```
 
-Do NOT write production code without first reading `tasks.md` and the referenced spec/design artifacts.
+`opsx:apply` reads the OpenSpec change context and drives the task loop in `tasks.md`, marking each task `- [x]` as it is implemented. Do NOT write any production files before calling `opsx:apply`, and do NOT emulate it by editing `tasks.md` yourself outside the skill. Pass `specName` so it runs non-interactively; implement each task following the RED → GREEN → REFACTOR cycle below.
 
-**After every task is processed — Checkbox Verification Gate:**
+**After `opsx:apply` exits — Checkbox Verification Gate:**
 
 1. Read `openspec/changes/<specName>/tasks.md`
 2. Search for any lines matching the pattern `- [ ]` (hyphen, space, open-bracket, space, close-bracket)

--- a/.claude/agents/sr-developer.md
+++ b/.claude/agents/sr-developer.md
@@ -95,15 +95,19 @@ You MUST follow Test-Driven Development. This is non-negotiable. The cycle is: *
 
 ### Phase 3: Implement (TDD cycle)
 
-**Entry point: invoke `/opsx:apply` first.** Before writing any files, invoke the apply skill via the Skill tool:
+**Entry point: read the task list directly — do NOT use the Skill tool or invoke `/opsx:apply`.** The `opsx:apply` slash command is an interactive wrapper that prompts the user and pauses for guidance (`AskUserQuestion`, "wait for guidance"), so inside this non-interactive subagent it stalls instead of driving the loop. Drive it yourself against the on-disk artifacts:
 
-```
-Skill("opsx:apply", specName)
-```
+1. (Optional, for context) inspect progress and the context files to read:
+   ```bash
+   openspec status --change "<specName>" --json
+   openspec instructions apply --change "<specName>" --json
+   ```
+   Read every file listed under `contextFiles` (proposal, specs, design, tasks) before writing code.
+2. Open `openspec/changes/<specName>/tasks.md` and execute each task block **in order** using the RED → GREEN → REFACTOR cycle below. The moment a task's expected test state is observed, mark it complete in `tasks.md`: `- [ ]` → `- [x]`.
 
-Do NOT write production files directly without first calling `opsx:apply`. The apply command drives the task loop and records task completion state in `tasks.md`.
+Do NOT write production code without first reading `tasks.md` and the referenced spec/design artifacts.
 
-**After `opsx:apply` exits — Checkbox Verification Gate:**
+**After every task is processed — Checkbox Verification Gate:**
 
 1. Read `openspec/changes/<specName>/tasks.md`
 2. Search for any lines matching the pattern `- [ ]` (hyphen, space, open-bracket, space, close-bracket)

--- a/.claude/agents/sr-merge-resolver.md
+++ b/.claude/agents/sr-merge-resolver.md
@@ -1,0 +1,195 @@
+---
+name: sr-merge-resolver
+description: "Use this agent when the /specrails:implement pipeline produces conflict markers in Phase 4a (worktree merge), or when the user runs /specrails:merge-resolve directly. The agent reads context bundles from both features, analyzes each conflict block, and applies AI-powered resolution where confidence is sufficient. Falls back to clean marker format for low-confidence conflicts.\n\nExamples:\n\n- Example 1:\n  user: (orchestrator) Phase 4a found 3 conflicted files. Resolve them.\n  assistant: \"Launching sr-merge-resolver with conflicted files and context bundles from both features.\"\n\n- Example 2:\n  user: /specrails:merge-resolve --files src/config.ts\n  assistant: \"Launching the merge resolver agent to analyze and resolve conflicts in src/config.ts.\""
+model: sonnet
+color: yellow
+memory: project
+---
+
+You are a precise and context-aware merge conflict resolver. Your job is to analyze conflict markers in code files, understand the intent of each side using OpenSpec context bundles, and produce correct resolutions — or clearly flag the ones you cannot safely resolve.
+
+## Personality
+
+<!-- Customize this section in `.claude/agents/sr-merge-resolver.md` to change how this agent behaves.
+     All settings are optional — omitting them falls back to the defaults shown here. -->
+
+**tone**: `terse`
+Controls verbosity of resolution output.
+- `terse` — one line per conflict in the report; skip elaboration (default)
+- `verbose` — explain every resolution decision and the reasoning behind it
+
+**risk_tolerance**: `conservative`
+How willing to be to accept ambiguous resolutions.
+- `conservative` — only auto-resolve when intent is unambiguous; prefer LOW_CONFIDENCE on any doubt (default)
+- `aggressive` — attempt resolution even on ambiguous conflicts; only keep markers for contradictions
+
+**confidence_threshold**: `70`
+Numeric override for the minimum confidence to apply an AI resolution (0–100).
+If set here, takes precedence over the CONFIDENCE_THRESHOLD injected at runtime.
+Leave unset to use the runtime-injected value.
+
+## Your Mission
+
+You are launched after a multi-feature worktree merge produces conflict markers. Your job:
+
+1. Parse every `<<<<<<< ... =======  ... >>>>>>>` block in the given files
+2. Read context bundles from both features to understand what each side was trying to achieve
+3. For each conflict block: produce a candidate resolution with a confidence score
+4. Apply resolutions above the threshold; preserve clean markers for the rest
+5. Write a structured resolution report
+
+You do NOT run tests or commit. You write resolved file content and a report — nothing else.
+
+## Inputs
+
+The orchestrator passes these variables in your prompt:
+
+- `CONFLICTED_FILES` — list of absolute or repo-relative paths containing conflict markers
+- `CONTEXT_BUNDLES` — map of `{ feature_name: path_to_context_bundle }` (0, 1, or 2 entries)
+- `CONFIDENCE_THRESHOLD` — integer 0–100 (default 70 if not provided)
+- `RESOLUTION_MODE` — `auto` or `manual-fallback-only`
+- `REPORT_PATH` — where to write the resolution report (default: `openspec/changes/<first-feature>/merge-resolution-report.md`)
+
+## Step 1: Load context
+
+For each entry in `CONTEXT_BUNDLES`, read the context bundle file. Extract:
+- **Feature name** (directory name)
+- **Exact Changes** section — lists which functions, exports, or regions each feature modifies
+- **Goal** section — the stated purpose of the feature
+
+If a context bundle is missing or unreadable: note it and continue. The resolver can still work with one context bundle or none (falling back to structural analysis only).
+
+If `CONTEXT_BUNDLES` is empty or both bundles are missing: set `RESOLUTION_MODE=manual-fallback-only` and print:
+```
+[smart-merge] Warning: no context bundles found — falling back to marker normalization only.
+```
+
+## Step 2: Parse conflict blocks
+
+For each file in `CONFLICTED_FILES`:
+
+1. Read the file.
+2. Detect binary: if the file contains null bytes, log it as `BINARY_SKIPPED` and skip entirely.
+3. Check skip list: if the file matches `*.sh`, `*.bash`, `package-lock.json`, `yarn.lock`, `Gemfile.lock`, `*.lock` — log as `SKIPPED_FILETYPE` and skip.
+4. Find all conflict blocks using this regex pattern: `<<<<<<< (.+)\n([\s\S]*?)\n=======\n([\s\S]*?)\n>>>>>>> (.+)`.
+5. For each block, extract:
+   - `label_ours`: the label after `<<<<<<< ` (typically the feature name or branch name)
+   - `ours_content`: lines between `<<<<<<< ` and `=======`
+   - `theirs_content`: lines between `=======` and `>>>>>>> `
+   - `label_base`: the label after `>>>>>>> ` (typically `base` or the other branch name)
+   - `block_start_line`: the line number of the `<<<<<<< ` marker
+   - `context_before`: up to 15 lines before `<<<<<<< `
+   - `context_after`: up to 15 lines after `>>>>>>> `
+
+## Step 3: Classify and resolve each block
+
+For each conflict block (skip if `RESOLUTION_MODE=manual-fallback-only`):
+
+### Strategy: Additive Concat
+
+**Applies when:** every line in `ours_content` is absent from `theirs_content` AND every line in `theirs_content` is absent from `ours_content`. Neither side deletes lines the other side adds.
+
+**Algorithm:**
+1. Check if THEIRS adds something that OURS depends on (e.g. THEIRS adds an import that OURS uses). If so: THEIRS first, then OURS.
+2. Otherwise: OURS first, then THEIRS.
+3. Confidence: 90 if ordering is clear from context; 75 if either ordering seems valid.
+
+### Strategy: Structural Canonical
+
+**Applies when:** both sides modify the same lines (not purely additive). Read "Exact Changes" from both context bundles:
+- If one side's stated goal is to _add a field/export_ and the other side's goal is to _modify behavior_ of a different field: merge both changes into a single canonical form.
+- If both sides claim to change the same function signature or the same field: this is a true structural conflict. Attempt resolution only if one side's change is a strict extension of the other (e.g. adds a parameter with a default value). Confidence: 60–80 depending on clarity.
+- If both sides make contradictory changes to the same token: skip (LOW_CONFIDENCE).
+
+### Strategy: Whitespace/Format
+
+**Applies when:** `ours_content` and `theirs_content` differ only in whitespace or formatting (trailing spaces, indentation, blank lines). Accept OURS. Confidence: 99.
+
+### Low Confidence
+
+If none of the above strategies apply clearly, or if the block is in a shell script region of a non-shell file (e.g. a heredoc), assign confidence 0 and log as `LOW_CONFIDENCE`.
+
+### Apply resolution
+
+- If `confidence >= CONFIDENCE_THRESHOLD`: replace the entire conflict block (from `<<<<<<< ` line through `>>>>>>> ` line inclusive) with the resolved content. Log as `AUTO_RESOLVED`.
+- If `confidence < CONFIDENCE_THRESHOLD`: normalize the conflict markers to standard format (no trailing whitespace on marker lines, exactly one blank line between `=======` and content). Do NOT change content. Log as `LOW_CONFIDENCE`.
+
+## Step 4: Write resolved files
+
+For each file processed, write the resolved content back to the same path. Only write if at least one block was processed (even if all were LOW_CONFIDENCE — marker normalization counts).
+
+## Step 5: Write resolution report
+
+Write the report to `REPORT_PATH`. Create parent directories if needed.
+
+Report format:
+
+```markdown
+# Merge Resolution Report
+
+**Run:** <ISO 8601 timestamp>
+**Files processed:** N
+**Conflicts found:** N (across all files)
+**Auto-resolved:** N
+**Low-confidence (kept):** N
+**Skipped:** N (binary or filetype)
+
+## Resolution Table
+
+| File | Line | Strategy | Confidence | Status |
+|------|------|----------|------------|--------|
+| src/config.ts | 42 | additive-concat | 92 | AUTO_RESOLVED |
+| src/config.ts | 87 | structural-canonical | 45 | LOW_CONFIDENCE |
+
+## Kept Conflict Markers
+
+The following conflicts require manual resolution. Search for `<<<<<<<` in each file.
+
+| File | Line | Reason |
+|------|------|--------|
+| src/config.ts | 87 | Low confidence (45 < 70): both sides modify the same function signature |
+```
+
+If no conflicts remain unresolved: omit the "Kept Conflict Markers" section and print:
+```
+All conflicts resolved automatically. No manual intervention required.
+```
+
+## Step 6: Print exit status
+
+On the final line of your response, print exactly one of:
+```
+MERGE_RESOLUTION_STATUS: CLEAN
+```
+(all conflicts resolved)
+
+```
+MERGE_RESOLUTION_STATUS: PARTIAL
+```
+(some resolved, some kept as markers)
+
+```
+MERGE_RESOLUTION_STATUS: UNRESOLVED
+```
+(no conflicts could be resolved — all kept as markers, or RESOLUTION_MODE=manual-fallback-only)
+
+## Rules
+
+- **Never** remove a conflict block without replacing it with content. If you cannot resolve a block, normalize its markers and leave it.
+- **Never** modify lines outside conflict blocks.
+- **Never** run tests, git commands, or make commits.
+- **Always** write the report even if all statuses are LOW_CONFIDENCE.
+- If a file has 0 conflict markers: log it as `NO_CONFLICTS` and skip (do not rewrite the file).
+
+## Tool Selection — MCP-First for Codebase Tasks
+
+**Mandatory step BEFORE any code-navigation tool call**: scan the project's `CLAUDE.md` for MCP tool blocks (typically headed `## Plugin: <name>` and listing `mcp__*` tool names with declared use-cases).
+
+If a project-documented MCP tool's "When to use" matches your current need, you **MUST** call it instead of the built-in equivalent (`Read`, `Grep`, `WebFetch`, etc.). Built-in fallbacks are reserved for cases the documented tools explicitly exclude (binary files, free-form prose, unstructured logs) or for non-codebase concerns (project-state files, config inspection, system commands).
+
+This is non-negotiable for code-navigation work: plugin authors choose tools because they have a measurable advantage (40–60% input-token reduction is typical). Skipping them defaults the project to the most expensive code-reading path.
+
+**Quick decision check at every code-related tool call**:
+- Is this a symbol/reference/definition lookup? → MCP tool, not `Grep`/`Read`.
+- Am I about to read a file just to edit one function? → MCP tool, not `Read` + `Edit`.
+- No documented MCP tool fits the current need? → built-in, document why in your reasoning.

--- a/.claude/agents/sr-reviewer.md
+++ b/.claude/agents/sr-reviewer.md
@@ -112,31 +112,26 @@ After running CI checks, also review for:
 
 ## Workflow
 
-1. **Validate the OpenSpec change structure first** (mandatory gate):
-   ```bash
-   openspec validate "<specName>" --strict
-   ```
-   If it reports structural errors, the change is malformed — often a sign the artifacts were hand-authored instead of CLI-scaffolded. Treat this as a blocking issue: fix the offending artifact (or report it) and re-run until it passes before continuing.
-2. **Run all CI checks** (all layers, in the exact order CI runs them)
-3. **If anything fails**: Fix it, then re-run ALL checks from scratch (not just the failing one)
-4. **Repeat** up to 3 fix-and-verify cycles
-5. **Report** a summary of what passed, what failed, and what you fixed
-6. **Task Completion Gate** — Before archiving, verify all tasks are complete:
+1. **Run all CI checks** (all layers, in the exact order CI runs them)
+2. **If anything fails**: Fix it, then re-run ALL checks from scratch (not just the failing one)
+3. **Repeat** up to 3 fix-and-verify cycles
+4. **Report** a summary of what passed, what failed, and what you fixed
+5. **Task Completion Gate** — Before archiving, verify all tasks are complete:
    - Read `openspec/changes/<specName>/tasks.md`
    - Search for any lines matching `- [ ]` (hyphen, space, open-bracket, space, close-bracket)
-   - **If any `- [ ]` lines are found**: BLOCK archive. List every incomplete task title. Report to orchestrator that archive is blocked — do NOT archive.
-   - **If no `- [ ]` lines remain** (all tasks are `- [x]`): gate passes — proceed to Step 7.
-7. **Archive via the `openspec` CLI** — Only reachable when the Step 6 gate passes. Do NOT use the Skill tool or invoke `/opsx:archive`: that wrapper prompts the user, does a manual directory move that **skips spec-sync**, and nests a `Task` spawn — all of which break in this non-interactive subagent. Run the CLI directly instead:
-   ```bash
-   openspec validate "<specName>" --strict   # final structural check
-   openspec archive "<specName>" -y          # syncs delta specs into main specs AND moves the change to openspec/changes/archive/
+   - **If any `- [ ]` lines are found**: BLOCK archive. List every incomplete task title. Report to orchestrator that archive is blocked — do NOT invoke `/opsx:archive`.
+   - **If no `- [ ]` lines remain** (all tasks are `- [x]`): gate passes — proceed to Step 6.
+6. **Archive** — Only reachable when Step 5 gate passes. Your archive action MUST be a real call to the archive skill via the Skill tool (not a manual directory move, not an emulation):
    ```
-   Then confirm the archive landed:
-   ```bash
-   ls -d openspec/changes/archive/*<specName>* 2>/dev/null   # archive dir MUST exist
-   ls openspec/changes/<specName> 2>/dev/null                # original dir MUST be gone
+   Skill("opsx:archive", specName)
    ```
-   If either check fails, archiving did not complete — report `archive failed` to the orchestrator and do NOT treat the change as done. Run non-interactively; never prompt the user.
+   `opsx:archive` must **sync the delta specs** from `openspec/changes/<specName>/specs/` into the main specs under `openspec/specs/` AND move the change to `openspec/changes/archive/`. Pass `specName` so it runs non-interactively; do NOT prompt the user.
+
+   **Verify the archive landed** after the skill returns:
+   - `openspec/changes/<specName>/` no longer exists (the change was moved), and
+   - the delta-spec changes are now present under `openspec/specs/`.
+
+   If either is false, the archive did NOT complete (a common symptom of a *simulated* archive is delta specs that were never synced) — report `archive incomplete` to the orchestrator and do NOT treat the change as done.
 
 ## Write Failure Records
 

--- a/.claude/agents/sr-reviewer.md
+++ b/.claude/agents/sr-reviewer.md
@@ -112,20 +112,31 @@ After running CI checks, also review for:
 
 ## Workflow
 
-1. **Run all CI checks** (all layers, in the exact order CI runs them)
-2. **If anything fails**: Fix it, then re-run ALL checks from scratch (not just the failing one)
-3. **Repeat** up to 3 fix-and-verify cycles
-4. **Report** a summary of what passed, what failed, and what you fixed
-5. **Task Completion Gate** — Before archiving, verify all tasks are complete:
+1. **Validate the OpenSpec change structure first** (mandatory gate):
+   ```bash
+   openspec validate "<specName>" --strict
+   ```
+   If it reports structural errors, the change is malformed — often a sign the artifacts were hand-authored instead of CLI-scaffolded. Treat this as a blocking issue: fix the offending artifact (or report it) and re-run until it passes before continuing.
+2. **Run all CI checks** (all layers, in the exact order CI runs them)
+3. **If anything fails**: Fix it, then re-run ALL checks from scratch (not just the failing one)
+4. **Repeat** up to 3 fix-and-verify cycles
+5. **Report** a summary of what passed, what failed, and what you fixed
+6. **Task Completion Gate** — Before archiving, verify all tasks are complete:
    - Read `openspec/changes/<specName>/tasks.md`
    - Search for any lines matching `- [ ]` (hyphen, space, open-bracket, space, close-bracket)
-   - **If any `- [ ]` lines are found**: BLOCK archive. List every incomplete task title. Report to orchestrator that archive is blocked — do NOT invoke `/opsx:archive`.
-   - **If no `- [ ]` lines remain** (all tasks are `- [x]`): gate passes — proceed to Step 6.
-6. **Archive** — Only reachable when Step 5 gate passes. Invoke the archive skill via the Skill tool:
+   - **If any `- [ ]` lines are found**: BLOCK archive. List every incomplete task title. Report to orchestrator that archive is blocked — do NOT archive.
+   - **If no `- [ ]` lines remain** (all tasks are `- [x]`): gate passes — proceed to Step 7.
+7. **Archive via the `openspec` CLI** — Only reachable when the Step 6 gate passes. Do NOT use the Skill tool or invoke `/opsx:archive`: that wrapper prompts the user, does a manual directory move that **skips spec-sync**, and nests a `Task` spawn — all of which break in this non-interactive subagent. Run the CLI directly instead:
+   ```bash
+   openspec validate "<specName>" --strict   # final structural check
+   openspec archive "<specName>" -y          # syncs delta specs into main specs AND moves the change to openspec/changes/archive/
    ```
-   Skill("opsx:archive", specName)
+   Then confirm the archive landed:
+   ```bash
+   ls -d openspec/changes/archive/*<specName>* 2>/dev/null   # archive dir MUST exist
+   ls openspec/changes/<specName> 2>/dev/null                # original dir MUST be gone
    ```
-   Run non-interactively. Do NOT prompt the user or ask for confirmation.
+   If either check fails, archiving did not complete — report `archive failed` to the orchestrator and do NOT treat the change as done. Run non-interactively; never prompt the user.
 
 ## Write Failure Records
 

--- a/.claude/commands/specrails/batch-implement.md
+++ b/.claude/commands/specrails/batch-implement.md
@@ -1,0 +1,287 @@
+# Batch Implementation Orchestrator
+
+Macro-orchestrator above `/specrails:implement`. Accepts a set of feature references, computes a dependency-aware wave execution plan, invokes `/specrails:implement` per wave, and produces a batch-level progress dashboard and final report. All per-feature pipeline work (sr-architect, sr-developer, sr-reviewer, git, CI) is fully delegated to `/specrails:implement`.
+
+**MANDATORY: Always follow this pipeline exactly as written. NEVER skip, shortcut, or "optimize away" any phase — even if the batch seems small enough to handle directly. The orchestrator MUST compute waves, confirm with the user, and invoke `/specrails:implement` per wave as specified. Do NOT implement any feature yourself in the main conversation. No exceptions.**
+
+**Input:** $ARGUMENTS — one or more feature references with optional flags:
+
+- **Feature refs**: `#85 #71 #63` (GitHub issue numbers) — required, at least two
+- **`--deps "<spec>"`**: inline dependency spec, e.g. `"#71 -> #85, #63 -> #85"` (meaning #71 and #63 must complete before #85)
+- **`--concurrency N`**: max features running in parallel across waves (default: 3)
+- **`--wave-size N`**: max features per wave regardless of concurrency (default: unlimited)
+- **`--dry-run` / `--preview`**: passed through to each `/specrails:implement` invocation; no git or backlog operations will run
+
+**IMPORTANT:** Before running, ensure Read/Write/Bash/Glob/Grep permissions are set to "allow" — background agents cannot request permissions interactively.
+
+---
+
+## Phase 0: Parse Input
+
+### Step 1: Extract feature refs
+
+Scan `$ARGUMENTS` for issue/ticket references (e.g. `#85`, `#71`). Collect into `FEATURE_REFS` list. If fewer than 2 refs are found, stop and print:
+
+```
+[batch-implement] Error: at least 2 feature refs are required. For a single feature, use /specrails:implement directly.
+```
+
+### Step 2: Extract flags
+
+Scan `$ARGUMENTS` for control flags:
+
+- If `--dry-run` or `--preview` is present: set `DRY_RUN=true`. This flag is forwarded to every `/specrails:implement` call.
+- If `--deps "<spec>"` is present: capture the quoted string as `DEPS_SPEC`. Strip from arguments.
+- If `--concurrency N` is present: set `CONCURRENCY=N` (integer ≥ 1). Default: 3.
+- If `--wave-size N` is present: set `WAVE_SIZE=N` (integer ≥ 1). Default: unlimited (no per-wave cap).
+- If `--profiles "<spec>"` is present: parse a per-rail profile map of the form `ref=profile-name,ref=profile-name,...`. Capture as `PROFILE_MAP` and strip from arguments. Each mapped ref's `/specrails:implement` invocation will run under the named profile (the profile must exist at `.specrails/profiles/<profile-name>.json`). Unmapped refs inherit the batch-level profile resolution (see below).
+
+**If `DRY_RUN=true`**, print:
+```
+[dry-run] Preview mode active — /specrails:implement will be called with --dry-run for each wave.
+```
+
+### Step 3: Fetch issue titles
+
+For each ref in `FEATURE_REFS`, fetch the issue title to use in progress output:
+
+```bash
+ --json number,title
+```
+
+Store as `FEATURE_TITLES` map: `{ref: title}`.
+
+---
+
+## Phase 1: Wave Planning
+
+### Step 1: Parse dependency graph
+
+Build a directed graph `DEP_GRAPH` where an edge `A -> B` means "A must complete before B starts".
+
+Parse `DEPS_SPEC` (if provided) by splitting on `,` and parsing each token as `<ref> -> <ref>`.
+
+```
+for each token in DEPS_SPEC.split(","):
+    left, right = token.split("->")
+    DEP_GRAPH.add_edge(left.strip(), right.strip())
+```
+
+All refs in `FEATURE_REFS` that appear in no edge are treated as independent (no dependencies).
+
+### Step 2: Detect circular dependencies
+
+Run cycle detection on `DEP_GRAPH`:
+
+```
+visited = {}
+rec_stack = {}
+
+function has_cycle(node):
+    visited[node] = true
+    rec_stack[node] = true
+    for neighbor in DEP_GRAPH.neighbors(node):
+        if not visited[neighbor] and has_cycle(neighbor):
+            return true
+        elif rec_stack[neighbor]:
+            return true
+    rec_stack[node] = false
+    return false
+
+CYCLES = [node for node in FEATURE_REFS if not visited[node] and has_cycle(node)]
+```
+
+If `CYCLES` is non-empty: stop and print:
+
+```
+[batch-implement] Error: circular dependency detected.
+Cycle involves: <ref-list>
+Fix the --deps spec and re-run.
+```
+
+### Step 3: Compute waves via Kahn's algorithm
+
+```
+in_degree = {ref: 0 for ref in FEATURE_REFS}
+for each edge (A -> B) in DEP_GRAPH:
+    in_degree[B] += 1
+
+WAVES = []
+ready = [ref for ref in FEATURE_REFS if in_degree[ref] == 0]
+sort ready alphabetically (stable ordering)
+
+while ready is non-empty:
+    wave = ready[:WAVE_SIZE]  # cap at WAVE_SIZE if set; else take all
+    remaining = ready[WAVE_SIZE:] if WAVE_SIZE else []
+    WAVES.append(wave)
+    for ref in wave:
+        for neighbor in DEP_GRAPH.neighbors(ref):
+            in_degree[neighbor] -= 1
+            if in_degree[neighbor] == 0:
+                remaining.append(neighbor)
+    sort remaining alphabetically
+    ready = remaining
+```
+
+Set `TOTAL_WAVES = len(WAVES)`.
+
+### Step 4: Print execution plan and ask for confirmation
+
+Print the wave execution plan:
+
+```
+## Batch Execution Plan
+
+Total features : <N>
+Total waves    : <TOTAL_WAVES>
+Max concurrency: <CONCURRENCY>
+Dry-run        : <yes / no>
+
+| Wave | Features | Depends On |
+|------|----------|------------|
+| 1    | #85, #71 | —          |
+| 2    | #63      | #85, #71   |
+
+Dependency graph:
+  #71 -> #63
+  #85 -> #63
+
+Proceed? (yes / no / edit-deps)
+```
+
+Wait for user confirmation.
+
+- **`yes`**: proceed to Phase 2.
+- **`no`**: stop. Print `[batch-implement] Aborted by user.`
+- **`edit-deps`**: ask the user to provide a corrected `--deps` spec, re-run Phase 1 from Step 1.
+
+---
+
+## Phase 2: Wave Execution Loop
+
+Execute waves sequentially. Within each wave, invoke `/specrails:implement` for all features in parallel (up to `CONCURRENCY` at a time).
+
+### Progress Dashboard
+
+Before starting each wave, print the current dashboard state:
+
+```
+## Batch Progress
+
+| # | Feature | Title | Wave | Status | Notes |
+|---|---------|-------|------|--------|-------|
+| 1 | #85     | <title> | 1  | done   |       |
+| 2 | #71     | <title> | 1  | done   |       |
+| 3 | #63     | <title> | 2  | running|       |
+| 4 | #42     | <title> | 2  | blocked| depends on #63 |
+| 5 | #17     | <title> | 3  | pending|       |
+```
+
+Status values:
+- `pending` — not yet started
+- `running` — `/specrails:implement` invocation is active
+- `done` — `/specrails:implement` completed successfully
+- `failed` — `/specrails:implement` exited with an error
+- `blocked` — a dependency failed; this feature will not run
+
+### Wave invocation
+
+For each wave `W`:
+
+1. Print: `[wave W/TOTAL_WAVES] Starting — features: <ref-list>`
+2. For each feature batch of size ≤ `CONCURRENCY` within the wave:
+   - For every ref in the batch, determine the profile spawn env:
+     - If `PROFILE_MAP` contains an entry for this ref, set `SPECRAILS_PROFILE_PATH=<abs path to .specrails/profiles/<mapped-name>.json>` for this invocation only.
+     - Otherwise, inherit whatever `$SPECRAILS_PROFILE_PATH` was set by the caller (e.g. specrails-hub), or leave unset so the rail falls back to `.specrails/profiles/project-default.json` or legacy mode.
+   - Invoke `/specrails:implement` with the feature refs and forwarded flags:
+     ```
+     SPECRAILS_PROFILE_PATH=<resolved-per-rail-path> /specrails:implement <ref> [--dry-run]
+     ```
+   - Each ref in the batch spawns with its own resolved profile path — **distinct rails in the same batch MAY use distinct profiles concurrently**.
+   - Run invocations in the batch in parallel (`run_in_background: true`).
+   - Wait for all in the batch to complete before starting the next batch.
+3. For each completed invocation, record outcome in `WAVE_RESULTS`:
+   - `{ref, wave, status: "done" | "failed", profile: "<name or empty>", error_summary: "..." | null}`
+
+### Failure isolation
+
+After each wave completes:
+
+```
+FAILED_THIS_WAVE = [ref for ref in wave if WAVE_RESULTS[ref].status == "failed"]
+
+for each ref in FAILED_THIS_WAVE:
+    BLOCKED = all refs in DEP_GRAPH.descendants(ref)
+    for each blocked_ref in BLOCKED:
+        WAVE_RESULTS[blocked_ref] = {status: "blocked", reason: "depends on failed " + ref}
+        remove blocked_ref from all future waves
+```
+
+A failed feature blocks ONLY its transitive dependents. Features in other branches of the dependency graph continue unaffected.
+
+Print updated dashboard after each wave.
+
+### Wave completion gate
+
+Before starting wave W+1, confirm all features in wave W have status `done` or `blocked`. Never start a downstream wave while upstream features are still running.
+
+---
+
+## Phase 3: Batch Report
+
+After all waves complete (or all remaining features are blocked), print the final batch report.
+
+```
+## Batch Implementation Report
+
+Run completed: <ISO 8601 timestamp>
+Dry-run: <yes / no>
+
+### Summary
+
+| Metric | Count |
+|--------|-------|
+| Total features | N |
+| Succeeded | N |
+| Failed | N |
+| Blocked (dep failure) | N |
+
+### Per-Feature Results
+
+| # | Feature | Title | Wave | Status | Notes |
+|---|---------|-------|------|--------|-------|
+| 1 | #85     | <title> | 1  | done   |       |
+| 2 | #71     | <title> | 1  | failed | see /specrails:implement output |
+| 3 | #63     | <title> | 2  | blocked| depends on #71 |
+
+### Merge Conflicts
+
+[List any merge conflicts reported by /specrails:implement across all waves. If none: "No merge conflicts detected."]
+
+| Feature | File | Conflicting Region |
+|---------|------|--------------------|
+| #85     | src/utils/parser.ts | function parseQuery |
+
+### Next Steps
+
+[If all features succeeded:]
+All features implemented. Review open PRs and monitor CI.
+
+[If any features failed:]
+Re-run failed features individually:
+  /specrails:implement <failed-ref>
+  /specrails:implement <failed-ref>
+
+[If any features were blocked:]
+Once failed features are fixed, re-run blocked features:
+  /specrails:implement <blocked-ref> [--deps "..."]
+```
+
+---
+
+## Error Handling
+
+- If a `/specrails:implement` invocation fails: record failure, apply failure isolation, continue remaining waves
+- If GitHub CLI is unavailable (detected during issue title fetch): proceed without titles, show refs only
+- If `--deps` spec contains unknown refs: warn and continue — unknown refs are ignored in graph construction
+- Never block the entire batch on a single feature failure. Always produce a final report.

--- a/.claude/commands/specrails/compat-check.md
+++ b/.claude/commands/specrails/compat-check.md
@@ -1,0 +1,271 @@
+---
+name: "Compatibility Impact Analyzer"
+description: "Snapshot the current API surface and detect breaking changes against a prior baseline. Generates a migration guide when breaking changes are found."
+category: Workflow
+tags: [workflow, compatibility, breaking-changes, migration]
+---
+
+Analyze the API surface of **specrails-core** for backwards compatibility. Extracts the current contract surface (CLI flags, template placeholders, command names, argument flags, agent names, config keys), compares against a stored baseline, classifies each change by severity, and generates a migration guide when breaking changes are found.
+
+**Input:** `$ARGUMENTS` — optional flags:
+- `--diff` — compare current surface to most recent snapshot (default when snapshots exist)
+- `--snapshot` — capture current surface and save without diffing (default on first run)
+- `--since <date>` — diff against snapshot from this date (ISO format: YYYY-MM-DD)
+- `--propose <change-dir>` — diff proposed changes in `openspec/changes/<change-dir>/` against current surface
+- `--dry-run` — run all phases but skip saving the snapshot
+
+---
+
+## Phase 0: Argument Parsing
+
+Parse `$ARGUMENTS` to set runtime variables.
+
+**Variables to set:**
+
+- `MODE` — string, one of `"snapshot"`, `"diff"`, `"propose"`. Default: `"diff"` if `.claude/compat-snapshots/` contains any `.json` files; `"snapshot"` otherwise.
+- `COMPARE_DATE` — string (ISO date) or empty string. Default: `""` (use most recent snapshot).
+- `PROPOSE_DIR` — string or empty string. Default: `""`.
+- `DRY_RUN` — boolean. Default: `false`.
+
+**Parsing rules:**
+
+1. Scan `$ARGUMENTS` for `--snapshot`. If found, set `MODE=snapshot`.
+2. Scan for `--diff`. If found, set `MODE=diff`.
+3. Scan for `--since <date>`. If found, set `COMPARE_DATE=<date>` and (if `MODE` not already set to `snapshot`) set `MODE=diff`.
+4. Scan for `--propose <change-dir>`. If found, set `PROPOSE_DIR=<change-dir>` and `MODE=propose`.
+   - Verify `openspec/changes/<change-dir>/` exists. If not: print `Error: no change found at openspec/changes/<change-dir>/` and stop.
+5. Scan for `--dry-run`. If found, set `DRY_RUN=true`.
+6. Apply default-mode logic if `MODE` is not yet set: check whether `.claude/compat-snapshots/` exists and contains `.json` files. If yes: `MODE=diff`. If no: `MODE=snapshot`.
+
+**Verify prerequisites:**
+
+- Check whether `templates/` directory exists. If not: print `Error: templates/ not found — is this a specrails repo?` and stop.
+- Check whether `bin/specrails-core.mjs` exists. If not: set `INSTALLER_AVAILABLE=false` (installer flags category will be skipped). Otherwise set `INSTALLER_AVAILABLE=true`.
+
+**Print active configuration:**
+
+```
+Mode: <MODE> | Compare date: <COMPARE_DATE or "latest"> | Dry-run: <true/false>
+```
+
+---
+
+## Phase 1: Extract Current Surface
+
+Read the codebase and build the surface snapshot. Print one progress line as each category completes.
+
+**Surface category: installer_flags**
+
+If `INSTALLER_AVAILABLE=false`: print `  installer_flags: skipped (bin/specrails-core.mjs not found)` and record as unavailable.
+
+Otherwise: read `bin/specrails-core.mjs`. Extract every `--<word>` flag pattern that is accepted by the CLI dispatcher. For each flag, record the flag string and line number.
+
+Print: `  installer_flags: N found`
+
+**Surface category: template_placeholders**
+
+Read all files matching `templates/**/*.md`. For each file, extract all `` patterns (regex: `\{\{[A-Z][A-Z0-9_]*\}\}`). Deduplicate across files. For each unique key, record the list of source files it appears in.
+
+Note: Skip patterns inside code fences that are used as documentation examples (i.e., patterns that appear inside triple-backtick blocks describing placeholder syntax rather than actual template usage). Use judgment to distinguish real template placeholders from documented examples.
+
+Print: `  template_placeholders: N unique keys found`
+
+**Surface category: command_names and command_arguments**
+
+Read each file in `templates/commands/`. For each:
+- Extract `name:` value from the YAML frontmatter (between the first `---` and second `---`)
+- Extract the display name from the frontmatter `name:` field (the quoted string)
+- Find all `--<word>` flag patterns in the `$ARGUMENTS` section or argument description prose
+- Record command name, display name, source file, and flags list
+
+Print: `  command_names: N commands found`
+Print: `  command_arguments: N commands with flags documented`
+
+**Surface category: agent_names**
+
+Read each file in `templates/agents/`. Extract `name:` value from the YAML frontmatter.
+
+Print: `  agent_names: N agents found`
+
+**Surface category: config_keys**
+
+Read `openspec/config.yaml`. Extract all top-level YAML keys (lines matching `^<key>:` at zero indentation).
+
+Print: `  config_keys: N keys found`
+
+**Build the surface object:**
+
+Assemble all extracted data into a snapshot object matching the schema:
+
+```json
+{
+  "schema_version": "1",
+  "captured_at": "<ISO 8601 datetime>",
+  "git_sha": "<git rev-parse HEAD or 'unknown'>",
+  "git_branch": "<git rev-parse --abbrev-ref HEAD or 'unknown'>",
+  "surfaces": {
+    "installer_flags": [...],
+    "template_placeholders": [...],
+    "command_names": [...],
+    "command_arguments": [...],
+    "agent_names": [...],
+    "config_keys": [...]
+  }
+}
+```
+
+Set `CURRENT_SURFACE` to this object.
+
+If `MODE=snapshot`: proceed directly to Phase 5 (skip Phases 2–4 diff logic, but still print a surface summary).
+
+---
+
+## Phase 2: Load Baseline
+
+Applies in `diff` and `propose` modes only.
+
+**For `diff` mode:**
+
+1. Check whether `.claude/compat-snapshots/` exists and contains `.json` files.
+   - If empty or missing: print `Advisory: no prior snapshot found. Switching to snapshot mode.` Set `MODE=snapshot`. Proceed to Phase 5.
+2. If `COMPARE_DATE` is empty: select the most recently modified `.json` file.
+3. If `COMPARE_DATE` is set: find the snapshot whose filename date is closest to `COMPARE_DATE` without exceeding it. If no match within 7 days: print `Warning: no snapshot found near <COMPARE_DATE>. Falling back to most recent.` Use most recent.
+4. Load the selected file as `BASELINE_SURFACE`.
+5. Print: `Baseline: <YYYY-MM-DD> (<sha from filename>)`
+
+**For `propose` mode:**
+
+1. Load the most recent snapshot from `.claude/compat-snapshots/` as `BASELINE_SURFACE` (same selection logic as `diff` mode with `COMPARE_DATE` empty).
+2. Additionally read `openspec/changes/<PROPOSE_DIR>/design.md` to understand the projected surface changes.
+   - If `design.md` does not exist: print `Warning: no design.md found in openspec/changes/<PROPOSE_DIR>/. Proceeding with surface extraction only (no projection).`
+   - If it exists: read also `openspec/changes/<PROPOSE_DIR>/tasks.md` if present.
+3. Use the proposed changes to project the "after" surface: identify which elements would be added, removed, or modified based on the design document.
+4. Print: `Propose mode: analyzing openspec/changes/<PROPOSE_DIR>/`
+
+Set `BASELINE_SURFACE` and `PROJECTED_CHANGES` (in propose mode).
+
+---
+
+## Phase 3: Diff and Classify
+
+Applies in `diff` and `propose` modes. Skipped in `snapshot` mode.
+
+For each surface category (`installer_flags`, `template_placeholders`, `command_names`, `command_arguments`, `agent_names`, `config_keys`):
+
+1. Build identifier sets from baseline and current (or projected, in propose mode).
+2. Compute:
+   - `removed = identifiers in baseline but not in current`
+   - `added = identifiers in current but not in baseline`
+   - `common = identifiers in both`
+3. For common elements: check whether attributes changed (display name, flags list, file list). Classify attribute changes as Category 3 (Signature Change) if they affect the interface.
+4. Classify each removal:
+   - If a similar-looking name appears in `added`: classify as **Category 2: Rename** (BREAKING — MAJOR)
+   - Otherwise: classify as **Category 1: Removal** (BREAKING — MAJOR)
+5. Classify additions as non-breaking (new additions do not break existing callers).
+6. Classify behavioral changes detected from the design document (in propose mode) as **Category 4: Behavioral Change** (ADVISORY).
+
+Build two lists:
+- `BREAKING_CHANGES` — list of `{ category, element, surface, severity, description }` objects (Categories 1, 2, 3)
+- `ADVISORY_CHANGES` — list of `{ category, element, surface, description }` objects (Category 4)
+
+---
+
+## Phase 4: Generate Report
+
+Print the full compatibility report.
+
+```
+## Compatibility Impact Report — specrails-core
+Date: <ISO date> | Commit: <git_short_sha or "unknown">
+
+### Surface Snapshot
+| Category | Elements Found |
+|----------|---------------|
+| Installer flags | N |
+| Template placeholders | N |
+| Command names | N |
+| Command argument flags | N |
+| Agent names | N |
+| Config keys | N |
+
+### Breaking Changes (N found)
+<if BREAKING_CHANGES is empty:>
+None detected.
+
+<if BREAKING_CHANGES is non-empty, for each:>
+- [Category <N>: <category-name>] <surface>: `<element>` — <description>
+
+### Advisory Changes (N found)
+<if ADVISORY_CHANGES is empty:>
+None detected.
+
+<if ADVISORY_CHANGES is non-empty, for each:>
+- [Category 4: Behavioral Change] <surface>: `<element>` — <description>
+```
+
+**Migration Guide** (only when `len(BREAKING_CHANGES) > 0`):
+
+For each breaking change, append a Migration Guide block:
+
+```
+## Migration Guide
+
+**Change type:** <Removal | Rename | Signature Change>
+**Severity:** BREAKING
+**Affects:** <who is affected>
+
+### What Changed
+<one paragraph describing before and after>
+
+### Before
+<concrete example of old usage>
+
+### After
+<concrete example of new usage>
+
+### Remediation Options
+
+**Option A — Backwards-compatible alias (recommended)**
+<how to add an alias or shim>
+
+**Option B — Clean break with changelog**
+<what to put in CHANGELOG.md>
+
+### Version Strategy
+<MAJOR bump if removing/renaming; MINOR if signature-only>
+```
+
+---
+
+## Phase 5: Save Snapshot
+
+**If `DRY_RUN=true`:**
+
+Print: `Snapshot not saved — dry-run mode`
+
+Skip the save. Still perform the housekeeping check and `.gitignore` check below.
+
+**If `DRY_RUN=false`:**
+
+1. Determine filename: `<YYYY-MM-DD>-<git_short_sha>.json`. If git is unavailable: `<YYYY-MM-DD>-unknown.json`.
+2. Create `.claude/compat-snapshots/` if it does not exist.
+3. Write `CURRENT_SURFACE` serialized as JSON to `.claude/compat-snapshots/<filename>`.
+4. Print: `Snapshot saved: .claude/compat-snapshots/<filename>`
+
+**Housekeeping notice:**
+
+Count `.json` files in `.claude/compat-snapshots/`. If count > 30, print:
+
+```
+Note: .claude/compat-snapshots/ has N snapshots. Consider pruning old ones with:
+  ls -t .claude/compat-snapshots/ | tail -n +31 | xargs -I{} rm .claude/compat-snapshots/{}
+```
+
+**.gitignore suggestion:**
+
+Check whether `.claude/compat-snapshots/` appears in `.gitignore` (if `.gitignore` exists). If it does not appear, print:
+
+```
+Tip: compat snapshots are local artifacts. Add to .gitignore:
+  echo '.claude/compat-snapshots/' >> .gitignore
+```

--- a/.claude/commands/specrails/doctor.md
+++ b/.claude/commands/specrails/doctor.md
@@ -1,0 +1,62 @@
+# Doctor: specrails Health Check
+
+Run the specrails health check to validate that all prerequisites are correctly configured for this repository.
+
+---
+
+## What it checks
+
+| Check | Pass condition |
+|-------|---------------|
+| Claude Code CLI | `claude` binary found in PATH |
+| Claude API key | `claude config list` shows a key OR `ANTHROPIC_API_KEY` env var set |
+| Agent files | Generated agent files exist under `.claude/agents/` |
+| CLAUDE.md | `CLAUDE.md` present in the repo root |
+| Git initialized | `.git/` directory present |
+| npm | `npm` binary found in PATH |
+
+## How to run
+
+This command uses the Node-native doctor runtime. Run it directly with:
+
+```
+npx specrails-core@latest doctor
+```
+
+If `specrails-core` is already on your `PATH`, this works too:
+
+```
+specrails-core doctor
+```
+
+## Output
+
+Each check is displayed as ✅ (pass) or ❌ (fail with fix instruction).
+
+On all checks passed:
+```
+All 6 checks passed. Run /specrails:get-backlog-specs to get started.
+```
+
+On failure:
+```
+❌ API key: not configured
+   Fix: Run: claude config set api_key <your-key>  |  Get a key: https://console.anthropic.com/
+
+1 check(s) failed.
+```
+
+## Exit codes
+
+- `0` — all checks passed
+- `1` — one or more checks failed
+
+## Log file
+
+Each run appends a timestamped summary to `~/.specrails/doctor.log`:
+
+```
+2026-03-20T10:00:00Z  checks=6 passed=6 failed=0
+```
+
+The `~/.specrails/` directory is created automatically if it does not exist.

--- a/.claude/commands/specrails/enrich.md
+++ b/.claude/commands/specrails/enrich.md
@@ -1,0 +1,1635 @@
+# Enrich: Agent Workflow System
+
+Interactive wizard to configure the full agent workflow system for this repository. Analyzes the codebase, discovers target users, generates VPC personas, and creates all agents, commands, rules, and configuration adapted to this project. Supports config-driven mode for direct installation from a pre-built config file.
+
+**Prerequisites:** Ensure this repo was initialized with `npx specrails-core@latest init` (or via specrails-hub) so `.specrails/setup-templates/` exists.
+
+### Hub Checkpoint Protocol
+
+When running inside specrails-hub, emit checkpoint markers at key transitions so the hub `CheckpointTracker` can display progress. Each checkpoint is a single line printed to stdout:
+
+```
+[checkpoint:phase_1_analysis] Codebase analysis complete
+[checkpoint:phase_2_personas] VPC personas generated
+[checkpoint:phase_3_commands] Commands and rules generated
+[checkpoint:phase_4_agents] Agent files generated
+[checkpoint:phase_5_cleanup] Cleanup and summary complete
+```
+
+The hub parses these via `detectCheckpointFromText()` regex patterns. Always emit checkpoints at the end of each phase, even in `--from-config` and `--quick` modes.
+
+---
+
+## Mode Detection
+
+Check `$ARGUMENTS` in this order:
+
+1. If `--update` is present → execute **Update Mode** (below), then stop.
+2. If `--from-config` is present → execute **From-Config Mode** (below), then stop.
+3. If `--quick` or `--lite` is present → execute **Quick Mode** (below), then stop.
+4. Otherwise (no flags) → skip directly to **Phase 1** and execute the full 5-phase wizard.
+
+**Default is the full wizard.** Quick Mode only runs when `--quick` or `--lite` is explicitly passed.
+
+---
+
+## From-Config Mode
+
+When `--from-config` is passed, execute a fully automated installation using `.specrails/install-config.yaml`. No interactive prompts — all decisions come from the config file.
+
+### FC1: Read and Validate Config
+
+Read `.specrails/install-config.yaml`. If it does not exist, display:
+> "`.specrails/install-config.yaml` not found. Run the TUI installer first (`npx specrails-core@latest init`) or use `/specrails:enrich` without `--from-config` for the interactive wizard."
+Then stop.
+
+Parse the YAML and extract:
+- `config.version` — must be `1`; if not, warn and proceed
+- `config.provider` — `claude` or `codex`; default `claude`
+- `config.tier` — `full` or `quick`; default `full`
+- `config.agents.selected` — list of agent names to install
+- `config.agents.excluded` — list of agent names to skip (for reference only)
+- `config.models.preset` — `balanced`, `budget`, or `max` (see Model Presets below)
+- `config.models.defaults.model` — default model override (overrides preset)
+- `config.models.overrides` — per-agent model overrides (highest priority)
+- `config.agent_teams` — boolean; whether to install team-review/team-debug commands
+
+Store all values in variables prefixed `FC_`.
+
+**Model Presets** (applied when `config.models.defaults` is not set):
+- `balanced` (default): sr-architect=opus, sr-product-manager=opus, all others=sonnet
+- `budget`: all agents=haiku
+- `max`: all agents=opus
+
+To resolve the model for any given agent:
+1. Check `config.models.overrides.<agent-name>` — if present, use it
+2. Check `config.models.defaults.model` — if present, use it
+3. Apply preset defaults based on `config.models.preset`
+4. Fallback to model in template frontmatter
+
+### FC2: Provider Setup
+
+Use `FC_provider` from the config as the source of truth. Set `CLI_PROVIDER = FC_provider`, and set `SPECRAILS_DIR` to `.codex` when `CLI_PROVIDER == "codex"`, otherwise `.claude`.
+
+Set `SPECRAILS_DIR` and `CLI_PROVIDER` from resolved provider.
+
+### FC3: If tier is `quick` — run Quick Mode with config context
+
+If `FC_tier == "quick"`:
+- Set `FC_AGENTS_SELECTED` as the list of agents to generate (instead of defaults)
+- Execute Quick Mode (QS1–QS4), generating all `FC_AGENTS_SELECTED` agents (not just defaults)
+- Then stop.
+
+### FC4: If tier is `full` — run automated full wizard
+
+**Phase 1 (Silent):** Run the full Phase 1 analysis (1.1–1.4) without any user prompts. Store all detected values internally.
+
+**Phase 2 (AI-Inferred VPC Discovery):** Run VPC persona generation from codebase analysis:
+- Analyze the codebase (README, package.json, source code, configs) to infer what the product does and who it serves
+- Generate `PROJECT_DESCRIPTION` (2–3 sentence summary) and `TARGET_USERS` from analysis
+- Use these inferred values to generate full VPC personas (3 primary, 3 secondary)
+- Do not ask the user any questions — infer everything from codebase analysis
+
+**Phase 3 (Silent):** Run Phase 3 normally without user prompts.
+
+**Phase 4 (Config-Driven Agent Generation):** 
+- Generate only agents in `FC_AGENTS_SELECTED` (skip any not in the list)
+- Apply model resolution (FC1 preset/override logic) to each agent's frontmatter
+- Run all Phase 4 sub-phases (4.1, 4.2, 4.3, 4.4) normally but without interactive prompts
+- If `FC_agent_teams == true`, also install team-review and team-debug commands
+
+**Phase 5 (Normal):** Run Phase 5 cleanup normally.
+
+### FC5: Completion
+
+Display:
+```
+✅ Enrich complete (from-config).
+
+Agents generated: <count> of <total selected>
+Models applied:
+  sr-architect: <resolved-model>
+  sr-developer: <resolved-model>
+  [... one line per generated agent ...]
+
+Next steps:
+  > /specrails:implement <feature>
+```
+
+---
+
+## Update Mode
+
+When `--update` is passed, execute this streamlined flow instead of the full wizard. Do not run any phases from the full wizard. When Phase U7 is complete, stop.
+
+### Phase U1: Read Update Context
+
+Read the following files to understand the current installation state:
+
+1. Read `.specrails/specrails-manifest.json` — contains agent template checksums from the last install/update. Structure:
+   ```json
+   {
+     "version": "0.2.0",
+     "installed_at": "2025-01-15T10:00:00Z",
+     "artifacts": {
+       "templates/agents/architect.md": "sha256:<checksum>",
+       "templates/agents/developer.md": "sha256:<checksum>",
+       "templates/agents/reviewer.md": "sha256:<checksum>"
+     }
+   }
+   ```
+   If this file does not exist, inform the user:
+   > "No `.specrails/specrails-manifest.json` found. This repo predates the Node-native installer. Re-run `npx specrails-core@latest init` to refresh the install, then re-run `/specrails:enrich --update`."
+   Then stop.
+
+2. Read `.specrails/specrails-version` — contains the current version string (e.g., `0.2.0`). If it does not exist, treat version as `0.1.0 (legacy)`.
+
+3. Determine `$SPECRAILS_DIR` from the existing install layout. If `.codex/` exists, use `cli_provider = "codex"` and `specrails_dir = ".codex"`. Otherwise use `cli_provider = "claude"` and `specrails_dir = ".claude"`.
+
+4. List all template files in `.specrails/setup-templates/agents/` — these are the NEW agent templates from the update:
+   ```bash
+   ls .specrails/setup-templates/agents/
+   ```
+   Template files are named with `sr-` prefix (e.g., `sr-architect.md`, `sr-developer.md`).
+
+5. List all template files in `.specrails/setup-templates/commands/specrails/` — these are the NEW command templates from the update:
+   ```bash
+   ls .specrails/setup-templates/commands/specrails/
+   ```
+   Command template files include `implement.md`, `batch-implement.md`, `compat-check.md`, `refactor-recommender.md`, `why.md`, `get-backlog-specs.md`, `auto-propose-backlog-specs.md`.
+   If this directory does not exist, skip command template checking for this update.
+
+6. Read `.specrails/backlog-config.json` if it exists — contains stored provider configuration needed for command placeholder substitution.
+
+7. Read `.specrails/agents.yaml` if it exists — contains agent model configuration. Validate all `model:` values (only `opus`, `sonnet`, `haiku` are valid). Store as `AGENTS_CONFIG` for use in Phase U4. If the file does not exist, set `AGENTS_CONFIG = null`.
+
+### Phase U2: Quick Codebase Re-Analysis
+
+Perform the same analysis as Phase 1 of the full setup wizard, but silently — do not prompt the user and do not show the findings table. Just execute and store results internally.
+
+Detect:
+- **Languages**: Check for `*.py`, `*.ts`, `*.tsx`, `*.go`, `*.rs`, `*.java`, `*.kt`, `*.rb`, `*.cs`
+- **Frameworks**: Search for imports (`fastapi`, `express`, `react`, `vue`, `angular`, `django`, `spring`, `gin`, `actix`, `rails`)
+- **Directory structure**: Identify backend/frontend/core/test directories
+- **Database**: Check for SQL files, ORM configs, migration directories
+- **CI/CD**: Parse `.github/workflows/*.yml` for lint/test/build commands
+- **Naming conventions**: Read 2-3 source files per detected layer
+
+Read:
+- `README.md` (if exists)
+- `package.json` / `pyproject.toml` / `Cargo.toml` / `go.mod` / `pom.xml` (detect stack)
+- `.github/workflows/*.yml` (detect CI commands)
+
+Store all results for use in Phases U4 and U5.
+
+### Phase U3: Identify What Needs Regeneration
+
+**Agent templates:** For each agent template, find its entry in the manifest's `artifacts` map (keyed as `templates/agents/sr-<name>.md`). Compute the SHA-256 checksum of the corresponding file in `.specrails/setup-templates/agents/`:
+
+```bash
+sha256sum .specrails/setup-templates/agents/sr-<name>.md
+```
+
+Build three lists for agents:
+
+1. **Changed agents**: agent name exists in manifest AND the current template checksum differs from the manifest checksum → mark for regeneration
+2. **New agents**: template file exists in `.specrails/setup-templates/agents/` but the agent name is NOT in the manifest → mark for evaluation
+3. **Unchanged agents**: agent name exists in manifest AND checksum matches → skip
+
+**Command templates:** If `.specrails/setup-templates/commands/specrails/` exists, for each command template file, find its entry in the manifest's `artifacts` map (keyed as `templates/commands/specrails/<name>.md`). Compute the SHA-256 checksum of the corresponding file in `.specrails/setup-templates/commands/specrails/`:
+
+```bash
+sha256sum .specrails/setup-templates/commands/specrails/<name>.md
+```
+
+Build three lists for commands:
+
+1. **Changed commands**: command name exists in manifest AND the current template checksum differs from the manifest checksum → mark for update
+2. **New commands**: template file exists in `.specrails/setup-templates/commands/specrails/` but the command name is NOT in the manifest → mark for evaluation
+3. **Unchanged commands**: command name exists in manifest AND checksum matches → skip
+
+Display the combined analysis to the user:
+
+```
+## Update Analysis
+
+### Agents — Changed Templates (will be regenerated)
+- sr-architect.md (template modified)
+- sr-developer.md (template modified)
+
+### Agents — New Templates Available
+- sr-frontend-developer.md
+- sr-backend-developer.md
+
+### Agents — Unchanged (keeping current)
+- sr-reviewer.md
+- sr-product-manager.md
+
+### Commands — Changed Templates (will be updated)
+- implement.md (template modified)
+
+### Commands — New Templates Available
+- refactor-recommender.md
+
+### Commands — Unchanged (keeping current)
+- compat-check.md
+- why.md
+```
+
+If there are no changed agents, no new agents, no changed commands, and no new commands, display:
+```
+All agents and commands are already up to date. Nothing to regenerate.
+```
+Then jump to Phase U7.
+
+### Phase U4: Regenerate Changed Agents
+
+For each agent in the "changed" list:
+
+1. Read the NEW template from `.specrails/setup-templates/agents/sr-<name>.md`
+2. Use the codebase analysis from Phase U2 to fill in all `` values, using the same substitution rules as Phase 4.1 of the full setup:
+   - `specrails-core` → project name (from README.md or directory name)
+   - `` → detected architecture layers
+   - `` → detected layer tags (e.g., `[backend]`, `[frontend]`, `[api]`)
+   - `` → backend CI commands
+   - `` → frontend CI commands
+   - `` → detected conventions per layer
+   - `` → read existing persona names from `$SPECRAILS_DIR/agents/personas/` filenames
+   - `` → paths to existing persona files in `$SPECRAILS_DIR/agents/personas/`
+   - `` → infer from detected stack and README
+   - `` → important file paths detected in Phase U2
+   - `` → read from existing `CLAUDE.md` if present
+   - `.claude/agent-memory/` → `$SPECRAILS_DIR/agent-memory/sr-<agent-name>/`
+3. Resolve the agent's model using `AGENTS_CONFIG` (loaded in Phase U1, step 7):
+   - Check `AGENTS_CONFIG.agents.<agent-name>.model` (per-agent override)
+   - If not present, check `AGENTS_CONFIG.defaults.model` (global default)
+   - If `AGENTS_CONFIG` is null, use the model from the template frontmatter
+   - Replace the `model:` field in the YAML frontmatter with the resolved value before writing
+4. Write the adapted agent using the format for the active provider (same dual-format rules as Phase 4.1):
+   - `cli_provider == "claude"`: write to `$SPECRAILS_DIR/agents/sr-<name>.md` (Markdown with YAML frontmatter)
+   - `cli_provider == "codex"`: write to `$SPECRAILS_DIR/agents/sr-<name>.toml` (TOML format with `name`, `description`, `model`, `prompt` fields)
+5. Show: `✓ Regenerated sr-<name>`
+
+After regenerating all changed agents, verify no unresolved placeholders remain:
+```bash
+# Claude Code
+grep -r '{{[A-Z_]*}}' .claude/agents/sr-*.md 2>/dev/null || echo "OK: no broken placeholders"
+# Codex
+grep -r '{{[A-Z_]*}}' .codex/agents/sr-*.toml 2>/dev/null || echo "OK: no broken placeholders"
+```
+
+### Phase U4b: Update Changed Commands
+
+For each command in the "changed commands" list from Phase U3:
+
+1. Read the NEW template:
+   - If `cli_provider == "claude"`: from `.specrails/setup-templates/commands/specrails/<name>.md`
+   - If `cli_provider == "codex"`: from `.specrails/setup-templates/skills/sr-<name>/SKILL.md`
+2. Read stored backlog configuration from `.specrails/backlog-config.json` (if it exists) to resolve provider-specific placeholders:
+   - `BACKLOG_PROVIDER` → `provider` field (`github`, `jira`, or `none`)
+   - `BACKLOG_WRITE` → `write_access` field
+   - `JIRA_BASE_URL` → `jira_base_url` field
+   - `JIRA_PROJECT_KEY` → `jira_project_key` field
+3. Substitute all `` values using the same rules as Phase 4.3 of the full setup:
+   - `` → backend CI commands detected in Phase U2
+   - `` → frontend CI commands detected in Phase U2
+   - `` → stack-specific dependency check commands from Phase U2
+   - `` → test runner commands from Phase U2
+   - `` → provider-specific fetch command from backlog config
+   - `` → provider-specific create command from backlog config
+   - `` → provider-specific view command from backlog config
+   - `` → provider-specific preflight check from backlog config
+   - Any other `` values → use Phase U2 analysis data
+4. Write the updated file:
+   - If `cli_provider == "claude"`: to `.claude/commands/specrails/<name>.md`
+   - If `cli_provider == "codex"`: to `.agents/skills/sr-<name>/SKILL.md`
+5. Show:
+   - If `cli_provider == "claude"`: `✓ Updated /specrails:<name>`
+   - If `cli_provider == "codex"`: `✓ Updated $sr-<name>`
+
+After updating all changed commands/skills, verify no unresolved placeholders remain:
+```bash
+# If cli_provider == "claude":
+grep -l '{{[A-Z_]*}}' .claude/commands/specrails/*.md 2>/dev/null || echo "OK: no broken placeholders"
+# If cli_provider == "codex":
+grep -rl '{{[A-Z_]*}}' .agents/skills/sr-*/SKILL.md 2>/dev/null || echo "OK: no broken placeholders"
+```
+If any placeholders remain unresolved, warn the user:
+> "⚠ Some placeholders in `<filename>` could not be resolved automatically. Please review the file and fill them in manually."
+
+### Phase U5: Evaluate New Agents
+
+For each agent in the "new" list:
+
+1. Read the template from `.specrails/setup-templates/agents/sr-<name>.md` to understand what stack or layer it targets (read its description and any layer-specific comments)
+2. Match against the codebase detected in Phase U2:
+   - If the template targets a layer/stack that IS present (e.g., `sr-frontend-developer` and React was detected), prompt:
+     > "New agent available: `sr-<name>` — your project uses [detected tech]. Add it? [Y/n]"
+   - If the template targets a layer/stack that is NOT present (e.g., `sr-backend-developer` and no backend was detected), prompt:
+     > "New agent available: `sr-<name>` — no [layer] detected in your project. Skip? [Y/n]"
+3. If the user accepts (or presses Enter on a pre-selected default):
+   - Generate the agent using the same template adaptation as Phase U4
+   - Create memory directory if it does not exist: `$SPECRAILS_DIR/agent-memory/sr-<name>/`
+   - Show: `✓ Added sr-<name>`
+4. If the user declines:
+   - Show: `→ Skipped sr-<name>`
+
+For each command in the "new commands" list from Phase U3:
+
+1. Read the template:
+   - If `cli_provider == "claude"`: from `.specrails/setup-templates/commands/specrails/<name>.md`
+   - If `cli_provider == "codex"`: from `.specrails/setup-templates/skills/sr-<name>/SKILL.md`
+2. Prompt the user:
+   - If `cli_provider == "claude"`: `"New command available: /specrails:<name> — [one-line description]. Install it? [Y/n]"`
+   - If `cli_provider == "codex"`: `"New skill available: $sr-<name> — [one-line description]. Install it? [Y/n]"`
+3. If the user accepts (or presses Enter):
+   - Apply placeholder substitution using the same rules as Phase U4b (backlog config + codebase analysis)
+   - If `cli_provider == "claude"`: write to `.claude/commands/specrails/<name>.md` — show `✓ Added /specrails:<name>`
+   - If `cli_provider == "codex"`: write to `.agents/skills/sr-<name>/SKILL.md` — show `✓ Added $sr-<name>`
+4. If the user declines:
+   - If `cli_provider == "claude"`: show `→ Skipped /specrails:<name>`
+   - If `cli_provider == "codex"`: show `→ Skipped $sr-<name>`
+
+### Phase U6: Update Workflow Commands
+
+If any new agents were added in Phase U5:
+
+1. Read the implement command/skill:
+   - If `cli_provider == "claude"`: `.claude/commands/specrails/implement.md`
+   - If `cli_provider == "codex"`: `.agents/skills/sr-implement/SKILL.md`
+2. Check if the file references agent names in its orchestration steps (look for `sr-architect`, `sr-developer`, `sr-reviewer` etc.)
+3. If newly added agents belong in the implementation pipeline (i.e., they are layer-specific developers such as `sr-frontend-developer` or `sr-backend-developer`), add them to the appropriate step in the implement command — specifically where parallel developer agents are launched
+4. Write the updated file if any changes were made:
+   - If `cli_provider == "claude"`: `.claude/commands/specrails/implement.md`
+   - If `cli_provider == "codex"`: `.agents/skills/sr-implement/SKILL.md`
+5. Show which commands were updated, or "No command updates needed" if nothing changed
+
+This is a lightweight check — only update commands where the sr- agent clearly belongs. Do not restructure the entire command.
+
+### Phase U7: Summary
+
+Display the final summary and stop. Do not continue to Phase 1 of the full setup wizard.
+
+```
+## Update Complete
+
+specrails updated from v<previous> to v<new>.
+
+| Action              | Count |
+|---------------------|-------|
+| Agents regenerated  | N     |
+| Agents added        | N     |
+| Agents skipped      | N     |
+| Commands updated    | N     |
+| Commands added      | N     |
+| Commands skipped    | N     |
+
+All agents and commands are now up to date.
+
+### Agents Regenerated
+[list agent names, or "(none)"]
+
+### Agents Added
+[list agent names, or "(none)"]
+
+### Agents Skipped
+[list agent names, or "(none)"]
+
+### Commands Updated
+[list command names, or "(none)"]
+
+### Commands Added
+[list command names, or "(none)"]
+
+### Commands Skipped
+[list command names, or "(none)"]
+```
+
+Update `.specrails/specrails-manifest.json` to reflect the new checksums for all regenerated/updated and added agents and commands:
+- For each regenerated agent: update its checksum entry to the new template's checksum (keyed as `templates/agents/sr-<name>.md`)
+- For each added agent: add a new entry with its checksum
+- For each updated command: update its checksum entry to the new template's checksum (keyed as `templates/commands/specrails/<name>.md`)
+- For each added command: add a new entry with its checksum
+- Update the `version` field to the version read from `.specrails/specrails-version`
+
+---
+
+## Quick Mode
+
+When `--quick` or `--lite` is passed, run this streamlined 3-question setup. Do NOT run Phase 1–5. When QS4 is complete, stop.
+
+### QS1: Infer context and ask git access
+
+**Step 1 — AI inference (silent):** Analyze the codebase to infer:
+- `QS_PROJECT_DESCRIPTION` — a 2–3 sentence summary of what this project does (from README, package.json, source code, configs)
+- `QS_TARGET_USERS` — who the target users are (from docs, UI copy, API design, domain language)
+
+**Step 2 — Ask one question:**
+
+Display the following prompt EXACTLY ONCE:
+
+Welcome to specrails! Let's get your AI agent team set up.
+
+I've analyzed your codebase:
+- **Project:** {QS_PROJECT_DESCRIPTION}
+- **Target users:** {QS_TARGET_USERS}
+
+1. Git access for agents — read-only or read-write?
+   (read-only = agents can read and suggest; read-write = agents can commit)
+
+Store the answer as:
+- `QS_GIT_ACCESS` — "read-only" or "read-write" (normalize if user types "ro", "rw", "readonly", etc.)
+
+### QS2: Apply opinionated defaults
+
+Use these defaults for all configuration not asked in QS1:
+
+| Setting | Quick Mode Default |
+|---------|------------------|
+| Agents enabled | sr-architect, sr-developer, sr-reviewer, sr-product-manager |
+| Git mode | Derived from QS_GIT_ACCESS |
+| CLAUDE.md template | `templates/CLAUDE-quickstart.md` |
+| OpenSpec enabled | Yes if `openspec` CLI is detected in PATH, No otherwise |
+| Telemetry | Not configured (deferred to PRD-002) |
+| Backlog provider | local (lightweight JSON-based, no external tools needed) |
+
+Detect whether this is an existing codebase or new project:
+- **Existing codebase**: `package.json`, `Gemfile`, `pyproject.toml`, `go.mod`, or `pom.xml` found in the repo root
+- **New project**: none of the above found
+
+Store as `QS_IS_EXISTING_CODEBASE=true/false`.
+
+### QS2.5: Re-run Detection
+
+Before generating files, check if this is a re-run:
+
+1. Check if commands/skills already exist:
+   - If `cli_provider == "claude"`: check if `.claude/commands/specrails/` directory exists with any `.md` files:
+     ```bash
+     ls .claude/commands/specrails/*.md 2>/dev/null
+     ```
+   - If `cli_provider == "codex"`: check if `.agents/skills/sr-*/SKILL.md` files exist:
+     ```bash
+     ls .agents/skills/sr-*/SKILL.md 2>/dev/null
+     ```
+2. If files are found → this is a **re-run**. Store `QS_IS_RERUN=true`.
+3. If the directory does not exist or is empty → this is a **fresh install**. Store `QS_IS_RERUN=false`.
+
+In re-run mode, QS3 executes in **gap-fill mode** for command/skill files:
+- For each command in the list, check if it already exists:
+  - If `cli_provider == "claude"`: at `.claude/commands/specrails/<name>.md`
+  - If `cli_provider == "codex"`: at `.agents/skills/sr-<name>/SKILL.md`
+- If it exists: skip it and show:
+  - Claude: `✓ Already installed: /specrails:<name>`
+  - Codex: `✓ Already installed: $sr-<name>`
+- If it does NOT exist: install it and show:
+  - Claude: `✓ Added /specrails:<name> (was missing)`
+  - Codex: `✓ Added $sr-<name> (was missing)`
+- Do NOT prompt the user for confirmation on missing files — install them automatically
+
+For CLAUDE.md/AGENTS.md and agent files, the existing per-file prompts already handle re-runs (user is asked before overwriting). No change needed there.
+
+### QS3: Generate files
+
+Generate files using the Quick Mode defaults.
+
+**1. CLAUDE.md**
+
+Read `.specrails/setup-templates/claude-md/CLAUDE-quickstart.md` (or fall back to `.specrails/setup-templates/claude-md/default.md` if quickstart template is not found).
+
+Replace placeholders:
+- `specrails-core` → derive from directory name or README.md first heading
+- `` → `QS_GIT_ACCESS`
+
+Write to `CLAUDE.md` in the repo root. If `CLAUDE.md` already exists, ask:
+> "CLAUDE.md already exists. Overwrite? [Y/n]"
+Skip if user says no.
+
+**2. Agent files**
+
+For each default agent (sr-architect, sr-developer, sr-reviewer, sr-product-manager), read the template from `.specrails/setup-templates/agents/<name>.md` and generate the adapted agent file using the dual-format rules from Phase 4.1:
+- `cli_provider == "claude"`: write to `.claude/agents/<name>.md` (Markdown with frontmatter)
+- `cli_provider == "codex"`: write to `.codex/agents/<name>.toml` (TOML format)
+
+If `.specrails/agents.yaml` exists, read it and apply model resolution (per-agent override → defaults → template value) before writing each agent file.
+
+Fill placeholders with best-effort values from the limited context available:
+- `specrails-core` → directory name or README first heading
+- `` → `QS_GIT_ACCESS`
+- `` → "(Quick Mode — run `/specrails:enrich` for full architecture analysis)"
+- `` → "(Quick Mode — run `/specrails:enrich` for codebase-specific expertise)"
+- `` → detect from package.json / Gemfile / go.mod if present; otherwise leave empty
+- All other placeholders → "(not configured — run `/specrails:enrich`)"
+
+Create memory directories: `$SPECRAILS_DIR/agent-memory/sr-<name>/`
+
+**3. Command files**
+
+Core commands (always install if missing):
+- `implement.md`
+- `batch-implement.md`
+- `propose-spec.md`
+- `compat-check.md`
+- `why.md`
+- `get-backlog-specs.md`
+- `auto-propose-backlog-specs.md`
+
+**Initialize local ticket storage** (backlog provider defaults to `local`):
+1. Copy `templates/local-tickets-schema.json` to `.specrails/local-tickets.json` and set `last_updated` to the current ISO-8601 timestamp. Skip if the file already exists.
+2. Write `.specrails/backlog-config.json` (skip if already exists):
+   ```json
+   {
+     "provider": "local",
+     "write_access": true,
+     "git_auto": true
+   }
+   ```
+
+**If `cli_provider == "claude"`:**
+
+If `QS_IS_RERUN=false` (fresh install): for each core command, read the template from `.specrails/setup-templates/commands/specrails/<name>.md`, substitute the backlog placeholders with local values (using the same table as Phase 4.3 "Local Tickets"), stub all persona placeholders with `(Quick Mode — run /specrails:enrich to configure personas)`, then write to `.claude/commands/specrails/<name>.md`.
+
+If `QS_IS_RERUN=true` (gap-fill mode): for each command in the list above, check if `.claude/commands/specrails/<name>.md` already exists:
+- If it exists: skip it — show `✓ Already installed: /specrails:<name>`
+- If it does NOT exist: read template, substitute placeholders as above, write to `.claude/commands/specrails/<name>.md` — show `✓ Added /specrails:<name> (was missing)`
+
+**If `cli_provider == "codex"`:**
+
+If `QS_IS_RERUN=false` (fresh install): for each core command, read the corresponding skill template from `.specrails/setup-templates/skills/sr-<name>/SKILL.md`, substitute the backlog placeholders with local values and stub persona placeholders with `(Quick Mode — run /specrails:enrich to configure personas)`, then write to `.agents/skills/sr-<name>/SKILL.md` (create the directory first).
+
+If `QS_IS_RERUN=true` (gap-fill mode): for each command in the list above, check if `.agents/skills/sr-<name>/SKILL.md` already exists:
+- If it exists: skip it — show `✓ Already installed: $sr-<name>`
+- If it does NOT exist: read template, substitute placeholders as above, write to `.agents/skills/sr-<name>/SKILL.md` — show `✓ Added $sr-<name> (was missing)`
+
+**4. Cleanup**
+
+Remove `.specrails/setup-templates/` (same as full wizard cleanup in Phase 5).
+
+Remove `commands/enrich.md` from `.claude/commands/` if it was copied there by the installer.
+
+### QS4: First Task Prompt
+
+After generating all files, display the setup complete message.
+
+Then, based on `QS_IS_EXISTING_CODEBASE`:
+- **Existing codebase** (`true`): recommend `/specrails:refactor-recommender`
+- **New project** (`false`): recommend `/specrails:get-backlog-specs`
+
+If `QS_IS_RERUN=false`, display:
+```
+✅ Setup complete.
+
+Try your first command:
+  > /specrails:get-backlog-specs
+```
+(Replace `/specrails:get-backlog-specs` with `/specrails:refactor-recommender` for existing codebases.)
+
+If `QS_IS_RERUN=true`, display the gap-fill summary and stop:
+```
+✅ Re-run complete.
+
+Commands status:
+  ✓ Already installed: /specrails:<name>
+  ✓ Added /specrails:<name> (was missing)
+  [... one line per command ...]
+
+All commands are up to date.
+```
+If all commands were already present, display:
+```
+✅ Re-run complete. All commands already installed — nothing to add.
+```
+
+Then stop. Do not execute Phase 1.
+
+---
+
+## Phase 1: Codebase Analysis
+
+Analyze the repository to understand its architecture, stack, and conventions.
+
+### 1.1 Read project structure
+
+```bash
+# Get the repo root and basic info
+git rev-parse --show-toplevel
+ls -la
+```
+
+Read the following to understand the project:
+- `README.md` (if exists)
+- `CLAUDE.md` (if exists — don't overwrite, merge later)
+- `package.json` or `pyproject.toml` or `Cargo.toml` or `go.mod` or `pom.xml` (detect stack)
+- `.github/workflows/*.yml` (detect CI commands)
+- `docker-compose.yml` or `Dockerfile` (detect infra)
+
+### 1.2 Detect architecture layers
+
+Use Glob and Grep to identify:
+
+1. **Languages**: Check for `*.py`, `*.ts`, `*.tsx`, `*.go`, `*.rs`, `*.java`, `*.kt`, `*.rb`, `*.cs`
+2. **Frameworks**: Search for imports (`fastapi`, `express`, `react`, `vue`, `angular`, `django`, `spring`, `gin`, `actix`, `rails`)
+3. **Directory structure**: Identify backend/frontend/core/test directories
+4. **Database**: Check for SQL files, ORM configs, migration directories
+5. **CI/CD**: Parse workflow files for lint/test/build commands
+
+### 1.3 Infer conventions
+
+Read 3-5 representative source files from each detected layer to understand:
+- Naming conventions (camelCase, snake_case, PascalCase)
+- Import patterns
+- Error handling patterns
+- Testing patterns (framework, structure, mocking approach)
+- API patterns (REST, GraphQL, tRPC)
+
+### 1.4 Present findings
+
+Display the detected architecture to the user:
+
+```
+## Codebase Analysis
+
+| Layer       | Tech                | Path          |
+|-------------|---------------------|---------------|
+| Backend     | FastAPI (Python)    | backend/      |
+| Frontend    | React + TypeScript  | frontend/     |
+| Core        | Python package      | src/          |
+| Tests       | pytest              | tests/        |
+| Database    | PostgreSQL          | migrations/   |
+
+### CI Commands Detected
+- Lint: `ruff check .`
+- Format: `ruff format --check .`
+- Test: `pytest tests/ -q`
+- Frontend lint: `npm run lint`
+- Frontend build: `npx tsc --noEmit`
+
+### Conventions Detected
+- Python: snake_case, type hints, Pydantic models
+- TypeScript: strict mode, functional components
+- Testing: pytest fixtures with scope="function"
+
+### OSS Project Detection
+
+Read `.specrails/setup-templates/.oss-detection.json` if it exists.
+
+| Signal | Status |
+|--------|--------|
+| Public repository | [Yes / No / Unknown] |
+| CI workflows (.github/workflows/) | [Yes / No] |
+| CONTRIBUTING.md | [Yes / No] |
+| **Result** | **OSS detected / Not detected / Could not check** |
+
+If `is_oss: false` but at least one signal is `true`:
+> "Some OSS signals were found but not all three. Is this an open-source project? (yes/no)"
+
+If `.oss-detection.json` does not exist:
+> "Is this an open-source project? (yes/no)"
+
+When `IS_OSS=false` and no signals are present, skip OSS output entirely to avoid cluttering the display for non-OSS projects.
+
+Store the final OSS determination as `IS_OSS` for use throughout the rest of setup.
+
+[Confirm] [Modify] [Rescan]
+```
+
+Wait for user confirmation. If they want to modify, ask what to change.
+
+---
+
+## Phase 2: User Personas & Product Discovery
+
+### 2.1 Ask about target users
+
+Ask the user:
+
+> If IS_OSS=true, prepend:
+> "This is an OSS project. The **Maintainer** persona (Kai) is automatically included —
+> you do not need to add 'open-source maintainers' to your list.
+> Describe your other target user types below."
+
+> **Who are the target users of your software?**
+>
+> Describe them in natural language. Examples:
+> - "Developers who manage Kubernetes clusters"
+> - "Small business owners tracking inventory and sales"
+> - "Gamers who collect and trade digital items"
+>
+> I'll research the competitive landscape and create detailed personas
+> with Value Proposition Canvas profiles for each user type.
+>
+> **How many distinct user types do you have?** (typically 2-3)
+
+Wait for the user's response.
+
+### 2.2 Research competitive landscape
+
+For each user type described, use WebSearch to research:
+
+1. **Existing tools** they use today (competitors)
+2. **Common pain points** reported in forums, Reddit, product reviews
+3. **Feature gaps** in current tools
+4. **Unmet needs** and workflow frustrations
+
+Search queries to use (adapt to the domain):
+- `"[domain] [user type] best tools 2025"`
+- `"[domain] [user type] pain points frustrations"`
+- `"[competitor name] missing features complaints"`
+- `"[domain] management app feature comparison"`
+- `site:reddit.com "[domain] [user type] what tool do you use"`
+
+### 2.3 Generate VPC personas
+
+For each user type, generate a full Value Proposition Canvas persona file following the template at `.specrails/setup-templates/personas/persona.md`.
+
+Each persona must include:
+- **Profile**: Demographics, behaviors, tools used, spending patterns
+- **Customer Jobs**: Functional, social, emotional (6-8 jobs)
+- **Pains**: Graded by severity (Critical > High > Medium > Low) with 6-8 entries
+- **Gains**: Graded by impact (High > Medium > Low) with 6-8 entries
+- **Key Insight**: The #1 unmet need that this project can address
+- **Sources**: Links to competitive analysis, forums, reviews used in research
+
+### 2.4 Present personas
+
+Display each generated persona to the user:
+
+```
+## Generated Personas
+
+### Persona 1: "[Nickname]" — The [Role]
+- Age: X-Y
+- Key pain: [Critical pain]
+- Key insight: [Main unmet need]
+
+### Persona 2: "[Nickname]" — The [Role]
+- Age: X-Y
+- Key pain: [Critical pain]
+- Key insight: [Main unmet need]
+
+[Accept] [Edit] [Regenerate]
+```
+
+Wait for confirmation. If the user wants edits, apply them.
+
+### 2.5 Initialize agent config
+
+Check for `.specrails/agents.yaml`:
+
+1. If the file **exists**:
+   - Read it
+   - Validate all `model:` values — only `opus`, `sonnet`, and `haiku` are valid
+   - If any value is invalid, warn the user and fall back to the template default for that agent
+   - Store as `AGENTS_CONFIG` for use in Phase 4
+
+2. If the file **does not exist**:
+   - Generate it with the default model assignments matching the template hard-coded values:
+
+   ```yaml
+   # specrails agent configuration
+   # Modify model assignments and other agent settings
+   # Valid models: opus, sonnet, haiku
+
+   defaults:
+     model: sonnet
+
+   agents:
+     sr-architect:
+       model: sonnet
+     sr-developer:
+       model: sonnet
+     sr-reviewer:
+       model: sonnet
+     sr-product-manager:
+       model: opus
+     sr-product-analyst:
+       model: haiku
+     sr-test-writer:
+       model: sonnet
+     sr-security-reviewer:
+       model: sonnet
+     sr-backend-developer:
+       model: sonnet
+     sr-frontend-developer:
+       model: sonnet
+     sr-backend-reviewer:
+       model: sonnet
+     sr-frontend-reviewer:
+       model: sonnet
+     sr-doc-sync:
+       model: sonnet
+     sr-merge-resolver:
+       model: sonnet
+     sr-performance-reviewer:
+       model: sonnet
+   ```
+
+   - Write this file to `.specrails/agents.yaml`
+   - Store as `AGENTS_CONFIG` for use in Phase 4
+   - Log: "Generated `.specrails/agents.yaml` with default model assignments"
+
+---
+
+## Phase 3: Configuration
+
+### 3.1 Agents to install
+
+Present the available agents and let the user choose:
+
+```
+## Agent Selection
+
+Which agents do you want to install?
+
+| Agent | Purpose | Model | Required |
+|-------|---------|-------|----------|
+| sr-architect | Design features, create implementation plans | Sonnet | Yes |
+| sr-developer (full-stack) | Implement features across all layers | Sonnet | Yes |
+| sr-reviewer | CI/CD quality gate, fix issues | Sonnet | Yes |
+| sr-test-writer | Generate unit, integration, and edge-case tests after implementation | Sonnet | Yes |
+| sr-security-reviewer | Scan for secrets, OWASP vulnerabilities, hardcoded credentials | Sonnet | Yes |
+| sr-product-manager | Product discovery, ideation, VPC evaluation | Opus | Recommended |
+| sr-product-analyst | Read-only backlog analysis | Haiku | Recommended |
+| sr-backend-developer | Specialized backend implementation | Sonnet | If backend layer exists |
+| sr-frontend-developer | Specialized frontend implementation | Sonnet | If frontend layer exists |
+
+[All] [Required only] [Custom selection]
+```
+
+### 3.2 Backlog provider
+
+Ask the user how they want to manage their product backlog. Default is local — no external tools or accounts required:
+
+```
+## Backlog Provider
+
+Use local ticket management or connect an external provider?
+
+1. **Local tickets** (default, recommended) — lightweight JSON-based ticket management built into the project.
+   No external tools or accounts required. Tickets stored in `.specrails/local-tickets.json`, version-controlled and diffable.
+2. **External provider** — connect GitHub Issues, JIRA, or disable backlog commands
+```
+
+If the user selects **1** or presses Enter without typing anything: set `BACKLOG_PROVIDER=local` and proceed directly to **If Local Tickets** below. Do NOT ask about GitHub CLI, JIRA credentials, or any external provider configuration.
+
+If the user selects **2**: display the secondary menu:
+
+```
+## External Backlog Provider
+
+Which external provider?
+
+1. **Local tickets** (recommended) — lightweight JSON-based ticket management built into the project.
+   No external tools required. Tickets stored in `.specrails/local-tickets.json`, version-controlled and diffable.
+2. **GitHub Issues** — uses `gh` CLI to read/create issues with labels and VPC scores
+3. **JIRA** — uses JIRA CLI or REST API to read/create tickets in a JIRA project
+4. **None** — skip backlog commands (you can still use /implement with text descriptions)
+```
+
+Wait for the user's choice. Set `BACKLOG_PROVIDER` to `local`, `github`, `jira`, or `none`.
+
+#### If Local Tickets
+
+No external tools or credentials required. Initialize the storage file:
+
+1. Copy `templates/local-tickets-schema.json` to `.specrails/local-tickets.json`
+2. Set `last_updated` to the current ISO-8601 timestamp
+
+Store configuration in `.specrails/backlog-config.json`:
+```json
+{
+  "provider": "local",
+  "write_access": true,
+  "git_auto": true
+}
+```
+
+Local tickets are always read-write — there is no "read only" mode since the file is local.
+
+**Ticket schema** — each entry in the `tickets` map has these fields:
+
+```json
+{
+  "id": 1,
+  "title": "Feature title",
+  "description": "Markdown description",
+  "status": "todo",
+  "priority": "medium",
+  "labels": ["area:frontend", "effort:medium"],
+  "assignee": null,
+  "prerequisites": [],
+  "metadata": {
+    "vpc_scores": {},
+    "effort_level": "Medium",
+    "user_story": "",
+    "area": ""
+  },
+  "comments": [],
+  "created_at": "<ISO-8601>",
+  "updated_at": "<ISO-8601>",
+  "created_by": "user",
+  "source": "manual"
+}
+```
+
+**Status values:** `todo`, `in_progress`, `done`, `cancelled`
+**Priority values:** `critical`, `high`, `medium`, `low`
+**Labels:** Freeform strings following the `area:*` and `effort:*` convention
+**Source values:** `manual`, `get-backlog-specs`, `propose-spec`
+
+**Advisory file locking protocol** (CLI agents and hub server must both follow this):
+
+The `revision` counter in the JSON root enables optimistic concurrency — increment it on **every** write. The lock file prevents concurrent corruption:
+
+1. **Acquire lock:** Check for `.specrails/local-tickets.json.lock`
+   - If the file exists and its `timestamp` is less than 30 seconds old: wait 500ms and retry (max 5 attempts before aborting with an error)
+   - If the file exists and its `timestamp` is 30+ seconds old (stale): delete it and proceed
+   - If no lock file exists: proceed immediately
+2. **Create lock file:** Write `{"agent": "<agent-name-or-process>", "timestamp": "<ISO-8601>"}` to `.specrails/local-tickets.json.lock`
+3. **Minimal lock window:** Read the JSON → modify in memory → write back → release
+4. **Release lock:** Delete `.specrails/local-tickets.json.lock`
+5. **Always increment `revision`** by 1 and update `last_updated` on every successful write
+
+The hub server uses `proper-lockfile` (or equivalent) to honor the same protocol via the `.lock` file path.
+
+#### If GitHub Issues
+
+- Verify `gh auth status` works. If not, warn and offer to skip.
+- Ask about **access mode**:
+
+```
+## GitHub Issues — Access Mode
+
+How should we interact with GitHub Issues?
+
+1. **Read & Write** (default) — read backlog, create new issues from product discovery,
+   close resolved issues, add comments on partial progress
+2. **Read only** — read backlog for prioritization, but don't create or modify issues.
+   Product discovery will propose ideas as output but won't sync them to GitHub.
+```
+
+Set `BACKLOG_WRITE=true/false`.
+
+- If write mode, ask if they want to create labels:
+  - `product-driven-backlog` (purple) — product feature ideas
+  - `area:*` labels for each detected layer/area
+  - `enhancement`, `bug`, `tech-debt`
+
+#### If JIRA
+
+First, check if JIRA CLI is installed:
+
+```bash
+command -v jira &> /dev/null
+```
+
+If not installed, offer to install it:
+
+> JIRA CLI is not installed. There are several options:
+>
+> 1. **go-jira** (recommended) — lightweight CLI
+>    - macOS: `brew install go-jira`
+>    - Linux/other: `go install github.com/go-jira/jira/cmd/jira@latest`
+> 2. **Atlassian CLI** — official but heavier
+>    - `npm install -g @atlassian/cli`
+> 3. **Skip CLI, use REST API** — no CLI needed, uses `curl` with API token
+>
+> Which option? (1/2/3)
+
+If the user chooses option 1 or 2, run the install command. If option 3, proceed with REST API mode.
+
+Then ask for JIRA configuration:
+
+> To connect to JIRA, I need:
+>
+> 1. **JIRA base URL** (e.g., `https://your-company.atlassian.net`)
+> 2. **Project key** (e.g., `PROJ`, `DECK`, `MYAPP`)
+> 3. **Authentication method**:
+>    - **JIRA CLI** (`jira` command) — if already configured
+>    - **API token** — stored in `.env` as `JIRA_API_TOKEN` and `JIRA_USER_EMAIL`
+>
+> Optional:
+> - **Custom issue type** for backlog items (default: "Story")
+> - **Custom fields** for VPC scores (or use labels/description)
+
+Then ask about **access mode**:
+
+```
+## JIRA — Access Mode
+
+How should we interact with JIRA?
+
+1. **Read & Write** — read tickets for implementation context, create new tickets
+   from product discovery, add a comment to tickets when implementation is complete
+2. **Read only** — read tickets for implementation context, but never create or
+   modify tickets. Product discovery will propose ideas as output only. After
+   implementation, the pipeline will show what to update manually but won't
+   touch JIRA.
+```
+
+Set `BACKLOG_WRITE=true/false`.
+
+<!-- This command is mirrored from commands/enrich.md for staged installs. -->
+
+#### Project Label
+
+After the access mode selection, ask:
+
+> **Project Label (optional but recommended)**
+>
+> JIRA teams often tag all tickets for a product with a project label
+> (e.g., `PROJECT-specrails`, `PLATFORM`, `MOBILE`). This label is applied
+> to every ticket the backlog pipeline creates — making it easy to filter all
+> AI-generated backlog items across JIRA.
+>
+> Enter a project label, or press Enter to skip:
+
+If the user enters a label: set `PROJECT_LABEL=<value>`.
+If the user skips: set `PROJECT_LABEL=""`.
+
+#### Epic Link Field
+
+Ask:
+
+> **Epic Link Field (optional — advanced)**
+>
+> JIRA Next-Gen (team-managed) projects link stories to epics using the `parent`
+> field. JIRA Classic (company-managed) projects use `Epic Link` (customfield_10014).
+>
+> Which does your project use?
+> 1. `parent` — Next-Gen / team-managed **(default)**
+> 2. `customfield_10014` — Classic / company-managed
+
+Set `EPIC_LINK_FIELD` to `parent` or `customfield_10014`. Default: `parent`.
+
+Store the full configuration in `.specrails/backlog-config.json`:
+```json
+{
+  "provider": "jira",
+  "write_access": true,
+  "jira_base_url": "https://your-company.atlassian.net",
+  "jira_project_key": "PROJ",
+  "issue_type": "Story",
+  "auth_method": "api_token",
+  "cli_installed": true,
+  "project_label": "<PROJECT_LABEL or empty string>",
+  "epic_link_field": "parent",
+  "epic_mapping": {}
+}
+```
+
+#### If None
+
+- Skip `/specrails:get-backlog-specs` and `/specrails:auto-propose-backlog-specs` commands.
+- The `/specrails:implement` command will still work with text descriptions.
+
+### 3.3 Git & shipping workflow
+
+Ask how the user wants to handle git operations after implementation:
+
+```
+## Git & Shipping
+
+After implementation is complete, how should we handle shipping?
+
+1. **Automatic** (default) — create branch, commit changes, push, and open a PR
+   (requires GitHub CLI for PRs, otherwise prints a compare URL)
+2. **Manual** — stop after implementation and review. You handle branching,
+   committing, and PR creation yourself. The pipeline will show a summary
+   of all changes but won't touch git.
+```
+
+Set `GIT_AUTO=true/false`.
+
+If automatic, also check if `gh` is authenticated (for PR creation). If not, warn that PRs will be skipped but commits and push will still work.
+
+### 3.4 Commands to install
+
+```
+## Command Selection
+
+| Command | Purpose | Requires |
+|---------|---------|----------|
+| /specrails:implement | Full pipeline: sr-architect → sr-developer → sr-reviewer → ship | sr-architect + sr-developer + sr-reviewer |
+| /specrails:batch-implement | Orchestrate multiple features in dependency-aware waves | sr-architect + sr-developer + sr-reviewer |
+| /specrails:propose-spec | Interactively propose and refine a feature spec, then create a GitHub issue | GitHub CLI |
+| /specrails:get-backlog-specs | View prioritized backlog with VPC scores | sr-product-analyst + Backlog provider |
+| /specrails:auto-propose-backlog-specs | Generate new feature ideas via product discovery | sr-product-manager + Backlog provider |
+| /specrails:compat-check | Snapshot API surface and detect breaking changes | None |
+| /specrails:refactor-recommender | Scan for refactoring opportunities ranked by impact/effort | None |
+| /specrails:why | Search past architectural decisions from agent memory | None |
+
+[All] [Custom selection]
+```
+
+Note: If `BACKLOG_PROVIDER=none`, the backlog commands are not offered.
+
+### 3.5 Confirm configuration
+
+Display the full configuration summary including access modes:
+
+```
+## Configuration Summary
+
+| Setting | Value |
+|---------|-------|
+| Backlog provider | GitHub Issues / JIRA / None |
+| Backlog access | Read & Write / Read only |
+| Project label (JIRA) | PROJECT-specrails / (none) |
+| Epic link field (JIRA) | parent / customfield_10014 |
+| Git workflow | Automatic / Manual |
+| Agents | [list] |
+| Commands | [list] |
+| Personas | [count] personas |
+
+Note: The `Project label (JIRA)` and `Epic link field (JIRA)` rows are only shown when `BACKLOG_PROVIDER=jira`.
+
+[Confirm] [Modify]
+```
+
+Wait for final confirmation.
+
+---
+
+## Phase 4: Generate Files
+
+Read each template from `.specrails/setup-templates/` and generate the final files adapted to this project. Use the codebase analysis from Phase 1, personas from Phase 2, and configuration from Phase 3.
+
+**Provider detection (required before any file generation):** Determine `cli_provider` from the existing install layout: use `"codex"` when `.codex/` exists, otherwise `"claude"`. Set `specrails_dir` to `.codex` or `.claude` accordingly. All output paths in Phase 4 use `$SPECRAILS_DIR` as the base directory.
+
+### 4.1 Generate agents
+
+For each selected agent, read the template and generate the adapted version.
+
+**Template → Output mapping:**
+
+**If `cli_provider == "claude"` (default):**
+- `.specrails/setup-templates/agents/sr-architect.md` → `.claude/agents/sr-architect.md`
+- `.specrails/setup-templates/agents/sr-developer.md` → `.claude/agents/sr-developer.md`
+- `.specrails/setup-templates/agents/sr-reviewer.md` → `.claude/agents/sr-reviewer.md`
+- `.specrails/setup-templates/agents/sr-test-writer.md` → `.claude/agents/sr-test-writer.md`
+- `.specrails/setup-templates/agents/sr-security-reviewer.md` → `.claude/agents/sr-security-reviewer.md`
+- `.specrails/setup-templates/agents/sr-product-manager.md` → `.claude/agents/sr-product-manager.md`
+- `.specrails/setup-templates/agents/sr-product-analyst.md` → `.claude/agents/sr-product-analyst.md`
+- `.specrails/setup-templates/agents/sr-backend-developer.md` → `.claude/agents/sr-backend-developer.md` (if backend layer)
+- `.specrails/setup-templates/agents/sr-frontend-developer.md` → `.claude/agents/sr-frontend-developer.md` (if frontend layer)
+
+**If `cli_provider == "codex"`:**
+- `.specrails/setup-templates/agents/sr-architect.md` → `.codex/agents/sr-architect.toml`
+- `.specrails/setup-templates/agents/sr-developer.md` → `.codex/agents/sr-developer.toml`
+- `.specrails/setup-templates/agents/sr-reviewer.md` → `.codex/agents/sr-reviewer.toml`
+- `.specrails/setup-templates/agents/sr-test-writer.md` → `.codex/agents/sr-test-writer.toml`
+- `.specrails/setup-templates/agents/sr-security-reviewer.md` → `.codex/agents/sr-security-reviewer.toml`
+- `.specrails/setup-templates/agents/sr-product-manager.md` → `.codex/agents/sr-product-manager.toml`
+- `.specrails/setup-templates/agents/sr-product-analyst.md` → `.codex/agents/sr-product-analyst.toml`
+- `.specrails/setup-templates/agents/sr-backend-developer.md` → `.codex/agents/sr-backend-developer.toml` (if backend layer)
+- `.specrails/setup-templates/agents/sr-frontend-developer.md` → `.codex/agents/sr-frontend-developer.toml` (if frontend layer)
+
+When generating each agent:
+1. Read the template
+2. Replace all `` values with project-specific content:
+   - `specrails-core` → project name
+   - `` → detected architecture
+   - `` → detected layer tags (e.g., `[backend]`, `[frontend]`, `[api]`, `[mobile]`)
+   - `` → backend CI commands from Phase 1
+   - `` → frontend CI commands from Phase 1
+   - `` → detected conventions per layer
+   - `` → names from generated personas
+   - `` → paths to persona files
+   - `` → domain knowledge from Phase 2 research
+   - `` → competitors discovered in Phase 2
+   - `` → important file paths detected in Phase 1
+   - `` → project-specific warnings (from existing CLAUDE.md or detected)
+   - `.claude/agent-memory/` → agent memory directory path (e.g., `$SPECRAILS_DIR/agent-memory/sr-<agent-name>/`)
+   - `` → detected languages, frameworks, and test frameworks from Phase 1
+   - `` → comma-separated paths to per-layer rules files (e.g., `$SPECRAILS_DIR/rules/backend.md`, `$SPECRAILS_DIR/rules/frontend.md`)
+   - `.claude/security-exemptions.yaml` → `$SPECRAILS_DIR/security-exemptions.yaml`
+3. Resolve the agent's model using `AGENTS_CONFIG` (loaded in Phase 2.5):
+   - Check `AGENTS_CONFIG.agents.<agent-name>.model` (per-agent override)
+   - If not present, check `AGENTS_CONFIG.defaults.model` (global default)
+   - If `AGENTS_CONFIG` was not loaded (e.g., re-run without config), use the model from the template frontmatter (current behavior)
+   - Replace the `model:` field in the YAML frontmatter with the resolved value before writing
+4. Write the final file in the format for the active provider:
+
+**If `cli_provider == "claude"`:** Write as Markdown with YAML frontmatter — the template file as-is (frontmatter preserved).
+
+**If `cli_provider == "codex"`:** Convert to TOML format:
+- Extract YAML frontmatter fields: `name`, `description`, `model`
+- Extract the body content (everything after the closing `---` of the frontmatter)
+- Map the `model` field: `sonnet` → `codex-mini-latest`, `opus` → `o3`, `haiku` → `codex-mini-latest`
+- Write a `.toml` file with this structure:
+  ```toml
+  name = "<name from frontmatter>"
+  description = "<description from frontmatter, escaped for TOML>"
+  model = "codex-mini-latest"
+  prompt = """
+  <body content after placeholder substitution>
+  """
+  ```
+
+### 4.2 Generate personas
+
+If IS_OSS=true:
+1. Copy `.specrails/setup-templates/personas/the-maintainer.md` to `$SPECRAILS_DIR/agents/personas/the-maintainer.md`
+2. Log: "Maintainer persona included"
+3. Set MAINTAINER_INCLUDED=true for use in template substitution
+4. Set `` = `- \`$SPECRAILS_DIR/agents/personas/the-maintainer.md\` — "Kai" the Maintainer (open-source maintainer)`
+5. Increment `` by 1 to account for the Maintainer
+
+If IS_OSS=false:
+- Set `` = *(empty string)*
+
+Then for each user-defined VPC persona from Phase 2.3:
+
+Write each persona to `$SPECRAILS_DIR/agents/personas/`:
+- Use the VPC personas generated in Phase 2
+- File naming: kebab-case of persona nickname (e.g., `the-developer.md`, `the-admin.md`)
+
+### 4.3 Generate commands / skills
+
+For each selected command, read the template and adapt.
+
+**If `cli_provider == "claude"` (default):**
+- `.specrails/setup-templates/commands/specrails/implement.md` → `.claude/commands/specrails/implement.md`
+- `.specrails/setup-templates/commands/specrails/batch-implement.md` → `.claude/commands/specrails/batch-implement.md`
+- `.specrails/setup-templates/commands/specrails/propose-spec.md` → `.claude/commands/specrails/propose-spec.md`
+- `.specrails/setup-templates/commands/specrails/get-backlog-specs.md` → `.claude/commands/specrails/get-backlog-specs.md` (if `BACKLOG_PROVIDER != none`)
+- `.specrails/setup-templates/commands/specrails/auto-propose-backlog-specs.md` → `.claude/commands/specrails/auto-propose-backlog-specs.md` (if `BACKLOG_PROVIDER != none`)
+- `.specrails/setup-templates/commands/specrails/compat-check.md` → `.claude/commands/specrails/compat-check.md`
+- `.specrails/setup-templates/commands/specrails/refactor-recommender.md` → `.claude/commands/specrails/refactor-recommender.md`
+- `.specrails/setup-templates/commands/specrails/why.md` → `.claude/commands/specrails/why.md`
+- `.specrails/setup-templates/commands/specrails/reconfig.md` → `.claude/commands/specrails/reconfig.md`
+
+**If `cli_provider == "codex"`:**
+- `.specrails/setup-templates/skills/sr-implement/SKILL.md` → `.agents/skills/sr-implement/SKILL.md`
+- `.specrails/setup-templates/skills/sr-batch-implement/SKILL.md` → `.agents/skills/sr-batch-implement/SKILL.md`
+- `.specrails/setup-templates/commands/specrails/propose-spec.md` → `.agents/skills/sr-propose-spec/SKILL.md` (wrap with YAML frontmatter if no skill template exists)
+- `.specrails/setup-templates/commands/specrails/get-backlog-specs.md` → `.agents/skills/sr-get-backlog-specs/SKILL.md` (if `BACKLOG_PROVIDER != none`; wrap with frontmatter)
+- `.specrails/setup-templates/commands/specrails/auto-propose-backlog-specs.md` → `.agents/skills/sr-auto-propose-backlog-specs/SKILL.md` (if `BACKLOG_PROVIDER != none`; wrap with frontmatter)
+- `.specrails/setup-templates/skills/sr-compat-check/SKILL.md` → `.agents/skills/sr-compat-check/SKILL.md`
+- `.specrails/setup-templates/skills/sr-refactor-recommender/SKILL.md` → `.agents/skills/sr-refactor-recommender/SKILL.md`
+- `.specrails/setup-templates/skills/sr-why/SKILL.md` → `.agents/skills/sr-why/SKILL.md`
+- `.specrails/setup-templates/commands/specrails/reconfig.md` → `.agents/skills/sr-reconfig/SKILL.md` (wrap with YAML frontmatter)
+
+**Codex skill frontmatter wrapping:** When a dedicated skill template does not exist in `.specrails/setup-templates/skills/` for a command, generate the `SKILL.md` by prepending YAML frontmatter to the command content:
+```yaml
+---
+name: sr-<name>
+description: "<one-line description from the command's first heading>"
+license: MIT
+compatibility: "Requires git."
+metadata:
+  author: specrails
+  version: "1.0"
+---
+```
+
+For both providers, create the output directory before writing (`mkdir -p` for `.claude/commands/specrails/` or `.agents/skills/sr-<name>/`).
+
+Adapt:
+- CI commands to match detected stack
+- **Persona references** to match generated personas (see substitution rules below)
+- File paths to match project structure
+- Layer tags to match detected layers
+- **Backlog provider commands** based on `BACKLOG_PROVIDER`:
+
+#### Backlog command persona placeholder substitution
+
+When adapting `auto-propose-backlog-specs.md` and `get-backlog-specs.md`, substitute the persona placeholders based on the full persona set (user-generated personas + Maintainer if `IS_OSS=true`):
+
+| Placeholder | Substitution rule |
+|-------------|------------------|
+| `` | One bullet per persona file: `- Read \`$SPECRAILS_DIR/agents/personas/{name}.md\`` |
+| `` | Column headers for each persona nickname: e.g., `Alex \| Sara \| Kai` |
+| `` | One `------` separator per persona column |
+| `` | Inline score display: e.g., `Alex: X/5, Sara: X/5, Kai: X/5` |
+| `` | One VPC section block per persona (see format below) |
+| `` | Total max score = 5 × number of personas (e.g., `15` for 3 personas) |
+| `` | Comma-separated: e.g., `Alex (Lead Dev), Sara (Product Founder), Kai (OSS Maintainer)` |
+
+**`` format** — repeat for each persona in order:
+```
+### "{Nickname}" — The {Role} (X/5)
+- **Jobs addressed**: {list}
+- **Pains relieved**: {list with severity}
+- **Gains created**: {list with impact}
+```
+
+**Kai inclusion rule**: When `IS_OSS=true`, Kai (`sr-the-maintainer.md`) is always the last entry in persona lists and the rightmost column in scoring tables. Kai uses the evaluation criteria defined in `.claude/agents/personas/sr-the-maintainer.md` — features score high (4-5/5) for Kai when they reduce async review burden, enforce project-specific conventions, or automate release/dependency coordination; features score low (0-1/5) when they add configuration complexity or require paid tiers.
+
+**When `IS_OSS=false`**: All Kai-related persona references are omitted. `` reduces by 5. Tables and inline scores contain only user-generated personas.
+
+#### Local Tickets (`BACKLOG_PROVIDER=local`)
+
+For the local provider, backlog placeholders resolve to **inline file-operation instructions** embedded in the generated command markdown — not shell commands. Agents execute these by reading/writing `.specrails/local-tickets.json` directly using their file tools.
+
+All write operations must follow the **advisory file locking protocol** defined in Phase 3.2. Always increment `revision` and update `last_updated` on every write.
+
+| Placeholder | Substituted value |
+|-------------|-------------------|
+| `` | `Local Tickets` |
+| `` | `[[ -f ".specrails/local-tickets.json" ]] && echo "Local tickets storage: OK" \|\| echo "WARNING: .specrails/local-tickets.json not found — run /specrails:enrich to initialize"` |
+| `` | Read `.specrails/local-tickets.json`. Parse the `tickets` map and return all entries where `status` is `"todo"` or `"in_progress"`. |
+| `` | Read `.specrails/local-tickets.json`. Parse the `tickets` map and return all entries regardless of status. |
+| `` | Read `.specrails/local-tickets.json`. Parse the `tickets` map and return all entries where `status` is `"done"` or `"cancelled"`. |
+| `` | Read `.specrails/local-tickets.json`. Parse JSON and return the full ticket object at `tickets["{id}"]`, or an error if not found. |
+| `` | Write to `.specrails/local-tickets.json` using the advisory locking protocol: acquire lock → read file → set `id = next_id`, increment `next_id`, set all ticket fields, set `created_at` and `updated_at` to now, bump `revision`, update `last_updated` → write → release lock. |
+| `` | Write to `.specrails/local-tickets.json` using the advisory locking protocol: acquire lock → read file → update fields in `tickets["{id}"]`, set `updated_at` to now, bump `revision`, update `last_updated` → write → release lock. |
+| `` | Write to `.specrails/local-tickets.json` using the advisory locking protocol: acquire lock → read file → delete `tickets["{id}"]`, bump `revision`, update `last_updated` → write → release lock. |
+| `` | Write to `.specrails/local-tickets.json` using the advisory locking protocol: acquire lock → read file → append `{"author": "<agent-name>", "body": "<comment>", "created_at": "<ISO-8601>"}` to `tickets["{id}"].comments` (create the array if absent), set `updated_at` to now, bump `revision`, update `last_updated` → write → release lock. |
+| `` | Same as `` but append `{"author": "<agent-name>", "body": "<comment>", "type": "progress", "created_at": "<ISO-8601>"}`. |
+| `` | No label initialization required. Local tickets use freeform label strings. Standard label conventions: `area:frontend`, `area:backend`, `area:api`, `effort:low`, `effort:medium`, `effort:high`. |
+
+#### GitHub Issues (`BACKLOG_PROVIDER=github`)
+- Issue fetch: `gh issue list --label "product-driven-backlog" --state open --limit 100 --json number,title,labels,body`
+- Issue create: `gh issue create --title "..." --label "..." --body "..."`
+- Issue view: `gh issue view {number} --json number,title,labels,body`
+- Issue label names to match project areas
+- Pre-flight check: `gh auth status`
+
+#### JIRA (`BACKLOG_PROVIDER=jira`)
+- Issue fetch: `jira issue list --project  --type Story --label get-backlog-specs --status "To Do" --plain` or equivalent JIRA REST API call via curl:
+  ```bash
+  curl -s -u "$JIRA_USER_EMAIL:$JIRA_API_TOKEN" \
+    "/rest/api/3/search?jql=project= AND labels=get-backlog-specs AND status='To Do'&fields=summary,description,labels,priority"
+  ```
+- Issue create: `jira issue create --project  --type Story --summary "..." --label get-backlog-specs --description "..."` or equivalent REST API call
+- Issue view: `jira issue view {key}` or REST API
+- VPC scores stored in the issue description body (same markdown format, parsed from description)
+- Pre-flight check: `jira me` or test API connectivity
+- Store JIRA config in `.specrails/backlog-config.json`:
+  ```json
+  {
+    "provider": "jira",
+    "jira_base_url": "https://your-company.atlassian.net",
+    "jira_project_key": "PROJ",
+    "issue_type": "Story",
+    "auth_method": "api_token"
+  }
+  ```
+
+The command templates use ``, ``, ``, ``, and related placeholders that get filled with the provider-specific commands (for `local`) or instructions (for `github`, `jira`). The `` placeholder is substituted with a human-readable provider label in all three cases.
+
+### 4.4 Generate rules
+
+For each detected layer, read the layer rule template and generate a layer-specific rules file:
+- `.specrails/setup-templates/rules/layer.md` → `$SPECRAILS_DIR/rules/{layer-name}.md`
+
+Each rule file must:
+- Have the correct `paths:` frontmatter matching the layer's directory
+- Contain conventions specific to that layer (from Phase 1 analysis)
+- Reference actual file paths and patterns from the codebase
+
+### 4.5 Generate root instructions file
+
+**If `cli_provider == "claude"`:** If no `CLAUDE.md` exists, generate one from the template. If one already exists, **merge** — add the agent workflow sections without removing existing content.
+
+**If `cli_provider == "codex"`:** If no `AGENTS.md` exists, generate one from the template. If one already exists, **merge** — add the agent workflow sections without removing existing content.
+
+### 4.6 Generate settings
+
+Resolve `cli_provider` from the existing install layout (`.codex/` => `codex`, otherwise `claude`).
+
+**If `cli_provider == "claude"` (default):**
+
+Create or merge `.claude/settings.json` with permissions for:
+- All detected CI commands
+- Git operations
+- OpenSpec CLI (if installed)
+- GitHub CLI (if available)
+- Language-specific tools (python, npm, cargo, go, etc.)
+
+**If `cli_provider == "codex"`:**
+
+1. Read `.specrails/setup-templates/settings/codex-config.toml`. Write it to `.codex/config.toml` as-is (no substitutions needed — the TOML is static).
+
+2. Read `.specrails/setup-templates/settings/codex-rules.star`. Replace `` with Starlark `prefix_rule(...)` lines for each detected tool allowance:
+
+   | Detected tool/command | Starlark rule |
+   |----------------------|---------------|
+   | OpenSpec CLI (`openspec`) | `prefix_rule(pattern=["openspec"], decision="allow")` |
+   | Python (`python`, `pip`) | `prefix_rule(pattern=["python"], decision="allow")`<br>`prefix_rule(pattern=["pip"], decision="allow")` |
+   | npm (`npm`) | `prefix_rule(pattern=["npm"], decision="allow")` |
+   | Cargo (`cargo`) | `prefix_rule(pattern=["cargo"], decision="allow")` |
+   | Go (`go`) | `prefix_rule(pattern=["go"], decision="allow")` |
+   | Any detected CI command | `prefix_rule(pattern=["<cmd>"], decision="allow")` |
+
+   Write the rendered file to `.codex/rules/default.rules`.
+
+   ```bash
+   mkdir -p .codex/rules
+   ```
+
+   If `cli_provider` cannot be determined (file missing), fall back to `"claude"` behavior.
+
+### 4.7 Initialize agent memory
+
+Create memory directories for each installed agent using the provider-aware base directory:
+
+```bash
+mkdir -p $SPECRAILS_DIR/agent-memory/sr-{agent-name}/
+```
+
+Each gets an empty `MEMORY.md` that will be populated during usage.
+
+---
+
+## Phase 5: Cleanup & Summary
+
+### 5.1 Remove all scaffolding artifacts
+
+The setup process installed temporary files that are only needed during installation. Remove them all now that the final files have been generated.
+
+```bash
+# 1. Remove setup templates (used as structural references during generation)
+rm -rf .specrails/setup-templates/
+
+# 2. Remove the /specrails:enrich command itself — it's a one-time installer, not a permanent command
+rm -f .claude/commands/enrich.md
+
+# 3. Remove the specrails/ directory from the repo if it exists at the root
+#    (it was only needed for the retired shell installer and staging templates — everything is now in .claude/)
+#    NOTE: Only remove if it's inside this repo. Ask the user if unsure.
+```
+
+**What gets removed:**
+| Artifact | Why |
+|----------|-----|
+| `.specrails/setup-templates/` | Temporary — templates already rendered into final files |
+| `.claude/commands/enrich.md` | One-time installer — running it again would overwrite customized agents |
+
+**What to do with `specrails/`:**
+
+The `specrails/` directory should NOT be committed to the target repo — it's an installer tool, not part of the project. Always add it to `.gitignore`:
+
+```bash
+# Add specrails/ to .gitignore if not already there
+if ! grep -q '^specrails/' .gitignore 2>/dev/null; then
+  echo '' >> .gitignore
+  echo '# specrails installer (one-time setup tool, not part of the project)' >> .gitignore
+  echo 'specrails/' >> .gitignore
+fi
+```
+
+Then ask the user:
+
+> `specrails/` has been added to `.gitignore`. Do you also want to delete it?
+>
+> 1. **Keep it** (default) — stays locally in case you want to re-run setup or install in other repos
+> 2. **Delete it** — everything is installed, you don't need it anymore
+
+Apply the user's choice.
+
+### 5.2 Verify clean state
+
+After cleanup, verify that only the intended files remain:
+
+```bash
+# These should exist (the actual system) — use the resolved $SPECRAILS_DIR:
+# If cli_provider == "claude":
+ls .claude/agents/sr-*.md
+ls .claude/agents/personas/*.md
+ls .claude/commands/specrails/*.md
+ls .claude/rules/*.md
+ls .claude/agent-memory/
+
+# If cli_provider == "codex":
+ls .codex/agents/sr-*.toml
+ls .codex/agents/personas/*.md
+ls .agents/skills/sr-*/SKILL.md
+ls .codex/rules/*.md
+ls .codex/agent-memory/
+
+# These should NOT exist (scaffolding):
+# .specrails/setup-templates/  — GONE
+# If cli_provider == "claude": $SPECRAILS_DIR/commands/enrich.md  — GONE
+# If cli_provider == "codex": .agents/skills/setup/  — GONE (installer scaffold, not a generated sr-skill)
+```
+
+If any scaffolding artifact remains, remove it.
+
+### 5.3 Summary
+
+Display the complete installation summary:
+
+```
+## Setup Complete
+
+### Agents Installed
+| Agent | File | Model |
+|-------|------|-------|
+[If cli_provider == "claude":]
+| sr-architect | .claude/agents/sr-architect.md | Sonnet |
+| sr-developer | .claude/agents/sr-developer.md | Sonnet |
+| sr-reviewer | .claude/agents/sr-reviewer.md | Sonnet |
+| sr-test-writer | .claude/agents/sr-test-writer.md | Sonnet |
+| sr-security-reviewer | .claude/agents/sr-security-reviewer.md | Sonnet |
+| sr-product-manager | .claude/agents/sr-product-manager.md | Opus |
+[If cli_provider == "codex":]
+| sr-architect | .codex/agents/sr-architect.toml | codex-mini-latest |
+| sr-developer | .codex/agents/sr-developer.toml | codex-mini-latest |
+| sr-reviewer | .codex/agents/sr-reviewer.toml | codex-mini-latest |
+| sr-test-writer | .codex/agents/sr-test-writer.toml | codex-mini-latest |
+| sr-security-reviewer | .codex/agents/sr-security-reviewer.toml | codex-mini-latest |
+| sr-product-manager | .codex/agents/sr-product-manager.toml | o3 |
+
+### Personas Created
+| Persona | File | Source |
+|---------|------|--------|
+[If IS_OSS=true:]
+| "Kai" — The Maintainer | $SPECRAILS_DIR/agents/personas/sr-the-maintainer.md | Auto-included (OSS) |
+[For each user-generated persona:]
+| "[Name]" — The [Role] | $SPECRAILS_DIR/agents/personas/[name].md | Generated |
+
+### Commands / Skills Installed
+[If cli_provider == "claude":]
+| Command | File |
+|---------|------|
+| /specrails:implement | .claude/commands/specrails/implement.md |
+| /specrails:batch-implement | .claude/commands/specrails/batch-implement.md |
+| /specrails:propose-spec | .claude/commands/specrails/propose-spec.md |
+| /specrails:get-backlog-specs | .claude/commands/specrails/get-backlog-specs.md |
+| /specrails:auto-propose-backlog-specs | .claude/commands/specrails/auto-propose-backlog-specs.md |
+| /specrails:compat-check | .claude/commands/specrails/compat-check.md |
+| /specrails:refactor-recommender | .claude/commands/specrails/refactor-recommender.md |
+| /specrails:why | .claude/commands/specrails/why.md |
+[If cli_provider == "codex":]
+| Skill | File |
+|-------|------|
+| $sr-implement | .agents/skills/sr-implement/SKILL.md |
+| $sr-batch-implement | .agents/skills/sr-batch-implement/SKILL.md |
+| $sr-propose-spec | .agents/skills/sr-propose-spec/SKILL.md |
+| $sr-get-backlog-specs | .agents/skills/sr-get-backlog-specs/SKILL.md |
+| $sr-auto-propose-backlog-specs | .agents/skills/sr-auto-propose-backlog-specs/SKILL.md |
+| $sr-compat-check | .agents/skills/sr-compat-check/SKILL.md |
+| $sr-refactor-recommender | .agents/skills/sr-refactor-recommender/SKILL.md |
+| $sr-why | .agents/skills/sr-why/SKILL.md |
+
+Note: Only commands/skills selected during setup are shown. Backlog commands are excluded if no backlog provider was configured.
+
+### Rules Created
+| Layer | File |
+|-------|------|
+| Backend | $SPECRAILS_DIR/rules/backend.md |
+| Frontend | $SPECRAILS_DIR/rules/frontend.md |
+
+### Scaffolding Removed
+| Artifact | Status |
+|----------|--------|
+| .specrails/setup-templates/ | Deleted |
+[If cli_provider == "claude":] | .claude/commands/enrich.md | Deleted |
+[If cli_provider == "codex":] | .agents/skills/setup/ | Deleted |
+| specrails/ | [User's choice] |
+
+### Next Steps
+[If cli_provider == "claude":]
+1. Review the generated files in .claude/
+2. Run `/specrails:get-backlog-specs` to see your backlog (if GitHub Issues exist)
+3. Run `/specrails:auto-propose-backlog-specs` to generate feature ideas
+4. Run `/specrails:implement #issue-number` to implement a feature
+5. Commit the .claude/ directory to version control
+[If cli_provider == "codex":]
+1. Review the generated files in .codex/ and .agents/skills/
+2. Run `$sr-get-backlog-specs` to see your backlog (if GitHub Issues exist)
+3. Run `$sr-auto-propose-backlog-specs` to generate feature ideas
+4. Run `$sr-implement #issue-number` to implement a feature
+5. Commit the .codex/ and .agents/ directories to version control
+
+### Quick Start
+[If cli_provider == "claude":]
+- `/specrails:implement "describe a feature"` — implement something right now
+- `/specrails:get-backlog-specs` — see prioritized feature ideas
+- `/specrails:auto-propose-backlog-specs` — discover new features using VPC
+[If cli_provider == "codex":]
+- `$sr-implement "describe a feature"` — implement something right now
+- `$sr-get-backlog-specs` — see prioritized feature ideas
+- `$sr-auto-propose-backlog-specs` — discover new features using VPC
+```
+
+## First Task Prompt (Full Wizard)
+
+After displaying the setup complete summary above, detect the project type and output:
+
+**New project** (no `package.json`, `Gemfile`, `pyproject.toml`, `go.mod`, or `pom.xml` in root):
+```
+✅ Setup complete.
+
+Try your first spec:
+[If cli_provider == "claude":]
+  > /specrails:get-backlog-specs
+[If cli_provider == "codex":]
+  > $sr-get-backlog-specs
+```
+
+**Existing codebase** (one or more of the above files found in root):
+```
+✅ Setup complete.
+
+Try your first spec:
+[If cli_provider == "claude":]
+  > /specrails:refactor-recommender
+[If cli_provider == "codex":]
+  > $sr-refactor-recommender
+```
+
+Then stop.

--- a/.claude/commands/specrails/explore-spec.md
+++ b/.claude/commands/specrails/explore-spec.md
@@ -1,0 +1,173 @@
+---
+description: Interactive thinking partner that helps the user shape a spec through conversation. Maintains a structured live draft via fenced spec-draft JSON blocks. The hub commits the ticket — never call ticket-creation commands yourself.
+---
+
+You are a senior product engineer helping the user shape a single spec through conversation. The user has opened the **Explore Spec** experience inside specrails-hub. You are their thinking partner — same stance as `/opsx:explore`, but the artefact you produce is a single backlog ticket (committed by the hub), not OpenSpec change files.
+
+# Your role
+
+- **Investigate first**, then ask. Do the homework on the codebase and existing specs before bombarding the user with questions. A grounded clarification beats five guess-questions.
+- **Listen** to the user's idea.
+- **Ask** only the questions you genuinely need to clarify scope, intent, constraints. Avoid filler questions. Two well-aimed questions beat eight generic ones.
+- **Surface** trade-offs, alternatives, and risks the user may not have considered.
+- **Propose** concrete shape: title, priority, labels, what's in/out, acceptance criteria.
+- **Stop asking** once you have enough information for a small, clear, testable spec.
+
+# Recommended first-turn investigation
+
+On the **first turn only**, take a moment to ground yourself in the project before responding. Read what is cheap to read and likely to inform the spec. Do not dump the findings into the chat — keep them in your context to inform questions and the draft.
+
+Useful sources, in order of priority:
+
+1. **Existing tickets** — `.specrails/local-tickets.json` if it exists. Tells you the labels in use, the tone of prior specs, and whether a similar item already exists.
+2. **OpenSpec specs (if the project uses OpenSpec)** — `openspec/specs/<capability>/spec.md` for capabilities related to the user's idea. Skim `openspec/specs/` to discover capability names. Check `openspec list --json` if it is available.
+3. **OpenSpec active changes** — `openspec/changes/` if it exists. A spec already in flight may overlap.
+4. **Project README / CLAUDE.md** — high-signal architectural notes. Often answers "where does X live" without grepping.
+5. **Targeted code reads** — only when the user's idea names a concrete component / module / feature. Use Glob + Grep to locate, then Read 1-3 focused files. Do **not** open dozens of files looking for inspiration.
+
+Stop reading as soon as you have enough to ask a meaningful question. If the idea is generic ("dark mode", "notifications"), you may not need to read any code at all — go straight to clarifying scope.
+
+# When to read more code mid-conversation
+
+If a later user reply names something specific you haven't seen yet, fetch it then. Examples:
+
+- "It should integrate with the SettingsPage" → open `SettingsPage` to confirm structure.
+- "Use the same labels as the auth specs" → grep `local-tickets.json` for auth tickets.
+- "Like the existing dark mode toggle in X" → read X.
+
+Avoid reading large or generic code areas. Read with intent.
+
+# Critical rule: do NOT modify the project
+
+You **MUST NOT**:
+- Create files of any kind.
+- Write to `.specrails/local-tickets.json`, `openspec/**`, or any project file.
+- Call `/specrails:propose-spec`, `/specrails:implement`, or other slash commands that produce side effects.
+- Run shell commands beyond read-only inspection (`ls`, `cat`-equivalents via Read).
+
+You may **read** anywhere in the project. The hub commits the final ticket via `POST /tickets/from-draft` when the user clicks **Create Spec**.
+
+# The structured draft protocol
+
+After every assistant turn that has new draft information, end your message with a fenced code block tagged `spec-draft` containing JSON. The hub parses this block and updates the live draft pane the user sees on the right side of the overlay.
+
+```spec-draft
+{
+  "title": "Concise, action-oriented title",
+  "description": "## Problem Statement\n2-3 sentences.\n\n## Proposed Solution\n3-5 sentences.\n\n## Out of Scope\n- bullet\n- bullet\n\n## Technical Considerations\n- bullet\n- bullet\n\n## Estimated Complexity\nMedium — one sentence justification.",
+  "labels": ["short-label", "another"],
+  "priority": "low | medium | high | critical",
+  "acceptanceCriteria": ["Bullet 1", "Bullet 2"],
+  "chips": ["Up to 3 short user-reply suggestions"],
+  "ready": false
+}
+```
+
+Field semantics:
+
+- All fields are **optional**. Only include fields you actually want to update; omitted fields keep their previous value.
+- **Empty strings** mean "leave the prior value alone" (no-op). Do not use `""` to clear a field.
+- **Arrays replace** the previous value entirely (they are not appended). To clear, send `[]`.
+- **`priority`** must be one of `low`, `medium`, `high`, `critical`. Other values are dropped.
+- **`description`** must follow this exact section template in markdown:
+  - `## Problem Statement` (2-3 sentences)
+  - `## Proposed Solution` (3-5 sentences)
+  - `## Out of Scope` (bullet list)
+  - `## Technical Considerations` (bullet list)
+  - `## Estimated Complexity` (`Low`/`Medium`/`High`/`Very High` plus one sentence)
+  - **Never include a `## Spec Title` heading inside `description`** — the title lives in its own field. Repeating it inside the body produces redundant tickets.
+  - **Never duplicate the acceptance criteria inside `description`** — they live in their own `acceptanceCriteria` array. The hub appends them to the ticket body under a `## Acceptance Criteria` section automatically.
+- **`acceptanceCriteria`** is a separate array of short, testable bullet strings. The hub appends them to the ticket body under a `## Acceptance Criteria` section automatically — do NOT duplicate them inside `description`.
+- **`chips`** are 0-3 short replies the user can click to send as their next message. Use them sparingly; capping the user's options is bad in early turns where the conversation is still wide.
+- **`ready: true`** signals "I think the draft is in good enough shape to commit." Set this when you have a meaningful title, a populated description matching the template, and at least one acceptance criterion. Setting `ready: true` does NOT create the ticket — it only highlights the Create Spec button for the user. The user is always the commit.
+- The block is **not shown to the user**. The hub strips it before rendering your message. So put your visible reasoning above the block, in plain prose.
+
+# Language
+
+- **Spec content MUST be in English.** All draft fields — `title`, `description`, `labels`, `acceptanceCriteria` — are always written in English regardless of the language the user is speaking. This matches how `/specrails:propose-spec` produces specs and keeps `local-tickets.json` consistent across the project.
+- **Conversation in the user's language.** Your visible prose (questions, summaries, chip suggestions) follows whichever language the user is using. Spanish in, Spanish out — Spanish in, English spec.
+- **Chips** can be in the user's language (they are conversational replies, not part of the spec).
+
+# Example interaction
+
+**User:** dark mode toggle
+
+**Assistant:**
+Good — quick clarifications to scope this tight:
+
+- Where lives the toggle: Settings page, in the header, or both?
+- Persistence: localStorage, server-side per user, or just session?
+
+```spec-draft
+{
+  "title": "Add dark mode toggle",
+  "labels": ["ui", "theme"],
+  "priority": "medium",
+  "chips": ["Settings page", "Both header and settings", "Just session, no persist"],
+  "ready": false
+}
+```
+
+**User:** settings, persist to localStorage, respect system preference as default
+
+**Assistant:**
+Got it. That keeps it focused. Anything you want explicitly out of scope (e.g. inline preview, smooth transition animation)?
+
+```spec-draft
+{
+  "description": "## Problem Statement\nThe app currently follows the OS theme passively, leaving users no way to override it per session.\n\n## Proposed Solution\nAdd a toggle on the Settings page that switches between light and dark. The first visit honors the OS preference (`prefers-color-scheme`); once the user picks a theme, the choice persists in `localStorage` and overrides the OS on later visits.\n\n## Out of Scope\n- Smooth fade transitions between themes\n- Per-page or per-component theme overrides\n- Multi-account theme sync\n\n## Technical Considerations\n- Read `localStorage['theme']` on bootstrap; fall back to `matchMedia('(prefers-color-scheme: dark)')`\n- Apply the resolved theme via a `data-theme` attribute on `<html>`\n- Toggle component lives in `SettingsPage`\n\n## Estimated Complexity\nLow — small, well-bounded change with no backend touchpoints.",
+  "acceptanceCriteria": [
+    "Toggle visible in Settings page",
+    "Manual choice persists across reloads",
+    "First visit honors prefers-color-scheme",
+    "Toggle reflects the active theme"
+  ],
+  "chips": ["No animation needed", "Looks good — create"],
+  "ready": true
+}
+```
+
+**User (Spanish):** modo oscuro, toggle en settings, recuerda en localStorage
+
+**Assistant (Spanish prose, English spec):**
+Hecho. ¿Algo que quieras dejar fuera explícitamente (p.ej. animaciones de transición)?
+
+```spec-draft
+{
+  "title": "Add dark mode toggle",
+  "description": "## Problem Statement\nUsers cannot override the OS theme on a per-session basis.\n\n## Proposed Solution\nAdd a Settings page toggle that switches the app between light and dark. The first visit honors the OS preference; once a manual choice is made, it persists in `localStorage` and overrides the OS on later visits.\n\n## Out of Scope\n- Smooth transitions between themes\n- Per-component theme overrides\n\n## Technical Considerations\n- Read `localStorage['theme']` on bootstrap with `prefers-color-scheme` fallback\n- Apply via `data-theme` on `<html>`\n\n## Estimated Complexity\nLow — small, well-scoped change.",
+  "acceptanceCriteria": [
+    "Toggle visible in Settings page",
+    "Manual choice persists across reloads",
+    "First visit honors prefers-color-scheme"
+  ],
+  "labels": ["ui", "theme"],
+  "priority": "medium",
+  "chips": ["Sin animaciones", "Listo, crear"],
+  "ready": true
+}
+```
+
+# Style and tone
+
+- Be brief. Two short sentences and a question beats a paragraph.
+- Don't pad with "great question". Get to the substance.
+- Match the user's language (English, Spanish, etc.) on each turn.
+- Don't quote your own draft block back at the user — the user sees the structured panel; you don't need to repeat its content in prose.
+- Treat the user as expert in their domain. Ask, don't lecture.
+
+# When to set ready: true
+
+Set ready when **all** of these are true:
+- The draft has a title.
+- The draft has a description.
+- The draft has at least one acceptance criterion.
+- You don't have an outstanding clarifying question for the user.
+
+Until then, leave `ready: false` (or omit `ready`).
+
+The user's idea follows below. Begin the conversation.
+
+---
+
+$ARGUMENTS

--- a/.claude/commands/specrails/health-check.md
+++ b/.claude/commands/specrails/health-check.md
@@ -1,0 +1,527 @@
+---
+name: "Health Check Dashboard"
+description: "Run a comprehensive codebase health check — tests, linting, coverage, complexity, and dependency audit. Compare with previous runs to detect regressions."
+category: Workflow
+tags: [workflow, health, quality, dashboard]
+---
+
+Run a full health check for **specrails-core**: detect available tools, execute each quality check, compare results against the previous run, detect regressions, compute a health grade, and store a snapshot for future comparison.
+
+**Input:** $ARGUMENTS — optional flags:
+- `--since <date>` — use the report from this date (ISO format: YYYY-MM-DD) as the comparison baseline instead of the most recent
+- `--only <checks>` — comma-separated subset to run. Valid values: `tests`, `coverage`, `lint`, `complexity`, `deps`, `perf`, `static`
+- `--save` — always save the snapshot even when `--only` is used (default: skip save for partial runs)
+
+---
+
+## Phase 0: Argument Parsing
+
+Parse `$ARGUMENTS` to set runtime variables.
+
+**Variables to set:**
+
+- `COMPARE_DATE` — string (ISO date) or empty string. Default: `""` (use most recent report).
+- `CHECKS_FILTER` — array of check names or the string `"all"`. Default: `"all"`.
+- `SAVE_SNAPSHOT` — boolean. Default: `true` when `CHECKS_FILTER="all"`, `false` for partial runs unless `--save` is present.
+
+**Parsing rules:**
+
+1. Scan `$ARGUMENTS` for `--since <date>`. If found, set `COMPARE_DATE=<date>`. Strip from arguments.
+2. Scan for `--only <checks>`. If found:
+   - Split `<checks>` on commas to produce an array.
+   - Validate each entry against the allowed set: `tests`, `coverage`, `lint`, `complexity`, `deps`, `perf`, `static`.
+   - If any unknown value is found: print `Error: unknown check "<value>". Valid checks: tests, coverage, lint, complexity, deps, perf, static` and stop.
+   - Set `CHECKS_FILTER=<validated-array>`.
+   - Set `SAVE_SNAPSHOT=false` (partial run — snapshot may be incomplete).
+3. Scan for `--save`. If found, set `SAVE_SNAPSHOT=true` regardless of `CHECKS_FILTER`.
+
+**Print active configuration:**
+
+```
+Running checks: <all | comma-separated list> | Static analysis: <enabled|disabled> | Comparing to: <COMPARE_DATE or "latest">
+```
+
+---
+
+## Phase 1: Toolchain Detection
+
+Detect available tools for each check category. Run all detections simultaneously (in parallel). For each category, try tools in the order listed — use the first one found.
+
+If `CHECKS_FILTER` is not `"all"`, skip detection for categories not in the filter.
+
+For each category, set two variables:
+- `TOOL_<CHECK>` — the tool name or command string (e.g., `"jest"`, `"eslint"`)
+- `TOOL_<CHECK>_AVAILABLE` — boolean (`true` / `false`)
+
+**Detection sequences:**
+
+- **tests:** Try in order: `jest`, `vitest`, `mocha`, `pytest`, `go test`, `cargo test`, `rspec`, `dotnet test`. If none found, check whether `` provides a test command — use it as fallback and set `TOOL_TESTS="ci-commands"`.
+- **coverage:** Try in order: `nyc`, `c8`, `pytest-cov`, `coverage` (Python), `go test -cover`, `cargo tarpaulin`, `lcov`.
+- **lint:** Try in order: `eslint`, `pylint`, `flake8`, `ruff`, `golangci-lint`, `rubocop`, `cargo clippy`.
+- **complexity:** Try in order: `lizard`, `radon`, `gocyclo`, `plato`. If none found, set `TOOL_COMPLEXITY_AVAILABLE=false` — complexity will be estimated from linter output if lint ran.
+- **deps:** Try in order: `npm audit`, `pip-audit`, `govulncheck`, `cargo audit`, `bundle audit`.
+- **perf:** Look for a performance entry point at these paths in order:
+  1. `scripts/perf.sh`
+  2. `scripts/benchmark.sh`
+  3. A `"perf"` or `"benchmark"` script key in `package.json`
+  4. A `perf` or `benchmark` target in `Makefile`
+
+  If found, set `TOOL_PERF=<path-or-command>` and `TOOL_PERF_AVAILABLE=true`. Otherwise set `TOOL_PERF_AVAILABLE=false`.
+
+**Detection summary table** (print after all probes complete):
+
+```
+| Category   | Available | Tool              |
+|------------|-----------|-------------------|
+| tests      | yes/no    | <tool or N/A>     |
+| coverage   | yes/no    | <tool or N/A>     |
+| lint       | yes/no    | <tool or N/A>     |
+| complexity | yes/no    | <tool or N/A>     |
+| deps       | yes/no    | <tool or N/A>     |
+| perf       | yes/no    | <tool or N/A>     |
+| static     | yes       | ai-analysis       |
+```
+
+The `static` check is always available (AI-assisted analysis requires no external tools).
+
+---
+
+## Phase 2: Load Previous Report
+
+Read `.claude/health-history/` to find the comparison baseline.
+
+**Variables to set:**
+- `PREV_REPORT_PATH` — absolute file path or `null`
+- `IS_FIRST_RUN` — boolean
+- `PREV_REPORT` — parsed JSON object or `null`
+
+**Logic:**
+
+1. Check whether `.claude/health-history/` exists and contains `.json` files.
+   - If directory is absent or empty: set `IS_FIRST_RUN=true`, `PREV_REPORT_PATH=null`, `PREV_REPORT=null`. Print: `First run — no previous report found. Regression comparison is not available.` Proceed.
+
+2. If reports exist and `COMPARE_DATE` is empty: select the most recently modified `.json` file.
+
+3. If `COMPARE_DATE` is set: find the report whose filename date component is closest to `COMPARE_DATE` (without exceeding it). If no report matches within 7 days, print: `Warning: no report found near <COMPARE_DATE>. Falling back to most recent.` Then use the most recent.
+
+4. Set `IS_FIRST_RUN=false`, `PREV_REPORT_PATH=<path>`, load file content into `PREV_REPORT`.
+
+5. Print one line:
+
+   - First run: `Baseline: first run (no comparison)`
+   - Report found: `Comparing to: <YYYY-MM-DD> (<short-sha from filename>)`
+
+---
+
+## Phase 3: Run Checks
+
+Run checks **sequentially** in this order: `tests`, `coverage`, `lint`, `complexity`, `deps`, `perf`. Sequential execution avoids resource contention that would skew timing and coverage metrics.
+
+For each check, follow this pattern:
+
+**Skip condition:** If `TOOL_<CHECK>_AVAILABLE=false` OR check is excluded by `CHECKS_FILTER`:
+- Set `RESULT_<CHECK> = { status: "skipped", tool: null, metrics: null }`
+- Print `<check>: SKIPPED`
+- Continue to next check.
+
+**Run:** Execute the tool with the command shown below. If the tool exits non-zero: set `status: "fail"`, capture the error message, record whatever partial metrics are available, and continue — do NOT abort the command.
+
+**Store:** Set `RESULT_<CHECK>` to a structured object with `status`, `tool`, and `metrics` fields.
+
+---
+
+### Check: tests
+
+Run command (first tool that matches):
+
+- `jest`: `jest --json 2>/dev/null` — parse JSON stdout for `numPassedTests`, `numFailedTests`, `numPendingTests`, `testResults[].duration`
+- `vitest`: `vitest run --reporter=json 2>/dev/null` — parse JSON for equivalent fields
+- `mocha`: `mocha --reporter json 2>/dev/null` — parse `stats` object
+- `pytest`: `pytest --tb=no -q 2>&1` — extract pass/fail/skip counts from summary line
+- `go test`: `go test ./... -v 2>&1` — count `--- PASS`, `--- FAIL`, `--- SKIP` lines
+- `cargo test`: `cargo test 2>&1` — parse `test result:` summary line
+- `rspec`: `rspec --format json 2>/dev/null` — parse JSON
+- `dotnet test`: `dotnet test --logger "console;verbosity=normal" 2>&1` — extract summary
+- `ci-commands` fallback: run `` and extract pass/fail counts from output using best-effort parsing
+
+**Metrics to extract:** `tests_total`, `tests_passed`, `tests_failed`, `tests_skipped`, `pass_rate` (0.0–100.0), `duration_seconds`.
+
+Set `RESULT_TESTS`.
+
+---
+
+### Check: coverage
+
+Run command:
+
+- `nyc` / `c8`: `nyc report --reporter=text-summary 2>/dev/null` or `c8 report --reporter=text-summary 2>/dev/null` — parse "Statements" or "Lines" coverage percentage
+- `pytest-cov`: re-run as `pytest --cov --cov-report=term-missing -q 2>&1` or read `.coverage` via `coverage report 2>/dev/null`
+- `coverage` (Python): `coverage report 2>/dev/null` — extract `TOTAL` line percentage
+- `go test -cover`: `go test -cover ./... 2>&1` — extract `coverage: N.N%` from each package, compute mean
+- `cargo tarpaulin`: `cargo tarpaulin --out Stdout 2>/dev/null` — extract coverage percentage
+- `lcov`: `lcov --summary coverage.info 2>/dev/null` — extract lines-found/lines-hit
+
+**Metrics to extract:** `coverage_pct` (float), `coverage_type` (`"line"` / `"branch"` / `"statement"`).
+
+Set `RESULT_COVERAGE`.
+
+---
+
+### Check: lint
+
+Run command:
+
+- `eslint`: `eslint . --format json 2>/dev/null` — count `severity: 2` (errors) and `severity: 1` (warnings) across all results; count files analyzed
+- `pylint`: `pylint --output-format json <src-dir-or-.> 2>/dev/null` — count messages by type (`error`, `warning`)
+- `flake8`: `flake8 --format default . 2>&1` — count lines with `E` prefix (errors) vs `W` prefix (warnings)
+- `ruff`: `ruff check --output-format json . 2>/dev/null` — parse JSON array, count by severity
+- `golangci-lint`: `golangci-lint run --out-format json 2>/dev/null` — count issues by severity
+- `rubocop`: `rubocop --format json 2>/dev/null` — parse offenses by severity
+- `cargo clippy`: `cargo clippy --message-format json 2>/dev/null` — count `"level":"error"` and `"level":"warning"` messages
+
+**Metrics to extract:** `lint_errors`, `lint_warnings`, `lint_files_checked`. Compute `lint_score = max(0, 100 - lint_errors * 5 - lint_warnings * 1)`.
+
+Set `RESULT_LINT`.
+
+---
+
+### Check: complexity
+
+If `TOOL_COMPLEXITY_AVAILABLE=false`:
+- If `RESULT_LINT` is available (lint ran and has output): set `complexity_source: "estimated"` — use Claude's reasoning to estimate complexity signals from lint output (e.g., complexity-related lint rules fired). Set numeric metrics to `null`.
+- Otherwise: set `complexity_source: "unavailable"`, all metrics `null`, `status: "skipped"`.
+
+Run command (if tool available):
+
+- `lizard`: `lizard . --csv 2>/dev/null` — parse CSV, compute average CCN, max CCN, count functions with CCN > 10
+- `radon`: `radon cc . -a -j 2>/dev/null` — parse JSON, use `average_complexity` field; count items with complexity > 10
+- `gocyclo`: `gocyclo -over 10 . 2>/dev/null` and `gocyclo -avg . 2>/dev/null` — extract average and functions exceeding threshold
+- `plato`: `plato -r -d /tmp/plato-report . 2>/dev/null && cat /tmp/plato-report/report.json` — extract `summary.average.maintainability`
+
+**Metrics to extract:** `avg_cyclomatic_complexity` (float), `max_cyclomatic_complexity` (int), `high_complexity_functions` (int, count with CCN > 10), `complexity_source` (`"measured"` / `"estimated"` / `"unavailable"`).
+
+Set `RESULT_COMPLEXITY`. Status is `"measured"` when a tool ran, `"estimated"` when inferred, `"skipped"` when neither is possible.
+
+---
+
+### Check: deps
+
+Run command:
+
+- `npm audit`: `npm audit --json 2>/dev/null` — parse `vulnerabilities` object; count by `severity` field
+- `pip-audit`: `pip-audit --format json 2>/dev/null` — parse JSON array; count by `fix_versions` presence and severity
+- `govulncheck`: `govulncheck ./... 2>&1` — extract vulnerability counts from summary; if no JSON flag, use Claude's reasoning on text output
+- `cargo audit`: `cargo audit --json 2>/dev/null` — parse `vulnerabilities.list`, count by `advisory.severity`
+- `bundle audit`: `bundle audit check 2>&1` — parse output for `Insecure Source` and `Unpatched versions`; classify by severity from advisory text
+
+**Metrics to extract:** `vuln_critical`, `vuln_high`, `vuln_moderate`, `vuln_low`, `vuln_total`.
+
+Set `RESULT_DEPS`.
+
+---
+
+### Check: perf
+
+If `TOOL_PERF_AVAILABLE=false`: set `RESULT_PERF = { status: "skipped", tool: null, metrics: null }`, print `perf: SKIPPED`, continue.
+
+Run the detected entry point. After it completes, attempt to parse its stdout for these standard keys:
+- `p50`, `p50_ms`, `median_ms` → `perf_p50_ms`
+- `p95`, `p95_ms` → `perf_p95_ms`
+- `p99`, `p99_ms` → `perf_p99_ms`
+- Any remaining numeric key-value pairs → `perf_custom`
+
+If the script output does not contain recognizable keys, set all latency fields to `null` and store the raw output in `perf_custom.raw`.
+
+**Metrics to extract:** `perf_p50_ms`, `perf_p95_ms`, `perf_p99_ms`, `perf_custom`.
+
+Set `RESULT_PERF`.
+
+---
+
+**Phase 3 summary** (print after all checks):
+
+```
+tests: <PASS|FAIL|SKIPPED> (<tool>)
+coverage: <PASS|FAIL|SKIPPED> (<tool>)
+lint: <PASS|FAIL|SKIPPED> (<tool>)
+complexity: <MEASURED|ESTIMATED|SKIPPED> (<tool>)
+deps: <PASS|FAIL|SKIPPED> (<tool>)
+perf: <PASS|FAIL|SKIPPED> (<tool>)
+```
+
+---
+
+## Phase 3.5: Static Code Analysis
+
+Perform static code inspection to detect issues that tools cannot surface: missing documentation, broken imports, and unused exports. These checks are language-aware and use AI-assisted code reading rather than external tooling.
+
+Always exclude the following directories from analysis:
+- `node_modules/`, `.git/`, `dist/`, `build/`, `vendor/`, `.claude/`, `coverage/`
+
+For each finding, record a structured object:
+```
+{ severity: "critical"|"warning"|"info", check: string, file: string, line: number, description: string, action: string }
+```
+
+Set `STATIC_FINDINGS = []` before starting. Append each finding to this list.
+
+---
+
+### Check: documentation
+
+Scan public-facing code units (exported functions, classes, interfaces, modules) for missing documentation comments.
+
+**Language-specific rules:**
+
+- **TypeScript/JavaScript**: Identify functions/classes with `export` keyword. Check whether a JSDoc block (`/** ... */`) appears immediately above the declaration. Missing JSDoc on exported symbols = finding.
+- **Python**: Identify top-level functions, classes, and methods. Check for a docstring (a string literal as the first statement in the body). Missing docstring on public (non-underscore-prefixed) symbols = finding.
+- **Ruby**: Identify public methods and classes. Check for a YARD/RDoc comment (`# @param`, `##`, or any comment block) immediately above the definition. Missing comment on public methods in lib/ = finding.
+- **Go**: Identify exported types and functions (capitalized names). Check for a doc comment (line starting with `// <ExportedName>`) immediately above. Missing comment on exported symbols = finding.
+
+**Severity assignment:**
+- `critical`: Main entry points (e.g., `index.ts`, `main.go`, `app.rb`) with no module-level documentation
+- `warning`: Exported/public function or class with no documentation
+- `info`: Non-exported function over 20 lines with no documentation
+
+Scan all source files matching the detected language(s). Skip test files (`*.test.*`, `*.spec.*`, `_test.go`, `spec/**`).
+
+Append each finding to `STATIC_FINDINGS`.
+
+---
+
+### Check: broken_imports
+
+Detect import/require statements that reference non-existent paths. Focus on local relative imports (skip `node_modules`, stdlib, installed packages — these are validated by the runtime).
+
+**Language-specific rules:**
+
+- **TypeScript/JavaScript**: Scan all `import ... from '...'` and `require('...')` statements. For each import path starting with `.` or `/`:
+  1. Resolve the path relative to the source file.
+  2. Check whether the resolved file exists (try: exact path, `.ts`, `.tsx`, `.js`, `.jsx`, `/index.ts`, `/index.js`).
+  3. If no match found: add a `critical` finding.
+- **Python**: Scan all `from . import`, `from .. import`, and `import X` with relative markers. Resolve relative paths from the package root. If the resolved module file does not exist: add a `critical` finding.
+- **Ruby**: Scan `require_relative '...'` statements. Resolve paths from the source file's directory (try `.rb` extension if missing). If the resolved path does not exist: add a `critical` finding.
+- **Go**: Skip — Go's compiler validates imports; broken imports would fail the build.
+
+**Severity:** Always `critical` — a broken import is a runtime error.
+
+Append each finding to `STATIC_FINDINGS`.
+
+---
+
+### Check: unused_exports
+
+Detect exported symbols that are never imported anywhere else in the codebase. Limit to the project source — do not flag exports intended as a library's public API (i.e., symbols re-exported from a barrel file like `index.ts`).
+
+**Language-specific rules:**
+
+- **TypeScript/JavaScript**:
+  1. Build a list of all exported symbols: scan `export const`, `export function`, `export class`, `export type`, `export interface`, `export default` across all non-test `.ts`/`.tsx`/`.js` files.
+  2. For each exported symbol, search the rest of the codebase for imports of that symbol by name. Exclude the barrel/index file itself.
+  3. If no import found anywhere: add a finding with severity `warning` (may be an intentional API export) unless the file is not `index.ts` and not under `src/` root — in that case severity is `info`.
+- **Python**:
+  1. Scan for symbols listed in `__all__` or public top-level definitions (non-underscore).
+  2. Search for usages across the codebase. If the symbol appears only in its definition file: add a `info` finding.
+- **Ruby**:
+  1. Scan for public constants, classes, and modules defined in `lib/`. Search for `require` or direct references elsewhere. If a class/module in `lib/` is never referenced outside its own file: add a `warning` finding.
+
+**Severity:** `warning` for clearly unexported contexts; `info` when the symbol could be part of a public API.
+
+Append each finding to `STATIC_FINDINGS`.
+
+---
+
+### Phase 3.5 summary
+
+After all three static checks complete, print:
+
+```
+documentation: <N findings> (<N critical, N warning, N info>)
+broken_imports: <N findings> (<N critical>)
+unused_exports: <N findings> (<N warning, N info>)
+Static findings total: <N>
+```
+
+---
+
+## Phase 4: Build Health Report
+
+Using all `RESULT_<CHECK>` values and `PREV_REPORT` (if `IS_FIRST_RUN=false`), compute the final health report object.
+
+### Step 1: Compute per-metric deltas
+
+For each numeric metric, compute `delta = current_value - prev_value`. If `IS_FIRST_RUN=true`, set all deltas to `"N/A (first run)"`.
+
+Delta notation convention:
+- For metrics where higher is better (pass_rate, coverage_pct, lint_score): positive delta = improvement, negative delta = regression.
+- For metrics where lower is better (lint_errors, vuln_*, high_complexity_functions): positive delta = regression, negative delta = improvement.
+
+### Step 2: Detect regressions
+
+A regression is triggered when any of the following thresholds is crossed vs. the previous report:
+
+| Check | Threshold |
+|-------|-----------|
+| tests | `pass_rate` drops by more than 1% |
+| coverage | `coverage_pct` drops by more than 2 percentage points |
+| lint | `lint_errors` increases vs. previous |
+| lint | `lint_score` drops by more than 5 points |
+| complexity | `high_complexity_functions` increases vs. previous |
+| deps | `vuln_critical` increases vs. previous |
+| deps | `vuln_high` increases vs. previous |
+| perf | `perf_p50_ms` increases by more than 10% vs. previous |
+
+If `IS_FIRST_RUN=true`: set `REGRESSIONS=[]` (no regression detection possible on first run).
+
+Build `REGRESSIONS` as a list of objects: `{ check, metric, previous, current, delta }`.
+
+### Step 3: Assign health grade
+
+Evaluate criteria in order from F to A; assign the first grade whose criteria are met:
+
+| Grade | Criteria |
+|-------|----------|
+| F | Test suite fails to run (RESULT_TESTS.status = "fail") OR pass_rate < 50% |
+| D | Multiple regressions detected (len(REGRESSIONS) >= 2) OR pass_rate < 80% OR vuln_critical > 2 |
+| C | One regression detected OR pass_rate 80–89% OR vuln_critical > 0 |
+| B | No critical regressions. Any one of: pass_rate 90–94%, OR coverage_pct 70–79%, OR lint_errors 1–5, OR vuln_high <= 2 |
+| A | No regressions. pass_rate >= 95%. coverage_pct >= 80% (if measured). lint_errors == 0 (if measured). vuln_critical == 0 AND vuln_high == 0 (if measured). |
+
+When `IS_FIRST_RUN=true`, regressions cannot be detected — base the grade on absolute metric thresholds only (no regression criteria apply).
+
+When a check is SKIPPED, omit its metric from grade criteria (do not penalize for unavailable tools).
+
+### Step 4: Assemble HEALTH_REPORT
+
+Build `HEALTH_REPORT` as a structured object matching the JSON storage schema exactly:
+
+```
+HEALTH_REPORT = {
+  schema_version: "1",
+  project: "specrails-core",
+  timestamp: <ISO 8601 current datetime>,
+  git_sha: <full SHA from `git rev-parse HEAD` or "unknown">,
+  git_short_sha: <7-char SHA from `git rev-parse --short HEAD` or "unknown">,
+  git_branch: <branch from `git rev-parse --abbrev-ref HEAD` or "unknown">,
+  checks: {
+    tests: { status, tool, metrics: { tests_total, tests_passed, tests_failed, tests_skipped, pass_rate, duration_seconds } },
+    coverage: { status, tool, metrics: { coverage_pct, coverage_type } },
+    lint: { status, tool, metrics: { lint_errors, lint_warnings, lint_score, lint_files_checked } },
+    complexity: { status, tool, metrics: { avg_cyclomatic_complexity, max_cyclomatic_complexity, high_complexity_functions, complexity_source } },
+    deps: { status, tool, metrics: { vuln_critical, vuln_high, vuln_moderate, vuln_low, vuln_total } },
+    perf: { status, tool, metrics: { perf_p50_ms, perf_p95_ms, perf_p99_ms, perf_custom } }
+  },
+  static_findings: <STATIC_FINDINGS array — each: { severity, check, file, line, description, action }>,
+  grade: <"A"|"B"|"C"|"D"|"F">,
+  regressions: <REGRESSIONS array>,
+  comparison_report: <PREV_REPORT_PATH basename or null>
+}
+```
+
+---
+
+## Phase 5: Display Report and Store Snapshot
+
+### Action 1: Display
+
+Render the health report to the terminal using Markdown formatting:
+
+```
+## Codebase Health Report — specrails-core
+Date: <ISO date> | Commit: <git_short_sha> | Compared to: <previous report date or "first run">
+
+Overall Grade: <A/B/C/D/F>  (<one-line summary>)
+
+### Test Suite      [<PASS/FAIL/SKIPPED>]
+  Tests: N passed, N failed, N skipped (N total)
+  Pass rate: N% <delta: (+N%) or (-N%) or N/A (first run)>
+  Duration: Xs
+
+### Code Coverage   [<PASS/FAIL/SKIPPED/ESTIMATED>]
+  Coverage: N% <delta vs previous>
+  Type: line/branch/statement
+
+### Linting         [<PASS/FAIL/SKIPPED>]
+  Score: N/100 <delta vs previous>
+  Errors: N  Warnings: N
+
+### Complexity      [<MEASURED/ESTIMATED/SKIPPED>]
+  Avg CCN: N  Max CCN: N
+  High-complexity functions: N (>10 CCN) <delta vs previous>
+
+### Dependencies    [<PASS/FAIL/SKIPPED>]
+  Vulnerabilities: N critical, N high, N moderate, N low
+
+### Performance     [<PASS/FAIL/SKIPPED>]
+  p50: Nms  p95: Nms  p99: Nms <delta vs previous>
+
+---
+Regressions detected: N
+<if N > 0, list each:>
+  - <check>: <metric> changed from X to Y (<delta>)
+<if N == 0:>
+  No regressions detected.
+
+---
+
+### Static Analysis Findings  [<N total: N critical, N warning, N info>]
+
+<if STATIC_FINDINGS is empty:>
+  No static findings detected.
+
+<if STATIC_FINDINGS is non-empty:>
+
+  | Severity | Check | File | Line | Finding | Action |
+  |----------|-------|------|------|---------|--------|
+  <for each finding in STATIC_FINDINGS, sorted by severity (critical first, then warning, then info):>
+  | <CRITICAL|WARNING|INFO> | <check> | <file> | <line> | <description> | <action> |
+
+  <if any critical findings:>
+  #### Critical Findings (require immediate attention)
+  <for each critical finding:>
+  **[CRITICAL] <check>** — `<file>:<line>`
+  > <description>
+  > **Action:** <action>
+
+  <if any warning findings (limit to top 5 by file breadth — prefer findings spread across more files):>
+  #### Warnings (recommended fixes)
+  <for each warning finding, up to 5:>
+  **[WARNING] <check>** — `<file>:<line>`
+  > <description>
+  > **Action:** <action>
+  <if more than 5 warning findings:>
+  > ... and N more warnings. Run with `--only static` to see all.
+
+  <if any info findings:>
+  #### Info (low-priority improvements)
+  Summary: N info-level findings across N files. Run with `--only static` to see full list.
+```
+
+For delta display: wrap positive deltas on error/failure metrics in `(+N)` to indicate regression; wrap negative deltas on pass-rate/coverage in `(-N%)` styled as improvement. For terminal rendering, use plain notation — the sign alone conveys direction.
+
+### Action 2: Store snapshot
+
+Only store if `SAVE_SNAPSHOT=true`.
+
+1. Determine filename: `<YYYY-MM-DD>-<git_short_sha>.json` where the date is today's ISO date. If git is unavailable, use `<YYYY-MM-DD>-unknown.json`.
+2. Create `.claude/health-history/` if it does not exist (idempotent — no error if already present).
+3. Write `HEALTH_REPORT` serialized as JSON to `.claude/health-history/<filename>`.
+4. Print: `Stored: .claude/health-history/<filename>`
+
+### Housekeeping notice
+
+After writing (or after checking the directory if `SAVE_SNAPSHOT=false`), count `.json` files in `.claude/health-history/`. If count > 30, print:
+
+```
+Note: .claude/health-history/ has N reports. Consider pruning old ones with:
+  ls -t .claude/health-history/ | tail -n +31 | xargs -I{} rm .claude/health-history/{}
+```
+
+### .gitignore suggestion
+
+Check whether `.claude/health-history` appears in `.gitignore` (if `.gitignore` exists). If it does not appear, print:
+
+```
+Tip: health history reports are local artifacts. Add to .gitignore:
+  echo '.claude/health-history/' >> .gitignore
+```

--- a/.claude/commands/specrails/implement.md
+++ b/.claude/commands/specrails/implement.md
@@ -1,0 +1,1457 @@
+# Implementation Pipeline
+
+Full OpenSpec lifecycle with specialized agents: architect designs, developer implements, reviewer validates and archives. Handles 1 to N features — adapts automatically (sequential for 1, parallel with worktrees for N).
+
+**MANDATORY: Always follow this pipeline exactly as written. NEVER skip, shortcut, or "optimize away" any phase — even if the task seems simple enough to do directly. The orchestrator MUST launch the architect, developer, and reviewer agents as specified. Do NOT implement changes yourself in the main conversation; delegate to the agents defined in each phase. No exceptions.**
+
+**Input:** $ARGUMENTS — accepts three modes:
+
+1. **Issue numbers** (recommended): `#85, #71, #63` — implement these specific GitHub Issues directly. Skips exploration and selection.
+2. **Text description** (single feature): `"add price history chart"` — implement a single feature from a description. Skips exploration and selection.
+3. **Area names** (fallback): `Analytics, UI, Testing` — explores areas and picks the best items. Only use if no backlog issues exist.
+
+**IMPORTANT:** Before running, ensure Read/Write/Bash/Glob/Grep permissions are set to "allow" — background agents cannot request permissions interactively.
+
+---
+
+## Phase -1: Environment Setup (cloud pre-flight)
+
+**This phase runs BEFORE anything else.** Detect if we're in a cloud/remote environment and ensure all required tools are available.
+
+### Detection
+
+Check the environment variable `CLAUDE_CODE_ENTRYPOINT`. If it contains `remote_mobile` or `remote_web`, OR if `CLAUDE_CODE_REMOTE` is `true`, we're in a **cloud environment**.
+
+### Checks to run (sequential, fail-fast)
+
+#### 1. Backlog provider availability
+
+Read `.specrails/backlog-config.json` and extract `BACKLOG_PROVIDER`.
+
+**If `BACKLOG_PROVIDER=local`:**
+```bash
+[[ -f ".specrails/local-tickets.json" ]] && echo "Local tickets storage: OK" || echo "WARNING: local-tickets.json not found"
+```
+- Set `LOCAL_TICKETS_AVAILABLE=true/false` based on file existence.
+- Set `GH_AVAILABLE=false` (GitHub CLI not needed for local provider).
+- Set `BACKLOG_AVAILABLE=true` if local-tickets.json exists.
+
+**Otherwise:**
+```bash
+gh auth status 2>&1
+```
+- Set `GH_AVAILABLE=true/false` for later phases.
+
+#### 2. OpenSpec CLI
+
+```bash
+which openspec && openspec --version
+```
+
+- If missing: try `npm install -g @fission-ai/openspec`
+- If install fails: **STOP** — openspec is required.
+
+#### 3. Project dependencies
+
+
+
+#### 4. Test runner
+
+
+
+#### 5. Agent discovery
+
+Agent discovery runs in one of two modes: **profile mode** (a profile JSON is active) or **legacy mode** (no profile — identical to pre-4.1.0 behavior).
+
+##### Profile detection
+
+A profile is active when either condition holds:
+
+1. The environment variable `SPECRAILS_PROFILE_PATH` is set AND points to a readable file. Tools like `specrails-hub` set this to a job-scoped snapshot.
+2. The file `.specrails/profiles/project-default.json` exists and is readable.
+
+If condition 1 holds, use `$SPECRAILS_PROFILE_PATH` as the profile path. Otherwise, if condition 2 holds, use `.specrails/profiles/project-default.json`. Otherwise, fall through to **legacy mode**.
+
+##### Preflight: `jq` availability (profile mode only)
+
+When running in profile mode, `jq` is required to read the profile JSON. Run:
+
+```bash
+command -v jq >/dev/null 2>&1 || { echo "[error] 'jq' is required for profile-aware mode. Install with: brew install jq / apt install jq / https://stedolan.github.io/jq/"; exit 1; }
+```
+
+##### Profile mode — load, validate, populate
+
+Read the profile:
+
+```bash
+PROFILE="$(cat "$PROFILE_PATH")"
+```
+
+Validate the schema version. Only `schemaVersion: 1` is supported:
+
+```bash
+SCHEMA_VERSION="$(jq -r '.schemaVersion // empty' <<<"$PROFILE")"
+case "$SCHEMA_VERSION" in
+  1) ;;
+  "") echo "[error] profile validation failed: missing required field 'schemaVersion'"; exit 1 ;;
+  *) echo "[error] profile validation failed: unsupported schemaVersion '$SCHEMA_VERSION'. Supported: 1"; exit 1 ;;
+esac
+```
+
+Validate required top-level fields. Every valid v1 profile MUST contain `name`, `orchestrator.model`, `agents` (non-empty array), and `routing` (non-empty array):
+
+```bash
+for field in name orchestrator agents routing; do
+  jq -e ".$field" <<<"$PROFILE" >/dev/null 2>&1 || { echo "[error] profile validation failed: missing required field '$field'"; exit 1; }
+done
+jq -e '.orchestrator.model' <<<"$PROFILE" >/dev/null 2>&1 || { echo "[error] profile validation failed: missing required field 'orchestrator.model'"; exit 1; }
+jq -e '.agents | length > 0' <<<"$PROFILE" >/dev/null 2>&1 || { echo "[error] profile validation failed: 'agents' must be a non-empty array"; exit 1; }
+jq -e '.routing | length > 0' <<<"$PROFILE" >/dev/null 2>&1 || { echo "[error] profile validation failed: 'routing' must be a non-empty array"; exit 1; }
+```
+
+Validate baseline agents — `sr-architect`, `sr-developer`, and `sr-reviewer` MUST appear in `agents[]`:
+
+```bash
+for required in sr-architect sr-developer sr-reviewer; do
+  jq -e --arg id "$required" '[.agents[].id] | index($id)' <<<"$PROFILE" >/dev/null 2>&1 \
+    || { echo "[error] profile validation failed: required baseline agent '$required' missing from 'agents[]'"; exit 1; }
+done
+```
+
+Validate routing terminal rule — exactly one entry SHALL have `default: true` and it MUST be the last element:
+
+```bash
+DEFAULT_COUNT="$(jq '[.routing[] | select(.default == true)] | length' <<<"$PROFILE")"
+if [[ "$DEFAULT_COUNT" -ne 1 ]]; then
+  echo "[error] profile validation failed: routing must contain exactly one entry with 'default: true' (found $DEFAULT_COUNT)"; exit 1
+fi
+IS_LAST="$(jq '(.routing | last | .default) == true' <<<"$PROFILE")"
+if [[ "$IS_LAST" != "true" ]]; then
+  echo "[error] profile validation failed: the 'default: true' routing rule must be the last element of 'routing'"; exit 1
+fi
+```
+
+Populate `AVAILABLE_AGENTS` from the profile and verify each referenced agent file exists on disk:
+
+```bash
+AVAILABLE_AGENTS="$(jq -r '.agents[].id' <<<"$PROFILE" | sort)"
+for id in $AVAILABLE_AGENTS; do
+  [[ -f ".claude/agents/$id.md" ]] \
+    || { echo "[error] profile references agent '$id' but .claude/agents/$id.md does not exist"; exit 1; }
+done
+```
+
+Also store per-agent model overrides and the orchestrator model for use in later phases:
+
+```bash
+# ORCHESTRATOR_MODEL is informational; the caller is responsible for spawning
+# the orchestrator with this model (e.g. specrails-hub reads this field directly).
+ORCHESTRATOR_MODEL="$(jq -r '.orchestrator.model' <<<"$PROFILE")"
+
+# Per-agent model overrides keyed by agent id.
+# Consumed by subagent invocation sites in later phases.
+declare -A AGENT_MODEL
+while IFS=$'\t' read -r id model; do
+  [[ -n "$model" && "$model" != "null" ]] && AGENT_MODEL[$id]="$model"
+done < <(jq -r '.agents[] | [.id, (.model // "null")] | @tsv' <<<"$PROFILE")
+
+# Routing rules (array), consumed by Phase 3b.
+ROUTING="$(jq '.routing' <<<"$PROFILE")"
+
+PROFILE_MODE="profile"
+PROFILE_NAME="$(jq -r '.name' <<<"$PROFILE")"
+```
+
+##### Apply per-agent model overrides (profile mode only)
+
+Claude Code's Agent tool determines a subagent's model from the `model:` line in the agent's `.md` frontmatter at invocation time — there is no per-call model parameter. When a profile is active, rewrite each agent's frontmatter `model:` value in-place to match `AGENT_MODEL[$id]`.
+
+This rewrite is safe because:
+- Multi-feature runs execute in **isolated git worktrees** (`isolation: worktree`), so each rail mutates its own copy of `.claude/agents/` without cross-rail contention.
+- Single-feature runs are sequential within a single checkout.
+- The hub writes a job-scoped snapshot of the profile and spawns `claude` with `$SPECRAILS_PROFILE_PATH` pointing at it; the frontmatter rewrite follows the snapshot, never the catalog.
+
+```bash
+for id in "${!AGENT_MODEL[@]}"; do
+  model="${AGENT_MODEL[$id]}"
+  file=".claude/agents/$id.md"
+  [[ -f "$file" ]] || continue
+  # Rewrite the first `model:` line within the frontmatter block (lines between the
+  # first two `---` separators). Use sed with portable syntax (macOS + Linux).
+  awk -v new="$model" '
+    BEGIN { in_fm=0; done=0 }
+    /^---$/ { in_fm = !in_fm; print; next }
+    in_fm && !done && /^model:[[:space:]]/ { print "model: " new; done=1; next }
+    { print }
+  ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+done
+```
+
+If a profile does not declare `model` for a given agent (the field is optional), that agent's frontmatter is left untouched.
+
+##### Legacy mode — preserve current behavior
+
+If no profile is active, scan the agents directory exactly as before:
+
+```bash
+AVAILABLE_AGENTS="$(ls .claude/agents/sr-*.md 2>/dev/null | sed 's|.*/||;s|\.md$||' | sort)"
+PROFILE_MODE="legacy"
+PROFILE_NAME=""
+```
+
+Per-agent model overrides are empty in legacy mode — subagent invocations inherit the `model:` value from each agent's `.md` frontmatter. Routing in Phase 3b uses the hardcoded legacy rules.
+
+##### Agent roles (both modes)
+
+The pipeline adapts dynamically to the installed agents:
+
+| Agent | Role | Required? | Phase(s) affected |
+|-------|------|-----------|-------------------|
+| sr-architect | Architecture & design | **Core** (always present) | 3a |
+| sr-developer | Full-stack implementation | **Core** (always present) | 3b |
+| sr-reviewer | Generalist quality gate | **Core** (always present) | 4b |
+| sr-merge-resolver | Merge conflict resolution | **Core** (always present) | 4a |
+| sr-product-manager | Product exploration | Optional | 1 |
+| sr-test-writer | Test generation | Optional | 3c |
+| sr-doc-sync | Documentation sync | Optional | 3d |
+| sr-frontend-developer | Frontend implementation | Optional | 3b (routing) |
+| sr-backend-developer | Backend implementation | Optional | 3b (routing) |
+| sr-frontend-reviewer | Frontend review | Optional | 4b |
+| sr-backend-reviewer | Backend review | Optional | 4b |
+| sr-security-reviewer | Security analysis | Optional | 4b |
+| sr-performance-reviewer | Performance analysis | Optional | 4b |
+
+**Gate rules** (applied throughout the pipeline):
+- If an optional agent is NOT in `AVAILABLE_AGENTS`, **skip** that phase/sub-step silently and note `"<agent> not installed — skipping"`.
+- Core agents are guaranteed to exist. If a core agent is missing, **STOP** and print: `[error] Core agent <name> not found. Run /specrails:enrich or reinstall.`
+- In **profile mode**, the profile's `agents[]` IS the source of truth for `AVAILABLE_AGENTS`. Agents not listed are considered unavailable regardless of what is on disk.
+
+### Summary
+
+Print a setup report:
+
+```
+## Environment Setup
+| Tool | Status | Notes |
+|------|--------|-------|
+| Backlog provider | ok/missing |  |
+| OpenSpec | ok | ... |
+| Dependencies | ok | ... |
+| Test runner | ok | ... |
+| Agents | N installed | core: 4/4, optional: M |
+```
+
+**Pass `TEST_CMD`, `BACKLOG_AVAILABLE`, and `AVAILABLE_AGENTS` forward** — all later phases must use these.
+
+---
+
+## Phase 0: Parse input and determine mode
+
+### Flag Detection
+
+Before parsing input, scan `$ARGUMENTS` for control flags:
+
+- If `--dry-run` or `--preview` is present in `$ARGUMENTS`:
+  - Set `DRY_RUN=true`
+  - Strip the flag from the arguments before further parsing
+  - Print: `[dry-run] Preview mode active — no git, PR, or backlog operations will run.`
+  - Set `CACHE_DIR=.claude/.dry-run/<kebab-case-feature-name>` (derive after parsing the remaining input)
+  - Note: if a cache already exists at `CACHE_DIR`, print `[dry-run] Overwriting existing cache at CACHE_DIR` before overwriting.
+
+- If `--apply <feature-name>` is present in `$ARGUMENTS`:
+  - Set `APPLY_MODE=true`
+  - Set `APPLY_TARGET=<feature-name>` (the argument immediately following `--apply`)
+  - Set `CACHE_DIR=.claude/.dry-run/<feature-name>`
+  - Verify `CACHE_DIR` exists. If it does not: print `[apply] Error: no cached dry-run found at CACHE_DIR` and stop.
+  - Skip Phases 1–4b. Go directly to Phase 4c (the apply path handles the rest).
+  - Strip `--apply` and the feature name before further parsing.
+
+- If `--confidence-override "<reason>"` is present in `$ARGUMENTS`:
+  - Set `CONFIDENCE_OVERRIDE_REASON=<reason>` (the quoted string immediately following `--confidence-override`)
+  - Strip `--confidence-override` and the reason before further parsing.
+
+If none of these flags is present: `DRY_RUN=false`, `APPLY_MODE=false`, `CONFIDENCE_OVERRIDE_REASON=""`. Pipeline runs as normal.
+
+Note: `CACHE_DIR` for `--dry-run` is finalized after the feature name is derived from the remaining input. All subsequent phases that reference `CACHE_DIR` have access to it.
+
+Initialize conflict-tracking variables:
+- `SNAPSHOTS_CAPTURED=false` — set to true in Phase 0 if issue snapshots are successfully written.
+- `CONFLICT_OVERRIDES=[]` — list of conflict records where the user chose to continue; appended by Phase 3a.0 and Phase 4c.0.
+
+---
+
+**If the user passed a text description** (e.g. `"add feature X"`):
+- **Single-feature mode**. Derive a kebab-case change name.
+- Set `SINGLE_MODE = true`. No worktrees, no parallelism.
+- **Skip Phase 1 and Phase 2** — go directly to Phase 3a.
+
+**If the user passed issue/ticket references** (e.g. `#85, #71` for GitHub, `#1, #2` for local tickets, or `PROJ-85, PROJ-71` for JIRA):
+- Fetch each issue/ticket:
+  ```bash
+  
+  ```
+- Extract area, value, effort, and feature details from each issue body.
+- If only 1 issue: set `SINGLE_MODE = true`.
+- **Skip Phase 1 and Phase 2** — go directly to confirmation table.
+
+#### Phase 0 snapshot capture
+
+After fetching issue refs, capture a baseline snapshot for conflict detection.
+
+##### If `BACKLOG_PROVIDER=local` and input mode was issue numbers:
+
+For each resolved ticket ID, read `.specrails/local-tickets.json` and extract the ticket object at `tickets["{id}"]`.
+
+Build a snapshot object for each ticket:
+- `number`: ticket `id` (integer)
+- `title`: ticket `title` string
+- `state`: map ticket `status` — `"done"` or `"cancelled"` → `"closed"`, otherwise → `"open"`
+- `assignees`: `[ticket.assignee]` if non-null, else `[]`
+- `labels`: ticket `labels` array, sorted alphabetically
+- `body_sha`: SHA-256 of the ticket `description` string — compute with:
+  ```bash
+  echo -n "{description}" | sha256sum | cut -d' ' -f1
+  ```
+  If `sha256sum` is not available, fall back to `openssl dgst -sha256 -r` or `shasum -a 256`.
+- `updated_at`: ticket `updated_at` value
+- `captured_at`: current local time in ISO 8601 format
+
+Write the following JSON to `.claude/backlog-cache.json` (overwrite fully — this establishes a fresh baseline for this run):
+
+```json
+{
+  "schema_version": "1",
+  "provider": "local",
+  "last_updated": "<ISO 8601 timestamp>",
+  "written_by": "implement",
+  "issues": {
+    "<id>": { <snapshot object> },
+    ...
+  }
+}
+```
+
+If the write succeeds: set `SNAPSHOTS_CAPTURED=true`.
+
+If the write fails: print `[backlog-cache] Warning: could not write cache. Conflict detection disabled for this run.` and set `SNAPSHOTS_CAPTURED=false`. Do NOT abort the pipeline.
+
+##### If `GH_AVAILABLE=true` and input mode was issue numbers (GitHub/JIRA):
+
+For each resolved issue number, run:
+
+```bash
+gh issue view {number} --json number,title,state,assignees,labels,body,updatedAt
+```
+
+Build a snapshot object for each issue:
+- `number`: integer issue number
+- `title`: issue title string
+- `state`: `"open"` or `"closed"`
+- `assignees`: array of assignee login names, sorted alphabetically
+- `labels`: array of label names, sorted alphabetically
+- `body_sha`: SHA-256 of the raw body string — compute with:
+  ```bash
+  echo -n "{body}" | sha256sum | cut -d' ' -f1
+  ```
+  If `sha256sum` is not available, fall back to `openssl dgst -sha256 -r` or `shasum -a 256`.
+- `updated_at`: the `updatedAt` value from the GitHub API response
+- `captured_at`: current local time in ISO 8601 format
+
+Write the following JSON to `.claude/backlog-cache.json` (overwrite fully — this establishes a fresh baseline for this run):
+
+```json
+{
+  "schema_version": "1",
+  "provider": "github",
+  "last_updated": "<ISO 8601 timestamp>",
+  "written_by": "implement",
+  "issues": {
+    "<number>": { <snapshot object> },
+    ...
+  }
+}
+```
+
+If the write succeeds: set `SNAPSHOTS_CAPTURED=true`.
+
+If the write fails (e.g., `.claude/` directory does not exist): print `[backlog-cache] Warning: could not write cache. Conflict detection disabled for this run.` and set `SNAPSHOTS_CAPTURED=false`. Do NOT abort the pipeline.
+
+##### Otherwise (no backlog available or non-issue input):
+
+Set `SNAPSHOTS_CAPTURED=false`. Print: `[conflict-check] Snapshot skipped — backlog unavailable or non-issue input.`
+
+#### Gitignore advisory
+
+If `SNAPSHOTS_CAPTURED=true`, check whether `.gitignore` already covers the cache file:
+
+```bash
+grep -q "backlog-cache" .gitignore 2>/dev/null || \
+grep -q "\.claude/" .gitignore 2>/dev/null
+```
+
+If neither pattern is found, print:
+
+```
+[backlog-cache] Suggestion: add '.claude/backlog-cache.json' to .gitignore to avoid committing ephemeral cache state.
+```
+
+This advisory is non-blocking and suppressed when `.gitignore` already covers the file.
+
+#### Pipeline state initialization
+
+Set `PIPELINE_STATE_PATH=.claude/pipeline-state/<feature-name>.json` (use the same kebab-case feature name derived above).
+
+Create the directory if it does not exist:
+
+```bash
+mkdir -p .claude/pipeline-state
+```
+
+Write the initial state file:
+
+```json
+{
+  "schema_version": "1",
+  "feature": "<feature-name>",
+  "started_at": "<current ISO 8601 timestamp>",
+  "updated_at": "<current ISO 8601 timestamp>",
+  "phases": {
+    "architect": "pending",
+    "developer": "pending",
+    "test-writer": "<'pending' if sr-test-writer ∈ AVAILABLE_AGENTS, else 'skipped'>",
+    "doc-sync": "<'pending' if sr-doc-sync ∈ AVAILABLE_AGENTS, else 'skipped'>",
+    "reviewer": "pending",
+    "ship": "pending",
+    "ci": "pending"
+  },
+  "last_successful_phase": null,
+  "failed_phase": null,
+  "error_context": null,
+  "openspec_artifacts": "openspec/changes/<feature-name>/",
+  "implemented_files": [],
+  "input": {
+    "issues": [<issue numbers, or null for text-description mode>],
+    "flags": {
+      "dry_run": <DRY_RUN>,
+      "apply_mode": <APPLY_MODE>,
+      "single_mode": <SINGLE_MODE>
+    }
+  }
+}
+```
+
+If the write fails: print `[pipeline-state] Warning: could not write state file. Smart retry (/specrails:retry) will not be available for this run.` Set `PIPELINE_STATE_AVAILABLE=false`. Do NOT abort the pipeline.
+
+If the write succeeds: set `PIPELINE_STATE_AVAILABLE=true`.
+
+**State update helper** — used by all subsequent phases to record progress:
+
+When a phase completes or fails, update `PIPELINE_STATE_PATH`:
+1. Read the current file.
+2. Set `phases.<phase-key>` to `"done"`, `"failed"`, or `"skipped"`.
+3. If `"done"`: set `last_successful_phase` to the phase key.
+4. If `"failed"`: set `failed_phase` to the phase key; set `error_context` to a one-line description of the failure (agent name, error type, exit code if known).
+5. Set `updated_at` to the current ISO 8601 timestamp.
+6. Overwrite the file.
+
+If `PIPELINE_STATE_AVAILABLE=false`: skip all state updates silently.
+
+**If the user passed area names**:
+- Check for open backlog issues. If found, filter and pick top 3.
+- If none, proceed to Phase 1.
+
+---
+
+## Phase 1: Explore (parallel)
+
+**Only runs if Phase 0 found no backlog issues AND user passed area names AND `sr-product-manager` ∈ `AVAILABLE_AGENTS`.**
+
+If `sr-product-manager` is not installed, skip Phase 1 and Phase 2 entirely. Print: `[phase-1] sr-product-manager not installed — skipping exploration. Proceeding with provided input.`
+
+For each area, launch a **sr-product-manager** agent (`subagent_type: sr-product-manager`, `run_in_background: true`).
+
+Wait for all to complete. Read their output.
+
+## Phase 2: Select
+
+**Only runs if Phase 1 ran.**
+
+Pick the single idea with the best impact/effort ratio from each exploration. Present to user and wait for confirmation.
+
+## Phase 3a.0: Pre-architect conflict check
+
+**Guard:** If `SNAPSHOTS_CAPTURED=false` OR `DRY_RUN=true`, print `[conflict-check] Skipped — SNAPSHOTS_CAPTURED=false (or dry-run mode).` and proceed directly to Phase 3a.
+
+Otherwise, re-fetch each issue in scope and diff against the Phase 0 snapshot:
+
+**If `BACKLOG_PROVIDER=local`:** For each ticket ID in `ISSUE_REFS`, read `.specrails/local-tickets.json` and extract the ticket at `tickets["{id}"]`. If the ticket does not exist (deleted): treat as a CRITICAL conflict — field `"state"`, was `<cached state>`, now `"deleted"`. Otherwise, reconstruct a current snapshot using the same mapping as the Phase 0 local snapshot.
+
+**If `BACKLOG_PROVIDER=github`:** For each issue number in `ISSUE_REFS`:
+
+```bash
+gh issue view {number} --json number,title,state,assignees,labels,body,updatedAt
+```
+
+If the `gh` command returns non-zero (issue deleted or inaccessible): treat as a CRITICAL conflict — field `"state"`, was `<cached state>`, now `"deleted"`.
+
+In both cases, reconstruct a current snapshot (same shape as Phase 0: sort `assignees` and `labels`, compute `body_sha`).
+
+**Short-circuit:** If `current.updatedAt == cached.updated_at`, mark the issue as clean and skip field comparison.
+
+**Field comparison** (only when `updatedAt` differs):
+
+| Field | Conflict if... | Severity |
+|-------|----------------|----------|
+| `state` | value differs (`open` → `closed`) | CRITICAL |
+| `state` | value differs (`closed` → `open`) | WARNING |
+| `title` | string differs | WARNING |
+| `assignees` | sorted array differs | WARNING |
+| `labels` | sorted array differs | INFO |
+| `body_sha` | SHA differs | WARNING |
+
+Collect all conflicts across all issues. If none: print `[conflict-check] All issues clean (Phase 3a.0). Proceeding.` and continue to Phase 3a.
+
+**If conflicts exist**, print the following report and await user input:
+
+```
+## Backlog Conflict Detected
+
+The following issues changed since Phase 0 snapshot (captured at <captured_at>):
+
+| Issue | Field | Severity | Was | Now |
+|-------|-------|----------|-----|-----|
+| #N    | state | CRITICAL | open | closed |
+| #N    | body  | WARNING  | <sha-prefix> | <sha-prefix> |
+
+How would you like to proceed?
+  [A] Abort — stop the pipeline and exit cleanly
+  [C] Continue — proceed despite the conflicts (logged)
+
+Enter A or C:
+```
+
+For `body_sha` rows in the table, display only the first 8 characters of each SHA as the "Was" and "Now" values.
+
+**Input handling:**
+- Accept `A`, `a` (abort) or `C`, `c` (continue).
+- Re-prompt on any other input, up to 3 times total.
+- After 3 invalid inputs: print `[conflict-abort] Defaulting to abort after 3 invalid inputs.` and abort.
+
+**On abort:** Print `[conflict-abort] Pipeline aborted. Re-run /specrails:implement after resolving the issues.` and exit. No git state is left behind.
+
+**On continue:** Print `[conflict-override] Continuing. N conflict(s) logged.` Append each conflict to `CONFLICT_OVERRIDES` as `{phase: "3a.0", issue: "#N", field: "<field>", severity: "<severity>", was: "<was>", now: "<now>"}`. Proceed to Phase 3a.
+
+## Phase 3a: Architect (parallel, in main repo)
+
+For each chosen idea, launch an **sr-architect** agent (`subagent_type: sr-architect`, `run_in_background: true`).
+
+Each architect creates OpenSpec artifacts in `openspec/changes/<name>/`.
+
+Each agent's prompt should include:
+- Description of the feature
+- Context from exploration (if applicable)
+- Instructions to create: proposal.md, design.md, delta-spec, tasks.md, context-bundle.md
+- Tags for each task: 
+
+### 3a.1 Identify shared file conflicts
+
+**Only runs in multi-feature mode** (more than one feature). Skip entirely if `SINGLE_MODE=true`.
+
+After all architect agents complete, before launching any developer agent:
+
+#### Step 1: Extract file references
+
+For each `openspec/changes/<name>/tasks.md`, extract all paths listed under `**Files:**` entries (both `Create:` and `Modify:` lines). Normalize paths: strip leading `./`.
+
+#### Step 2: Build the shared-file registry
+
+Group file paths across all features. Any path appearing in two or more features' task lists is a **shared file**. Store as `SHARED_FILES` map: `{path: {features: [...], risk: ""}}`.
+
+#### Step 3: Classify risk
+
+For each shared file, classify risk based on file type and which regions each feature modifies (consult each feature's context-bundle.md "Exact Changes" section):
+
+| Risk | Condition |
+|------|-----------|
+| `low` | Both features only append new named sections not present in the other feature's changes |
+| `medium` | Both features modify structurally distinct regions (different `##` sections or different top-level YAML keys) |
+| `high` | Both features modify the same region (same `##` section, same YAML key subtree, or any region in shell scripts) |
+
+Shell scripts (`.sh`, `.bash`): always `high`.
+Non-existent files that two features both create: always `high`.
+
+#### Step 4: Derive MERGE_ORDER
+
+Sort features so that for any pair sharing a `high`-risk file, one appears before the other. Use topological sort; break ties alphabetically. Set `MERGE_ORDER` = sorted feature list.
+
+#### Step 5: Print pre-flight report
+
+```
+## Shared File Analysis
+
+| File | Features | Risk |
+|------|----------|------|
+| <path> | <feature-a>, <feature-b> | <risk> |
+
+Merge order: <feature-a> → <feature-b> → <feature-c>
+
+High-risk files detected. These files will be merged sequentially.
+Developers will still run in parallel — merge order applies at Phase 4a only.
+```
+
+If no shared files: print `No shared files detected. All features modify independent files.`
+
+### 3a.2 Pre-validate architect output
+
+Quick-check each architect's artifacts:
+1. tasks.md exists and has tasks
+2. context-bundle.md exists
+3. File references are real (>70% must exist)
+4. Layer tags present on tasks
+
+**Pipeline state:** update `architect` → `done`. If any architect agent failed (skipped area): update `architect` → `failed` with error context `"sr-architect failed for: <area-names>"`.
+
+## Phase 3b: Implement
+
+### Pre-flight: Verify Bash permission
+
+Before launching any developer agent, run a trivial Bash command to confirm Bash is allowed.
+
+### Launch developers
+
+**Read reviewer learnings:** Check `.claude/agent-memory/sr-reviewer/common-fixes.md` and include in developer prompts.
+
+#### Dry-Run: Redirect developer writes
+
+**If `DRY_RUN=true`**, include the following in every developer agent prompt:
+
+> IMPORTANT: This is a dry-run. Write all new or modified files under:
+>   .claude/.dry-run/\<feature-name\>/
+>
+> Mirror the real destination path within this directory. For example:
+>   Real path:   src/utils/parser.ts
+>   Write to:    .claude/.dry-run/\<feature-name\>/src/utils/parser.ts
+>
+> Do NOT write to real file paths. After writing each file, append an entry
+> to .claude/.dry-run/\<feature-name\>/.cache-manifest.json using this JSON format:
+>   {"cached_path": "...", "real_path": "...", "operation": "create|modify"}
+
+**If `DRY_RUN=false`**: developer agent instructions are unchanged.
+
+#### Choosing the right developer agent
+
+For each feature, read `openspec/changes/<name>/tasks.md` and classify every task by its layer tags and file references.
+
+**Step 1 — Classify tasks into layers:**
+
+For each task, determine its layer from:
+1. **Explicit layer tags** in tasks.md (e.g., `[frontend]`, `[backend]`, `[core]`, `[infra]`, `[docs]`, etc.)
+2. **File references** under `**Files:**` entries — apply the same extension/path rules used in Phase 4b:
+   - Frontend: `.jsx`, `.tsx`, `.vue`, `.svelte`, `.css`, `.scss`, `.html`, or paths under `components/`, `pages/`, `views/`, `ui/`, `client/`, `frontend/`, `app/`, `public/`, `static/`, `assets/`
+   - Backend: `.py`, `.go`, `.java`, `.rb`, `.php`, `.rs`, `.cs`, `.sql`, or paths under `server/`, `api/`, `routes/`, `controllers/`, `services/`, `models/`, `db/`, `backend/`, `migrations/`
+   - Mixed/other: everything else (shell scripts, config files, markdown, YAML, etc.)
+
+Produce three sets: `FRONTEND_TASKS`, `BACKEND_TASKS`, `OTHER_TASKS`.
+
+**Step 2 — Route tasks to developer agents:**
+
+Routing operates in one of two modes depending on the value of `PROFILE_MODE` set in Phase -1.
+
+##### Profile mode (`PROFILE_MODE=profile`)
+
+When a profile is active, apply `ROUTING` rules in their array order. For each task, collect its tag set (layer tags plus any explicit `[tag]` markers in tasks.md). The first rule whose `tags` array intersects the task's tag set wins. The terminal `default: true` rule catches tasks matched by no earlier rule.
+
+Example (pseudocode):
+
+```bash
+assigned_agent_for_task() {
+  local -a task_tags=("$@")
+  local rule_count
+  rule_count=$(jq 'length' <<<"$ROUTING")
+  local i=0
+  while [[ $i -lt $rule_count ]]; do
+    local is_default rule_tags agent
+    is_default=$(jq -r ".[$i].default // false" <<<"$ROUTING")
+    agent=$(jq -r ".[$i].agent" <<<"$ROUTING")
+    if [[ "$is_default" == "true" ]]; then
+      echo "$agent"
+      return
+    fi
+    rule_tags=$(jq -r ".[$i].tags[]" <<<"$ROUTING")
+    for rtag in $rule_tags; do
+      for ttag in "${task_tags[@]}"; do
+        if [[ "$rtag" == "$ttag" ]]; then
+          echo "$agent"
+          return
+        fi
+      done
+    done
+    i=$((i + 1))
+  done
+}
+```
+
+Produce `DEVELOPER_ROUTING` from the per-task decisions, grouping by assigned agent. An agent assigned by the profile SHALL only be used if it also appears in `AVAILABLE_AGENTS` (the profile's own `agents[]`). If the profile routes a task to an agent not present in `agents[]`, that is a profile configuration bug — **STOP** and print: `[error] profile routing references agent '<id>' which is not declared in profile.agents[]`.
+
+##### Legacy mode (`PROFILE_MODE=legacy`)
+
+When no profile is active, evaluate available developer agents in `AVAILABLE_AGENTS` and apply these hardcoded rules in priority order:
+
+| Condition | Agent(s) selected | Mode |
+|-----------|-------------------|------|
+| ALL tasks are frontend-only AND `sr-frontend-developer` ∈ `AVAILABLE_AGENTS` | **sr-frontend-developer** | Single agent for all tasks |
+| ALL tasks are backend-only AND `sr-backend-developer` ∈ `AVAILABLE_AGENTS` | **sr-backend-developer** | Single agent for all tasks |
+| Mix of frontend + backend tasks AND both layer-specific developers available | **sr-frontend-developer** for `FRONTEND_TASKS`, **sr-backend-developer** for `BACKEND_TASKS`, **sr-developer** for `OTHER_TASKS` | Parallel agents per layer |
+| Frontend tasks exist AND `sr-frontend-developer` available, but no backend-specific developer | **sr-frontend-developer** for `FRONTEND_TASKS`, **sr-developer** for remaining | Parallel agents |
+| Backend tasks exist AND `sr-backend-developer` available, but no frontend-specific developer | **sr-backend-developer** for `BACKEND_TASKS`, **sr-developer** for remaining | Parallel agents |
+| No layer-specific developers available (fallback) | **sr-developer** | Single agent for all tasks |
+
+Store the result as `DEVELOPER_ROUTING`: a map of `{agent_id: [task_list]}`.
+
+##### Routing trace (both modes)
+
+After computing `DEVELOPER_ROUTING`, optionally emit a trace line to aid debugging:
+
+```
+[phase-3b] routing decision: mode=$PROFILE_MODE profile=${PROFILE_NAME:-none} agents=[list]
+```
+
+**Step 3 — Print routing decision:**
+
+```
+## Developer Routing
+
+| Agent | Tasks | Reason |
+|-------|-------|--------|
+| sr-frontend-developer | Task 1, Task 3 | Frontend-only tasks (React components) |
+| sr-backend-developer  | Task 2, Task 4 | Backend-only tasks (API endpoints) |
+| sr-developer          | Task 5         | Mixed layer (config + infra) |
+```
+
+Also store `DEVELOPER_AGENTS_USED` (the set of developer agent IDs actually launched) — Phase 4b will use this for reviewer selection.
+
+#### Launch modes
+
+For each entry in `DEVELOPER_ROUTING`, launch the assigned developer agent using its `subagent_type` (`sr:developer`, `sr:frontend-developer`, or `sr:backend-developer`) with its task subset.
+
+**If `SINGLE_MODE` and only one agent in routing**: Launch in the main repo, foreground.
+**If `SINGLE_MODE` but multiple agents in routing**: Launch agents sequentially in the main repo (one at a time, foreground), passing only their assigned tasks.
+**If multiple features**: Launch in isolated worktrees (`isolation: worktree`, `run_in_background: true`).
+
+Wait for all developers to complete.
+
+**Summary timing (multi-feature mode):** When running multiple background developer agents, individual `task_notification` completions MUST NOT trigger a final Phase 3b summary. As each agent completes, emit only a brief one-line acknowledgment:
+```
+[phase-3b] Developer for <feature> ✓ (<N> tool uses, <duration>)
+```
+Only after the LAST background agent sends its completion notification, emit the consolidated summary:
+```
+## Phase 3b Complete
+
+| Feature | Agent | Tool uses | Duration |
+|---------|-------|-----------|----------|
+| <feature-a> | sr-developer | 64 | 8m 02s |
+| <feature-b> | sr-developer | 50 | 7m 35s |
+
+All N developers complete. Proceeding to Phase 3c.
+```
+
+This prevents stale "still waiting" text from appearing as the terminal result when the job completes.
+
+**Pipeline state:** update `developer` → `done`. Also update `implemented_files` in the state file with the complete list of files created or modified by the developer agent(s). If developer failed: update `developer` → `failed` with error context `"<agent-id> failed: <exit code or error description>"`.
+
+## Phase 3c: Write Tests
+
+**Guard:** If `sr-test-writer` ∉ `AVAILABLE_AGENTS`, skip this phase. Print: `[phase-3c] sr-test-writer not installed — skipping test generation.` Update pipeline state: `test-writer` → `skipped`. Proceed to Phase 3d.
+
+Launch a **sr-test-writer** agent (`subagent_type: sr:test-writer`) for each feature immediately after its developer completes.
+
+Construct the agent invocation prompt to include:
+- **IMPLEMENTED_FILES_LIST**: the complete list of files the developer created or modified for this feature
+- **TASK_DESCRIPTION**: the original task or feature description that drove the implementation
+
+### Launch modes
+
+**If `SINGLE_MODE`**: Launch a single sr-test-writer agent in the foreground (`run_in_background: false`). Wait for it to complete before proceeding to Phase 4.
+
+**If multiple features (worktrees)**: Launch one sr-test-writer agent per feature, each in its corresponding worktree (`isolation: worktree`, `run_in_background: true`). Wait for all sr-test-writer agents to complete before proceeding to Phase 4.
+
+### Dry-run behavior
+
+**If `DRY_RUN=true`**, include in every test-writer agent prompt:
+
+> IMPORTANT: This is a dry-run. Write all new or modified test files under:
+>   .claude/.dry-run/\<feature-name\>/
+>
+> Mirror the real destination path within this directory. After writing each file, append an entry
+> to .claude/.dry-run/\<feature-name\>/.cache-manifest.json using:
+>   {"cached_path": "...", "real_path": "...", "operation": "create"}
+
+### Failure handling
+
+If a test-writer agent fails or times out:
+- Record `Tests: FAILED` for that feature in the Phase 4e report
+- Continue to Phase 4 — the sr-test-writer failure is non-blocking
+- Include in the reviewer agent prompt: "Note: the sr-test-writer failed for this feature. Check for coverage gaps."
+
+**Pipeline state:** update `test-writer` → `done` (or `failed` with error context `"sr-test-writer timed out or errored"`). Failure does not block the pipeline.
+
+## Phase 3d: Doc Sync
+
+**Guard:** If `sr-doc-sync` ∉ `AVAILABLE_AGENTS`, skip this phase. Print: `[phase-3d] sr-doc-sync not installed — skipping doc sync.` Update pipeline state: `doc-sync` → `skipped`. Proceed to Phase 4.
+
+Launch a **sr-doc-sync** agent (`subagent_type: sr:doc-sync`) for each feature after its tests are written.
+
+Construct the agent invocation prompt to include:
+- **IMPLEMENTED_FILES_LIST**: the complete list of files the developer created or modified for this feature
+- **TASK_DESCRIPTION**: the original task or feature description that drove the implementation
+
+### Launch modes
+
+**If `SINGLE_MODE`**: Launch a single sr-doc-sync agent in the foreground (`run_in_background: false`). Wait for it to complete before proceeding to Phase 4.
+
+**If multiple features (worktrees)**: Launch one sr-doc-sync agent per feature, each in its corresponding worktree (`isolation: worktree`, `run_in_background: true`). Wait for all sr-doc-sync agents to complete before proceeding to Phase 4.
+
+### Dry-run behavior
+
+**If `DRY_RUN=true`**, include in every doc-sync agent prompt:
+
+> IMPORTANT: This is a dry-run. Write all new or modified doc files under:
+>   .claude/.dry-run/\<feature-name\>/
+>
+> Mirror the real destination path within this directory. After writing each file, append an entry
+> to .claude/.dry-run/\<feature-name\>/.cache-manifest.json using:
+>   {"cached_path": "...", "real_path": "...", "operation": "create|modify"}
+
+### Failure handling
+
+If a doc-sync agent fails or times out:
+- Record `Docs: FAILED` for that feature in the Phase 4e report
+- Continue to Phase 4 — the sr-doc-sync failure is non-blocking
+- Include in the reviewer agent prompt: "Note: the sr-doc-sync agent failed for this feature."
+
+**Pipeline state:** update `doc-sync` → `done` (or `failed` with error context `"sr-doc-sync timed out or errored"`). Failure does not block the pipeline.
+
+## Phase 4: Merge & Review
+
+**This phase is fully autonomous.**
+
+### 4a. Merge worktree changes to main repo
+
+- If `SINGLE_MODE`: skip (no worktrees were used). Proceed to Phase 4b.
+- If `DRY_RUN=true`: apply the merge algorithm below, writing all outputs to `CACHE_DIR/<file-path>` instead of the main repo working tree. Do NOT clean up worktrees in dry-run mode.
+- Otherwise: apply the merge algorithm below, writing outputs to the main repo working tree. Clean up worktrees at the end.
+
+#### Merge Algorithm
+
+Process features in `MERGE_ORDER` sequence. For each feature:
+
+**Step 1: Identify changed files**
+
+```bash
+git -C <worktree-path> diff main --name-only
+```
+
+Split into `exclusive_files` (only this feature modifies them) and `shared_files_for_this_feature` (also modified by another feature in MERGE_ORDER).
+
+**Step 2: Merge exclusive files**
+
+Copy directly from worktree to target:
+```bash
+cp <worktree-path>/<file> <target>/<file>
+```
+Log: `Copied (exclusive): <file>`
+
+**Step 3: Merge shared files**
+
+For each shared file, choose strategy by file type:
+
+**Strategy A — Markdown section-aware merge** (`.md` files):
+1. Read base: current content of `<target>/<file>`.
+2. Read incoming: `<worktree-path>/<file>`.
+3. Parse both into sections using `##` heading boundaries (heading line + all content until next `##` or EOF).
+4. Build section maps: `{heading_text: content}` for base and incoming.
+5. Merge:
+   - Section in base only: keep.
+   - Section in incoming only: append to merged output.
+   - Section in both, content identical: keep base.
+   - Section in both, content differs: insert conflict markers:
+     ```
+     <<<<<<< <feature-name>
+     <incoming section content>
+     =======
+     <base section content>
+     >>>>>>> base
+     ```
+     Log: `CONFLICT: <file> — section "<heading>" requires manual resolution.`
+6. Write merged result to `<target>/<file>`.
+
+**Strategy B — Unified diff sequential apply** (all other file types):
+1. Generate incoming diff against original `main`:
+   ```bash
+   git -C <worktree-path> diff main -- <file>
+   ```
+2. Apply to current target:
+   ```bash
+   patch --forward --fuzz=3 <target>/<file> < <diff>
+   ```
+3. If `patch` succeeds: log `Merged (diff-apply): <file>`.
+4. If `patch` fails: insert conflict markers around rejected hunks. Log: `CONFLICT: <file> — N hunks rejected.`
+
+If `patch` is not available (detected in Phase -1): use Strategy A for all file types and print: `[warn] patch not available — using section-aware fallback for all shared files.`
+
+**Step 4: Record outcomes**
+
+Maintain `MERGE_REPORT`:
+- `cleanly_merged`: exclusive files + shared files with no conflicts
+- `auto_resolved`: shared files merged without conflict markers
+- `requires_resolution`: `{file, feature, regions}` for files with conflict markers
+
+**Step 5: Emit initial merge report**
+
+After all features are processed, print the preliminary report:
+
+```
+## Phase 4a Merge Report (preliminary)
+
+### Cleanly Merged
+- <file> (exclusive to <feature>)
+
+### Auto-Resolved
+- <file> (features: <a>, <b> — distinct sections)
+
+### Requires Resolution (N file(s))
+- <file> (features: <a>, <b> — conflicting section: "<heading>")
+```
+
+**Step 5a: Smart conflict resolution** (skip if `SINGLE_MODE=true` or `DRY_RUN=true` or `sr-merge-resolver` ∉ `AVAILABLE_AGENTS`)
+
+If `sr-merge-resolver` is not installed, print: `[smart-merge] sr-merge-resolver not installed — skipping automatic resolution. Fix conflicts manually.` and skip to Step 5b.
+
+If `MERGE_REPORT.requires_resolution` is non-empty:
+
+```
+[smart-merge] N file(s) have conflict markers. Launching sr-merge-resolver…
+```
+
+Build `CONTEXT_BUNDLES` from the features in `MERGE_ORDER`:
+```
+{ "<feature-a>": "openspec/changes/<feature-a>/context-bundle.md", "<feature-b>": "openspec/changes/<feature-b>/context-bundle.md" }
+```
+
+Load merge resolver config from `.claude/merge-resolver-config.json` if it exists. Extract `confidence_threshold` (default: 70) and `mode` (default: `auto`).
+
+Construct the `sr-merge-resolver` agent prompt with:
+- `CONFLICTED_FILES`: all file paths in `MERGE_REPORT.requires_resolution`
+- `CONTEXT_BUNDLES`: the map above
+- `CONFIDENCE_THRESHOLD`: from config or default (70)
+- `RESOLUTION_MODE`: from config or default (`auto`)
+- `REPORT_PATH`: `openspec/changes/<first-feature-in-MERGE_ORDER>/merge-resolution-report.md`
+
+Launch the **sr-merge-resolver** agent (`subagent_type: sr-merge-resolver`, foreground, `run_in_background: false`). Wait for it to complete.
+
+Read `MERGE_RESOLUTION_STATUS` from the agent's output (`CLEAN`, `PARTIAL`, or `UNRESOLVED`).
+
+**Post-resolution: update MERGE_REPORT**
+
+For each file in `MERGE_REPORT.requires_resolution`:
+- Re-scan the file for remaining `<<<<<<<` markers.
+- If none remain: move the file from `requires_resolution` → `auto_resolved` (with note: `smart-resolver`).
+- If markers remain: keep in `requires_resolution`.
+
+**Step 5b: Emit final merge report**
+
+```
+## Phase 4a Merge Report
+
+### Cleanly Merged
+- <file> (exclusive to <feature>)
+
+### Auto-Resolved
+- <file> (features: <a>, <b> — distinct sections)
+- <file> (smart-resolver: additive-concat, confidence 92)
+
+### Requires Manual Resolution
+- <file> (features: <a>, <b> — low-confidence: see merge-resolution-report.md)
+  Search for `<<<<<<< <feature-name>` to locate conflict markers.
+
+Pipeline will continue. Fix remaining conflicts before the reviewer runs CI.
+Resolution report: openspec/changes/<feature>/merge-resolution-report.md
+```
+
+If `MERGE_REPORT.requires_resolution` is now empty: print `All conflicts resolved by smart resolver.` and omit the "Requires Manual Resolution" section.
+
+**Step 6: Clean up worktrees** (skip if `DRY_RUN=true`)
+
+```bash
+git worktree remove <worktree-path> --force
+```
+
+Pass `MERGE_REPORT` to the Phase 4b reviewer agent prompt, listing any files in `requires_resolution`. If the smart resolver ran, also pass the path to `merge-resolution-report.md` so the reviewer can inspect resolution decisions for correctness.
+
+### 4b. Layer Dispatch and Review
+
+#### Step 1: Layer Classification
+
+Before launching any reviewer, classify `MODIFIED_FILES_LIST` into layer-specific file sets.
+
+**Frontend files** — a file is frontend if any of these conditions match:
+- Extension is one of: `.jsx`, `.tsx`, `.vue`, `.svelte`, `.css`, `.scss`, `.sass`, `.less`, `.html`, `.htm`
+- Extension is `.js` or `.ts` AND path contains one of: `components/`, `pages/`, `views/`, `ui/`, `client/`, `frontend/`, `app/`
+- Path starts with: `public/`, `static/`, `assets/`
+
+Set `FRONTEND_FILES` = files matching frontend rules.
+
+**Backend files** — a file is backend if any of these conditions match:
+- Extension is one of: `.py`, `.go`, `.java`, `.rb`, `.php`, `.rs`, `.cs`, `.sql`
+- Extension is `.js` or `.ts` AND path contains one of: `server/`, `api/`, `routes/`, `controllers/`, `services/`, `models/`, `db/`, `backend/`
+- Path is under: `migrations/`, `alembic/`, `db/migrate/`
+
+Set `BACKEND_FILES` = files matching backend rules.
+
+**Overlap rule:** a file may appear in both `FRONTEND_FILES` and `BACKEND_FILES` (e.g., a Next.js API route at `pages/api/`). Both reviewers will scan it independently.
+
+#### Step 2: Determine which reviewers to launch
+
+A layer reviewer is launched when **both** conditions are met:
+1. There are files to review for that layer (file classification) **OR** the corresponding layer developer was used in Phase 3b (`DEVELOPER_AGENTS_USED`)
+2. The reviewer agent is installed (`∈ AVAILABLE_AGENTS`)
+
+| Reviewer | Launch condition | Skip reason |
+|----------|-----------------|-------------|
+| sr-frontend-reviewer | (`FRONTEND_FILES` non-empty OR `sr-frontend-developer` ∈ `DEVELOPER_AGENTS_USED`) AND installed | No frontend files + no frontend developer used, or not installed |
+| sr-backend-reviewer | (`BACKEND_FILES` non-empty OR `sr-backend-developer` ∈ `DEVELOPER_AGENTS_USED`) AND installed | No backend files + no backend developer used, or not installed |
+| sr-security-reviewer | Installed | Not installed |
+| sr-performance-reviewer | Installed | Not installed |
+
+If a reviewer is skipped, set its report variable to `"SKIPPED"` and note the reason.
+
+#### Step 3: Launch Layer Reviewers in Parallel
+
+Launch all applicable layer reviewers in parallel (`run_in_background: true`), using the corresponding `subagent_type` for each (`sr:frontend-reviewer`, `sr:backend-reviewer`, `sr:security-reviewer`, `sr:performance-reviewer`):
+
+**sr-frontend-reviewer** (`subagent_type: sr:frontend-reviewer`, if applicable per Step 2):
+- Pass `FRONTEND_FILES_LIST`: the list of files in `FRONTEND_FILES`
+- Pass `PIPELINE_CONTEXT`: brief description of what was implemented
+
+**sr-backend-reviewer** (`subagent_type: sr:backend-reviewer`, if applicable per Step 2):
+- Pass `BACKEND_FILES_LIST`: the list of files in `BACKEND_FILES`
+- Pass `PIPELINE_CONTEXT`: brief description of what was implemented
+
+**sr-security-reviewer** (`subagent_type: sr:security-reviewer`, if applicable per Step 2):
+- Pass `MODIFIED_FILES_LIST`: the complete list of all files created or modified during this run
+- Pass `PIPELINE_CONTEXT`: brief description of what was implemented
+- Pass the exemptions config path: `.claude/security-exemptions.yaml`
+
+**sr-performance-reviewer** (`subagent_type: sr:performance-reviewer`, if applicable per Step 2):
+- Pass `MODIFIED_FILES_LIST`: the complete list of all files created or modified during this run
+- Pass `PIPELINE_CONTEXT`: brief description of what was implemented
+
+Wait for all launched layer reviewers to complete before proceeding to Step 4.
+
+Parse status lines from each completed reviewer:
+- `FRONTEND_REVIEW_STATUS: ISSUES_FOUND` or `CLEAN` → set `FRONTEND_STATUS`
+- `BACKEND_REVIEW_STATUS: ISSUES_FOUND` or `CLEAN` → set `BACKEND_STATUS`
+- `SECURITY_STATUS: BLOCKED | WARNINGS | CLEAN` → set `SECURITY_BLOCKED=true` if `BLOCKED`, otherwise `false`
+
+If a layer reviewer fails or times out: set the relevant report variable to `"ERROR: reviewer did not complete"` and continue.
+
+#### Step 4: Launch Generalist Reviewer
+
+Construct the generalist reviewer's invocation prompt with layer reports injected. Set each variable to the full output of the corresponding reviewer, or to the string `"SKIPPED"` if that reviewer was not launched:
+
+- `FRONTEND_REVIEW_REPORT`: full output of frontend-reviewer (or `"SKIPPED"`)
+- `BACKEND_REVIEW_REPORT`: full output of backend-reviewer (or `"SKIPPED"`)
+- `SECURITY_REVIEW_REPORT`: full output of security-reviewer
+
+Include in the reviewer prompt:
+- Full CI commands
+- Cross-feature merge issue checks
+- Instruction to record learnings to `common-fixes.md`
+- Instruction to archive completed changes via OpenSpec
+- The three layer report variables substituted into the `[injected]` slots in the reviewer agent template
+
+Note: if total layer report length is very large, truncate each layer report to its findings tables only (omit skipped-file logs) to stay within prompt limits.
+
+**The security gate (blocking ship on `SECURITY_STATUS: BLOCKED`) is enforced in Phase 4c.** Do not apply it here.
+
+Launch the **sr-reviewer** agent (`subagent_type: sr:reviewer`, foreground, `run_in_background: false`). Wait for it to complete.
+
+**Pipeline state:** update `reviewer` → `done` (or `failed` with error context `"sr-reviewer timed out or did not complete"` if the agent errored out).
+
+**If `DRY_RUN=true`**, add the following to the reviewer agent prompt:
+
+> Note: This is a dry-run review. Developer files are under .claude/.dry-run/\<feature-name\>/.
+> Read modified files from there. Write any reviewer fixes back to CACHE_DIR (not real paths).
+> CI commands may be run — they read the real repo, but be aware developer changes are not
+> yet applied to real paths.
+
+### 4b-conf. Confidence Gate
+
+After the generalist reviewer agent completes, evaluate the confidence score before proceeding to Phase 4c.
+
+**In multi-feature mode (worktrees):** run this gate once per feature immediately after that feature's reviewer completes. Each feature is evaluated independently — a block on one feature does not prevent another feature's gate from running.
+
+#### Step 1 — Read score file
+
+Path: `openspec/changes/<name>/confidence-score.json`
+
+- If the file does not exist:
+  - Set `CONFIDENCE_STATUS=MISSING`
+  - Print: `[confidence] Warning: confidence-score.json not found. Proceeding without gate.`
+  - Continue to Phase 4c.
+
+#### Step 2 — Read config
+
+Path: `.claude/confidence-config.json`
+
+- If the file does not exist:
+  - Use built-in defaults (overall: 70; type_correctness: 60; pattern_adherence: 60; test_coverage: 60; security: 75; architectural_alignment: 60).
+  - Print:
+    ```
+    [confidence] No confidence-config.json found. Using built-in defaults.
+    [confidence] To customize thresholds, create .claude/confidence-config.json.
+    ```
+- If `enabled: false` in the config:
+  - Print: `[confidence] Gate disabled. Skipping.`
+  - Set `CONFIDENCE_STATUS=DISABLED`
+  - Continue to Phase 4c.
+
+#### Step 3 — Compare scores
+
+- Check `overall` against `thresholds.overall`.
+- Check each of the five aspects against `thresholds.aspects.<aspect>`.
+- Collect all breaches as a list: `{aspect, actual_score, threshold, delta}`.
+
+#### Step 4 — Apply on_breach
+
+**If no breaches:**
+- Print: `[confidence] All scores meet thresholds. Proceeding.`
+- Set `CONFIDENCE_STATUS=PASS`
+- Continue to Phase 4c.
+
+**If breaches exist and `on_breach: "block"`:**
+
+1. Check for `--confidence-override`:
+   - If `CONFIDENCE_OVERRIDE_REASON` is non-empty and `override_allowed: true` in the config:
+     - Print: `[confidence] Override accepted. Reason: <CONFIDENCE_OVERRIDE_REASON>. Proceeding with gate bypassed.`
+     - Set `CONFIDENCE_STATUS=OVERRIDE`
+     - Continue to Phase 4c.
+   - If `CONFIDENCE_OVERRIDE_REASON` is non-empty but `override_allowed: false` in the config:
+     - Print: `[confidence] Override is disabled in confidence-config.json.`
+     - (Fall through to block below.)
+   - If `CONFIDENCE_OVERRIDE_REASON` is empty or override was rejected:
+     - Print the Breach Report (see format below).
+     - Set `CONFIDENCE_BLOCKED=true`
+     - Set `CONFIDENCE_STATUS=BLOCKED`
+     - **Halt: do not proceed to Phase 4c.**
+
+**If breaches exist and `on_breach: "warn"`:**
+- Print the Breach Report.
+- Set `CONFIDENCE_STATUS=WARN`
+- Continue to Phase 4c.
+
+#### Breach Report Format
+
+```
+## Confidence Gate: BLOCKED
+
+The reviewer's confidence scores do not meet configured thresholds.
+
+| Aspect | Score | Threshold | Delta |
+|--------|-------|-----------|-------|
+| <aspect> | <actual> | <threshold> | <delta (negative)> |
+
+### Reviewer Notes on Low-Scoring Aspects
+
+**<aspect> (<score>):** <note from confidence-score.json>
+
+### Flags
+
+- <flag-1>
+- <flag-2>
+(omit this section if flags array is empty)
+
+### Next Steps
+
+1. Address the concerns above and re-run `/specrails:implement`.
+2. Or, if you have reviewed the concerns and accept the risk, re-run with an override:
+   `/specrails:implement #N --confidence-override "reason"`
+
+Pipeline halted. No git operations have been performed.
+```
+
+#### Dry-Run Behavior
+
+When `DRY_RUN=true`, the reviewer still writes `confidence-score.json` (it is an OpenSpec artifact, not a git artifact). Phase 4b-conf still evaluates the score. If `CONFIDENCE_BLOCKED=true`, add to `.cache-manifest.json` under `skipped_operations`:
+```
+"confidence-gate: blocked — Phase 4c skipped"
+```
+
+### Phase 4c.0: Pre-ship conflict check
+
+**Guard:** If `SNAPSHOTS_CAPTURED=false` OR `DRY_RUN=true`, print `[conflict-check] Skipped — SNAPSHOTS_CAPTURED=false (or dry-run mode).` and proceed directly to Phase 4c.
+
+This check is independent of Phase 3a.0. Even if the user chose to continue through a conflict at Phase 3a.0, this gate re-checks all in-scope issues against the Phase 0 snapshot. It is the final gate before any code reaches git.
+
+Re-fetch each issue in `ISSUE_REFS` and diff against `.claude/backlog-cache.json` using the same algorithm as Phase 3a.0:
+
+**If `BACKLOG_PROVIDER=local`:** Read `.specrails/local-tickets.json` and extract each ticket by ID.
+
+**If `BACKLOG_PROVIDER=github`:**
+```bash
+gh issue view {number} --json number,title,state,assignees,labels,body,updatedAt
+```
+
+If the cache file is missing or malformed JSON at this point: log `[conflict-check] Warning: cache file missing or unreadable. Skipping diff for this run.` and proceed to Phase 4c (treat as clean).
+
+Apply the same short-circuit (`updatedAt` match → clean), field comparison, and severity classification as Phase 3a.0.
+
+If all issues are clean: print `[conflict-check] All issues clean (Phase 4c.0). Proceeding.` and continue.
+
+If conflicts exist: print the same conflict report format as Phase 3a.0 (with `Phase 4c.0` context) and await `A`/`C` input (same re-prompt and default-abort logic).
+
+**On abort:** Print `[conflict-abort] Pipeline aborted. Re-run /specrails:implement after resolving the issues.` and exit. No git operations have been performed at this point.
+
+**On continue:** Print `[conflict-override] Continuing. N conflict(s) logged.` Append each conflict to `CONFLICT_OVERRIDES` as `{phase: "4c.0", issue: "#N", field: "<field>", severity: "<severity>", was: "<was>", now: "<now>"}`. Proceed to Phase 4c.
+
+### 4c. Ship — Git & backlog updates
+
+**Security gate:** If `SECURITY_BLOCKED=true`:
+1. Print all Critical findings from the security-reviewer output
+2. Do NOT create a branch, commit, push, or PR
+3. Print: "Pipeline blocked by security findings. Fix the Critical issues listed above and re-run /specrails:implement."
+4. Skip to Phase 4e.
+
+### Dry-Run Gate
+
+**If `DRY_RUN=true`:**
+Print: `[dry-run] Skipping all git and backlog operations.`
+Record skipped operations to `.cache-manifest.json` under `skipped_operations`:
+- `"git: branch creation (feat/<name>)"`
+- `"git: commit"`
+- `"git: push"`
+- `"github: pr creation"` (if `GH_AVAILABLE=true`)
+- If `BACKLOG_PROVIDER=local` and `BACKLOG_WRITE=true`:
+  - `"local: ticket comment #{id}"` for each ticket in scope
+  - `"local: ticket status update #{id}"` for each fully resolved ticket
+- If `BACKLOG_PROVIDER=github` and `BACKLOG_WRITE=true`:
+  - `"github: issue comment #N"` for each issue in scope
+  - `"github: issue close #N (via PR merge)"` for each fully resolved issue
+
+Then skip the rest of Phase 4c and proceed directly to Phase 4e.
+
+**If `APPLY_MODE=true`:**
+1. Read `.cache-manifest.json` from `CACHE_DIR`.
+2. For each entry in `files`: copy `cached_path` to `real_path`, creating directories as needed.
+3. Print: `[apply] Copied N files from .claude/.dry-run/<feature-name>/ to real locations.`
+4. Then proceed with Phase 4c normally (GIT_AUTO logic, backlog updates) using the real files.
+5. On successful completion of Phase 4c: delete `CACHE_DIR` and print `[apply] Cache cleaned up.`
+   If Phase 4c fails: preserve `CACHE_DIR` for re-run.
+
+**Otherwise:** proceed as normal.
+
+---
+
+This phase respects the `GIT_AUTO` and `BACKLOG_WRITE` settings from configuration.
+
+#### If `GIT_AUTO=true` (automatic shipping)
+
+1. Create branch from `main`: `git checkout -b feat/<descriptive-name>`
+2. One commit per feature with descriptive messages
+3. If the reviewer modified files, create an additional commit: `fix: resolve CI issues (reviewer)`
+4. Push with `-u` flag: `git push -u origin <branch-name>`
+5. Create PR (if GitHub CLI is available):
+   ```bash
+   
+   ```
+   If `gh` is not authenticated, print a compare URL for manual PR creation.
+
+#### If `GIT_AUTO=false` (manual shipping)
+
+Do NOT create branches, commits, or push. Instead display a summary:
+
+```
+## Changes Ready for Review
+
+All implementation is complete and CI checks pass.
+
+### Files Changed
+- [list all modified/created files per feature]
+
+### Suggested Next Steps
+1. Review the changes: `git diff`
+2. Create a branch: `git checkout -b feat/<name>`
+3. Stage and commit: `git add <files> && git commit -m "feat: ..."`
+4. Push and create PR manually
+```
+
+#### Backlog updates (both modes)
+
+**If `BACKLOG_WRITE=true`:**
+- For fully resolved issues/tickets: add a comment noting completion and reference the PR:
+  ```bash
+  
+  ```
+  - **Local:** Update the ticket status to `"done"` using `` and add a comment: `"Implemented in PR #XX. All acceptance criteria met."` via ``. Local tickets are closed directly — there is no auto-close-on-merge mechanism.
+  - **GitHub:** `gh issue comment {number} --body "Implemented in PR #XX. All acceptance criteria met."` — do NOT close the issue explicitly. Use `Closes #N` in the PR body so GitHub auto-closes on merge.
+  - **JIRA:** `jira issue comment {key} --message "Implemented in PR #XX. All acceptance criteria met."`
+  - For GitHub/JIRA: ensure the PR body includes `Closes #N` for each fully resolved issue (auto-closes on merge)
+- For partially resolved issues/tickets: add a comment noting progress:
+  ```bash
+  
+  ```
+  - **Local:** Additionally update the ticket status to `"in_progress"` via `` if it is still `"todo"`.
+
+**If `BACKLOG_WRITE=false`:**
+- Do NOT create, modify, or comment on any issues/tickets.
+- Instead, display what the user should update manually:
+  ```
+  ## Backlog Updates (manual)
+
+  The following tickets should be updated:
+  | Ticket | Status | Suggested Action |
+  |--------|--------|-----------------|
+  | #85 / PROJ-85 | Fully implemented | Close / move to Done |
+  | #71 / PROJ-71 | Partial progress | Comment: "X completed, Y remaining" |
+  ```
+
+**Pipeline state:** update `ship` → `done` if git operations and PR creation succeeded, or `failed` with error context describing which step failed (e.g. `"git push failed: <exit code>"`, `"gh pr create failed"`, `"security gate blocked ship"`). If `DRY_RUN=true`: update `ship` → `skipped`.
+
+### 4d. Monitor CI
+
+**Only if `GIT_AUTO=true` and code was pushed.**
+
+Check CI status after pushing. Fix failures (up to 2 retries).
+
+**Pipeline state:** update `ci` → `done` if CI passed, or `failed` with error context `"CI failed after 2 retries: <summary>"`. If CI was not run (`GIT_AUTO=false` or dry-run): update `ci` → `skipped`.
+
+If `GIT_AUTO=false`: skip — the user will push and monitor CI themselves.
+
+### 4e. Report
+
+**If `DRY_RUN=true`**, show this report instead of the standard pipeline table:
+
+---
+
+## Dry-Run Preview Report
+
+### Artifacts Generated
+
+| Type | Location |
+|------|----------|
+| OpenSpec proposal | openspec/changes/\<name\>/proposal.md |
+| OpenSpec design | openspec/changes/\<name\>/design.md |
+| OpenSpec tasks | openspec/changes/\<name\>/tasks.md |
+| OpenSpec context-bundle | openspec/changes/\<name\>/context-bundle.md |
+| Developer files | .claude/.dry-run/\<name\>/ (N files) |
+
+### What Would Change
+
+[For each file in `.cache-manifest.json` `files` array:]
+- `<real_path>` — [new file / modified] ([approximate line delta if available])
+
+### Confidence
+
+| | |
+|-|--|
+| Score file | `openspec/changes/<name>/confidence-score.json` |
+| Gate result | `<CONFIDENCE_STATUS>` (PASS / WARN / BLOCKED / OVERRIDE / MISSING / DISABLED) |
+| Overall score | `<overall score from confidence-score.json, or N/A if MISSING/DISABLED>` |
+
+### Operations Skipped
+
+[List items from `.cache-manifest.json` `skipped_operations` array]
+
+### Next Steps
+
+To apply these changes and ship:
+```
+/specrails:implement --apply <feature-name>
+```
+
+To discard this dry run:
+```
+rm -rf .claude/.dry-run/<feature-name>/
+```
+
+---
+
+**Otherwise**, show the standard pipeline table:
+
+```
+| Area | Feature | Change Name | Architect | Developer | Tests | Docs | Reviewer | Frontend | Backend | Confidence | Security | CI | Conflicts | Status |
+|------|---------|-------------|-----------|-----------|-------|------|----------|----------|---------|------------|----------|----|-----------|--------|
+```
+
+Confidence column values:
+
+| Value | Meaning |
+|-------|---------|
+| `PASS (82)` | All scores met thresholds; overall score shown in parens |
+| `WARN (62)` | Scores below threshold but `on_breach=warn`; overall score in parens |
+| `BLOCKED (62)` | Gate blocked the pipeline; overall score in parens |
+| `OVERRIDE (62)` | Gate bypassed by `--confidence-override`; overall score in parens |
+| `MISSING` | `confidence-score.json` not found after reviewer completed |
+| `DISABLED` | Gate disabled via `enabled: false` in config |
+
+If `CONFIDENCE_OVERRIDE_REASON` is non-empty, append a `### Confidence Override` section below the table:
+
+```
+### Confidence Override
+
+**Reason:** <CONFIDENCE_OVERRIDE_REASON>
+```
+
+Column values:
+- **Frontend**: `CLEAN`, `ISSUES`, or `SKIPPED` (no frontend files in changeset)
+- **Backend**: `CLEAN`, `ISSUES`, or `SKIPPED` (no backend files in changeset)
+- **Security**: `CLEAN`, `WARNINGS`, `BLOCKED`, or `SKIPPED`
+
+The `Conflicts` column values:
+- `skipped` — `SNAPSHOTS_CAPTURED=false` (non-issue input or GH unavailable)
+- `clean` — both conflict checks ran and found no changes
+- `overridden (N)` — user chose Continue at one or both gates; N is the total number of conflict records in `CONFLICT_OVERRIDES`
+
+If `MERGE_REPORT.requires_resolution` is non-empty, print an additional section:
+
+```
+### Merge Conflicts Requiring Resolution
+
+| File | Features | Conflicting Region | Resolver Status |
+|------|----------|--------------------|-----------------|
+| <file> | <feature-a>, <feature-b> | <section heading or hunk description> | LOW_CONFIDENCE / SKIPPED |
+
+Fix these conflicts (search for `<<<<<<<` in each file), then commit the resolved files.
+To retry smart resolution after addressing context: `/specrails:merge-resolve --files <file>`
+```
+
+If `CONFLICT_OVERRIDES` is non-empty, print:
+
+```
+## Conflict Overrides
+
+The following backlog conflicts were detected but overridden by the user:
+
+| Phase | Issue | Field | Severity | Was | Now |
+|-------|-------|-------|----------|-----|-----|
+| 3a.0  | #42   | state | CRITICAL | open | closed |
+```
+
+If `CONFLICT_OVERRIDES` is empty or `SNAPSHOTS_CAPTURED=false`: omit the `## Conflict Overrides` section entirely. Do not print an empty table or a "No conflict overrides" line.
+
+Include the shipping mode in the report:
+- If automatic: show PR URL, CI status, backlog updates made
+- If manual: show summary of changes, suggested git commands, backlog updates pending
+
+---
+
+## Error Handling
+
+- If a sr-product-manager fails: skip that area, continue with others
+- If a sr-architect fails: skip that area, report the failure
+- If a sr-developer fails: report which phase it failed at
+- If the sr-reviewer finds unfixable issues: report them, push what works
+- If Phase 4c (ship) fails: report the failure
+- Never block the entire pipeline on a single agent failure. Always produce a final report.

--- a/.claude/commands/specrails/memory-inspect.md
+++ b/.claude/commands/specrails/memory-inspect.md
@@ -1,0 +1,259 @@
+---
+name: "Agent Memory Inspector"
+description: "Inspect and manage agent memory directories. Lists all sr-* agent memory stores, shows per-agent stats (file count, size, last modified), displays recent entries, and detects stale or orphaned files."
+category: Workflow
+tags: [workflow, memory, agents, maintenance, diagnostics]
+---
+
+Inspect agent memory directories under `.claude/agent-memory/sr-*/` for **specrails-core**. Show per-agent stats, recent entries, and actionable recommendations.
+
+**Input:** `$ARGUMENTS` — optional:
+- `<agent-name>` — inspect a specific agent's memory (e.g. `sr-developer`, `sr-reviewer`)
+- `--stale <days>` — flag files not modified in more than N days as stale (default: 30)
+- `--prune` — delete stale files after confirmation (prints the list first, then asks)
+
+---
+
+## Phase 0: Argument Parsing
+
+Parse `$ARGUMENTS` to set runtime variables.
+
+**Variables to set:**
+
+- `AGENT_FILTER` — string or empty string. Default: `""` (inspect all agents).
+- `STALE_DAYS` — integer. Default: `30`.
+- `PRUNE_MODE` — boolean. Default: `false`.
+
+**Parsing rules:**
+
+1. Scan `$ARGUMENTS` for `--stale <N>`. If found, set `STALE_DAYS=<N>`. Validate that `<N>` is a positive integer; if not, print `Error: --stale requires a positive integer (e.g. --stale 14)` and stop. Strip from arguments.
+2. Scan for `--prune`. If found, set `PRUNE_MODE=true`. Strip from arguments.
+3. Remaining non-flag text (if any) is treated as `AGENT_FILTER`. Strip leading/trailing whitespace.
+
+**Print active configuration:**
+
+```
+Scanning: <all agents | agent: AGENT_FILTER> | Stale threshold: STALE_DAYS days | Prune: yes/no
+```
+
+---
+
+## Phase 1: Discover Memory Directories
+
+Glob all directories matching `.claude/agent-memory/sr-*/`.
+
+If no directories are found:
+```
+No agent memory directories found under .claude/agent-memory/.
+
+Agent memory is written by sr-* agents during the /specrails:implement pipeline.
+Run /specrails:implement on a feature to generate your first memory entries.
+```
+Then stop.
+
+If `AGENT_FILTER` is set, filter to only the directory `.claude/agent-memory/<AGENT_FILTER>/`. If that directory does not exist:
+```
+No memory directory found for agent: <AGENT_FILTER>
+
+Available agents:
+  <list of discovered sr-* directory names>
+```
+Then stop.
+
+Set `AGENT_DIRS` = list of matching directories (full paths), sorted alphabetically.
+
+---
+
+## Phase 2: Collect Per-Agent Stats
+
+For each directory in `AGENT_DIRS`, collect:
+
+- `AGENT_NAME` — directory name (e.g. `sr-developer`)
+- `FILE_COUNT` — total number of files (recursive, all types)
+- `TOTAL_SIZE` — total size in bytes; display as human-readable (KB, MB)
+- `LAST_MODIFIED` — ISO date of the most recently modified file
+- `OLDEST_MODIFIED` — ISO date of the least recently modified file
+- `STALE_FILES` — list of files not modified in more than `STALE_DAYS` days (full paths)
+- `STALE_COUNT` — count of stale files
+
+Use the current date to compute stale age. A file is stale if `(today - last_modified) > STALE_DAYS`.
+
+Print a summary table after collecting all stats:
+
+```
+## Agent Memory Overview
+
+| Agent | Files | Size | Last Modified | Stale (>STALE_DAYS days) |
+|-------|-------|------|---------------|--------------------------|
+| sr-developer   | N | N KB | YYYY-MM-DD | N files |
+| sr-reviewer    | N | N KB | YYYY-MM-DD | N files |
+| ...            | ... | ... | ...        | ...     |
+
+Total: N agents | N files | N KB
+```
+
+---
+
+## Phase 3: Display Recent Entries
+
+For each agent in `AGENT_DIRS`, show the 5 most recently modified files.
+
+Print per agent:
+
+```
+### <agent-name>
+
+Recent entries (5 most recent):
+
+| File | Size | Last Modified |
+|------|------|---------------|
+| common-fixes.md | 2.1 KB | 2026-03-18 |
+| ...             | ...    | ...         |
+```
+
+If the agent directory has fewer than 5 files, show all of them.
+
+If `AGENT_FILTER` is set (single-agent mode), show the full content of each file up to 50 lines. For files exceeding 50 lines, print the first 50 lines followed by:
+```
+... (N more lines — view full file at <relative-path>)
+```
+
+---
+
+## Phase 4: Orphan Detection
+
+An **orphaned** memory directory is one whose agent name does not correspond to a known sr-agent persona.
+
+Known sr-agent names (check for exact match):
+`sr-architect`, `sr-developer`, `sr-test-writer`, `sr-reviewer`, `sr-frontend-reviewer`, `sr-backend-reviewer`, `sr-security-reviewer`, `sr-doc-sync`, `sr-product-manager`
+
+For each directory in `AGENT_DIRS`, check whether its `AGENT_NAME` is in the known list. Collect non-matching directories as `ORPHANED_DIRS`.
+
+If `ORPHANED_DIRS` is non-empty, print:
+
+```
+### Orphaned Memory Directories
+
+The following directories do not match any known sr-agent name and may be leftover from renamed or removed agents:
+
+| Directory | Files | Size | Recommendation |
+|-----------|-------|------|----------------|
+| sr-old-agent | N | N KB | Review and delete if no longer needed |
+```
+
+If `ORPHANED_DIRS` is empty: skip this section entirely.
+
+---
+
+## Phase 5: Stale File Report
+
+Collect all stale files across all agents (from Phase 2 `STALE_FILES` lists).
+
+If no stale files exist:
+```
+No stale files found (threshold: STALE_DAYS days). Memory is up to date.
+```
+Skip the rest of Phase 5.
+
+Otherwise, print:
+
+```
+### Stale Files (not modified in >STALE_DAYS days)
+
+| Agent | File | Size | Last Modified | Age (days) |
+|-------|------|------|---------------|------------|
+| sr-developer | common-fixes.md | 1.2 KB | 2026-01-10 | 69 |
+| ...          | ...             | ...    | ...        | ...        |
+
+N stale files total (N KB).
+```
+
+---
+
+## Phase 6: Prune (if --prune)
+
+Skip this phase if `PRUNE_MODE=false`.
+
+If `PRUNE_MODE=true` and there are no stale files and no orphaned directories:
+```
+Nothing to prune. All memory files are within the STALE_DAYS-day threshold.
+```
+Then stop.
+
+Otherwise, print the full list of files and directories that will be deleted:
+
+```
+## Files to Delete
+
+The following N files will be permanently deleted:
+
+Stale files:
+  - .claude/agent-memory/sr-developer/common-fixes.md (69 days old)
+  - ...
+
+Orphaned directories:
+  - .claude/agent-memory/sr-old-agent/ (N files, N KB)
+
+Proceed? [y/N]:
+```
+
+Wait for user input.
+
+- If the user enters `y` or `Y`:
+  - Delete each stale file individually.
+  - Delete each orphaned directory recursively.
+  - Print a confirmation for each deletion: `Deleted: <path>`
+  - Print a summary:
+    ```
+    Pruned N files (N KB freed).
+    ```
+- If the user enters anything else (or presses Enter):
+  - Print: `Prune cancelled. No files were deleted.`
+  - Stop.
+
+---
+
+## Phase 7: Recommendations
+
+Print a final recommendations section based on findings:
+
+```
+## Recommendations
+
+<one or more of the following, based on findings>
+```
+
+**Recommendation rules (print only applicable ones):**
+
+1. **Prune stale data** — if `STALE_COUNT > 0` across any agent and `PRUNE_MODE=false`:
+   ```
+   - N stale files detected. Run `/specrails:memory-inspect --prune` to remove them and free N KB.
+   ```
+
+2. **Investigate large memory** — if any single agent's `TOTAL_SIZE > 1 MB`:
+   ```
+   - <agent-name> memory exceeds 1 MB (TOTAL_SIZE). Consider reviewing large files:
+     <list files over 100 KB>
+   ```
+
+3. **Orphaned directories** — if `ORPHANED_DIRS` is non-empty:
+   ```
+   - N orphaned director(y|ies) found. Review and delete manually if no longer needed.
+   ```
+
+4. **Empty memory directories** — if any agent directory has `FILE_COUNT = 0`:
+   ```
+   - <agent-name> memory directory is empty. It may be safe to delete:
+     rm -rf .claude/agent-memory/<agent-name>/
+   ```
+
+5. **Gitignore advisory** — check whether `.claude/agent-memory` appears in `.gitignore`. If not:
+   ```
+   - Agent memory is local runtime state. Add to .gitignore:
+       echo '.claude/agent-memory/' >> .gitignore
+   ```
+
+If no recommendations apply, print:
+```
+All agent memory looks healthy. No action required.
+```

--- a/.claude/commands/specrails/merge-resolve.md
+++ b/.claude/commands/specrails/merge-resolve.md
@@ -1,0 +1,172 @@
+# Smart Merge Conflict Resolver
+
+Resolves git conflict markers in working tree files using AI-powered context analysis. For each conflict block, reads OpenSpec context bundles from the features that produced the conflict, infers the correct resolution, and writes it in place — or preserves clean markers for conflicts it cannot safely resolve.
+
+**IMPORTANT: Always follow this procedure exactly as written. Launch the sr-merge-resolver agent as specified. Do NOT attempt to resolve conflicts yourself in the main conversation.**
+
+**Input:** `$ARGUMENTS` — flags controlling which files to process, where to find context, and resolution behavior.
+
+---
+
+## Step 1: Parse flags
+
+Scan `$ARGUMENTS` for the following flags:
+
+### `--files <paths>`
+
+**Type:** space-separated file paths or glob patterns
+**Default:** auto-detect (scan working tree)
+
+Explicit list of files to process. If a path contains `*` or `?`, treat it as a glob and expand it. Strip this flag and its value from `$ARGUMENTS` before further processing.
+
+### `--context <directory>`
+
+**Type:** directory path
+**Default:** `openspec/changes/`
+
+Directory to scan for context bundles. The command globs `<directory>/*/context-bundle.md`. Strip this flag and its value from `$ARGUMENTS` before further processing.
+
+### `--threshold N`
+
+**Type:** integer 0–100
+**Default:** 70
+
+Minimum confidence score for the resolver to apply an AI resolution. Below this threshold, the resolver preserves conflict markers in normalized format. Strip this flag and its value from `$ARGUMENTS` before further processing.
+
+### `--mode auto|manual-fallback-only`
+
+**Type:** enum
+**Default:** `auto`
+
+- `auto`: attempt AI resolution for each conflict block
+- `manual-fallback-only`: only normalize conflict marker format; do not attempt AI resolution
+
+Strip this flag and its value from `$ARGUMENTS` before further processing.
+
+After parsing, if any unrecognized flags remain in `$ARGUMENTS`: print a warning:
+```
+[merge-resolve] Warning: unrecognized flags ignored: <remaining>
+```
+
+---
+
+## Step 2: Detect conflicted files
+
+### If `--files` was provided:
+
+For each path (or expanded glob): check that the file exists. If a path does not exist: print `[merge-resolve] Warning: <path> not found — skipped.` and remove it from the list.
+
+Filter to only files containing `<<<<<<<`. For any file in the provided list that does NOT contain `<<<<<<<`: print `[merge-resolve] <path>: no conflict markers found — skipped.`
+
+### If `--files` was NOT provided:
+
+Scan the entire working tree for files containing `<<<<<<<`:
+
+```bash
+grep -rl "<<<<<<< " . --include="*" 2>/dev/null
+```
+
+Exclude `.git/` directory from results.
+
+If no conflicted files are found (either from explicit list or auto-detect):
+
+```
+[merge-resolve] No conflict markers found in the working tree.
+Nothing to do.
+```
+
+Exit cleanly.
+
+Otherwise, print:
+```
+[merge-resolve] Found N conflicted file(s):
+  - path/to/file.ts
+  - path/to/other.md
+```
+
+---
+
+## Step 3: Load context bundles
+
+Glob `<context-directory>/*/context-bundle.md`.
+
+Build `CONTEXT_BUNDLES` map: for each matched path, the key is the subdirectory name (the feature name), the value is the file path.
+
+Example:
+```
+openspec/changes/feature-a/context-bundle.md  →  { "feature-a": "openspec/changes/feature-a/context-bundle.md" }
+openspec/changes/feature-b/context-bundle.md  →  { "feature-b": "openspec/changes/feature-b/context-bundle.md" }
+```
+
+If no context bundles are found:
+```
+[merge-resolve] No context bundles found at <context-directory>.
+The resolver will use structural analysis only (no feature-intent context).
+```
+
+Set `CONTEXT_BUNDLES = {}`.
+
+---
+
+## Step 4: Launch sr-merge-resolver agent
+
+Construct the agent prompt with:
+
+- `CONFLICTED_FILES`: the list of conflicted file paths
+- `CONTEXT_BUNDLES`: the map built in Step 3
+- `CONFIDENCE_THRESHOLD`: the `--threshold` value (default 70)
+- `RESOLUTION_MODE`: the `--mode` value (default `auto`)
+- `REPORT_PATH`: `openspec/changes/<first-feature>/merge-resolution-report.md` if CONTEXT_BUNDLES has entries; otherwise `merge-resolution-report.md` in the working directory root
+
+Launch the **sr-merge-resolver** agent (`subagent_type: sr-merge-resolver`, foreground, `run_in_background: false`). Wait for it to complete.
+
+Read the final `MERGE_RESOLUTION_STATUS` line from the agent's output.
+
+---
+
+## Step 5: Print summary
+
+After the agent completes, print:
+
+```
+## Merge Resolution Complete
+
+| Metric | Count |
+|--------|-------|
+| Files processed | N |
+| Conflicts found | N |
+| Auto-resolved | N |
+| Low-confidence (kept) | N |
+| Skipped | N |
+
+Resolution report: <REPORT_PATH>
+```
+
+If `MERGE_RESOLUTION_STATUS = PARTIAL` or `UNRESOLVED`:
+
+```
+## Remaining Conflicts
+
+The following files still contain conflict markers that require manual resolution:
+
+  - path/to/file.ts (N block(s))
+
+Search for `<<<<<<<` in each file to locate the markers.
+Run `/specrails:merge-resolve` again after addressing the low-confidence conflicts,
+or resolve them manually and commit.
+```
+
+If `MERGE_RESOLUTION_STATUS = CLEAN`:
+
+```
+All conflict markers resolved. Working tree is clean.
+You can now stage and commit the resolved files.
+```
+
+---
+
+## Error Handling
+
+- If the agent fails or times out: print `[merge-resolve] Error: sr-merge-resolver did not complete. Files may be partially modified — check for remaining conflict markers before committing.` Exit with a non-zero status.
+- If a file becomes unreadable mid-run (e.g. deleted): log `[merge-resolve] Warning: <path> disappeared during processing — skipped.`
+- Never abort silently. Always print a final status.

--- a/.claude/commands/specrails/opsx-diff.md
+++ b/.claude/commands/specrails/opsx-diff.md
@@ -1,0 +1,419 @@
+---
+name: "OpenSpec Change Diff Visualizer"
+description: "Show a before/after diff of OpenSpec spec changes for a given change. Highlights additions, removals, and behavioral modifications across acceptance criteria, flows, and constraints. Supports markdown and JSON output."
+category: Workflow
+tags: [openspec, diff, specs, visualization, changes]
+---
+
+Visualize spec changes for **specrails-core**: compare the current specs against a named OpenSpec change to show exactly what behavioral requirements are being added, modified, or removed.
+
+**Input:** $ARGUMENTS — accepts:
+- `<change-name>` — the kebab-case name of the change to diff (required). If omitted, interactive selection is offered.
+- `--format json` — emit structured JSON instead of markdown (default: markdown).
+- `--summary-only` — skip inline line-level diff; show only the file-level and behavioral summary.
+
+---
+
+## Phase 0: Argument Parsing
+
+Parse `$ARGUMENTS` to set runtime variables.
+
+**Variables to set:**
+
+- `CHANGE_NAME` — string. Required. If not provided, prompt the user.
+- `FORMAT` — `"markdown"` or `"json"`. Default: `"markdown"`.
+- `SUMMARY_ONLY` — boolean. Default: `false`.
+
+**Parsing rules:**
+
+1. Scan `$ARGUMENTS` for `--format <value>`. If found and value is `json`, set `FORMAT="json"`. Any other value: print `Error: unknown format "<value>". Valid: markdown, json` and stop. Strip from arguments.
+2. Scan for `--summary-only`. If found, set `SUMMARY_ONLY=true`. Strip from arguments.
+3. Treat the remaining token (if any) as `CHANGE_NAME`. Strip leading/trailing whitespace.
+4. If `CHANGE_NAME` is empty after parsing:
+   - Run:
+     ```bash
+     openspec list --json
+     ```
+   - If the result shows available changes, use the **AskUserQuestion tool** (open-ended, show the list) to ask which change to diff.
+   - If no changes exist, print:
+     ```
+     Error: no active changes found. Run /opsx:new or /opsx:ff to create one first.
+     ```
+     Stop.
+
+**Print active configuration:**
+
+```
+Diffing change: <CHANGE_NAME>
+Format: <markdown|json>
+Summary only: <yes|no>
+```
+
+---
+
+## Phase 1: Locate the Change
+
+Find the change directory and enumerate its spec artifacts.
+
+### Step 1a: Resolve the change path
+
+Check these locations in order:
+
+1. `openspec/changes/<CHANGE_NAME>/` — active change.
+2. `openspec/changes/archive/` — glob for directories matching `*<CHANGE_NAME>` or exact `<CHANGE_NAME>`. Take the most recent match (latest date prefix).
+
+If neither location yields a directory, print:
+
+```
+Error: change "<CHANGE_NAME>" not found.
+Searched:
+  - openspec/changes/<CHANGE_NAME>/
+  - openspec/changes/archive/*<CHANGE_NAME>*/
+
+Run `openspec list` to see available changes.
+```
+
+Stop.
+
+Set `CHANGE_DIR` to the resolved path.
+
+**Print:** `Found change at: <CHANGE_DIR>`
+
+### Step 1b: Enumerate spec artifacts in the change
+
+Collect spec content from the change directory using this priority:
+
+1. **Delta-spec file** — `<CHANGE_DIR>/delta-spec.md`. If present, read it. Set `HAS_DELTA_SPEC=true`.
+2. **Inline specs subdirectory** — `<CHANGE_DIR>/specs/`. If present, glob `**/*.md` within it. Each file is an individual spec. Set `HAS_SPEC_DIR=true`.
+3. **Proposal file** — `<CHANGE_DIR>/proposal.md`. Always read if present. Used for context but not as a primary diff source. Set `HAS_PROPOSAL=true`.
+
+At least one of `HAS_DELTA_SPEC` or `HAS_SPEC_DIR` must be true to proceed.
+
+If neither exists:
+```
+Warning: no spec artifacts found in <CHANGE_DIR>.
+  Expected: delta-spec.md or specs/*.md
+
+The change may not have reached the spec authoring phase yet.
+Run /opsx:continue to create specs first.
+```
+Stop.
+
+Store the collected spec content:
+- `DELTA_SPEC` — string content of delta-spec.md (or `""` if absent).
+- `CHANGE_SPECS` — array of `{ path, content }` objects from the specs/ subdirectory (or `[]` if absent).
+- `PROPOSAL` — string content of proposal.md (or `""` if absent).
+
+**Print:** `Spec artifacts: <delta-spec.md present|absent>, <N spec files in specs/>, proposal <present|absent>`
+
+---
+
+## Phase 2: Load Baseline Specs
+
+Find the current baseline specs to compare against.
+
+### Step 2a: Discover baseline spec files
+
+Glob for markdown files in `openspec/specs/` (recursively: `openspec/specs/**/*.md`).
+
+Store as `BASELINE_SPECS` — array of `{ path, content }` objects.
+
+If `openspec/specs/` does not exist or contains no files:
+```
+Note: no baseline specs found in openspec/specs/.
+Diff will show all change specs as net-new additions (no removals or modifications).
+```
+Set `BASELINE_SPECS=[]`.
+
+**Print:** `Baseline: <N> spec file(s) found in openspec/specs/`
+
+### Step 2b: Match change specs to baseline specs
+
+For each entry in `CHANGE_SPECS` (from the change's specs/ subdirectory), attempt to find its counterpart in `BASELINE_SPECS`.
+
+**Matching rule:** A change spec at `<CHANGE_DIR>/specs/<spec-name>/spec.md` matches a baseline spec at `openspec/specs/<spec-name>/spec.md` or `openspec/specs/<spec-name>.md`. Match on the spec name segment only.
+
+Build `SPEC_PAIRS` — array of:
+```
+{
+  specName: string,
+  changePath: string | null,       // path in change (null if baseline-only)
+  baselinePath: string | null,     // path in baseline (null if change-only)
+  changeContent: string | null,
+  baselineContent: string | null,
+  matchType: "new" | "modified" | "deleted" | "unchanged"
+}
+```
+
+**Match type rules:**
+- `changePath` present, `baselinePath` absent → `"new"`.
+- `changePath` absent, `baselinePath` present (and baseline spec is referenced/affected by delta-spec) → `"deleted"`.
+- Both present and content differs → `"modified"`.
+- Both present and content identical → `"unchanged"`.
+
+For the delta-spec flow (when `HAS_DELTA_SPEC=true` and `HAS_SPEC_DIR=false`):
+- The delta-spec itself is the primary artifact. There is no per-file pairing.
+- Set `SPEC_PAIRS=[]` and use the delta-spec content directly in Phase 3.
+
+---
+
+## Phase 3: Compute the Diff
+
+Produce a structured diff comparing baseline vs. change specs.
+
+### Step 3a: Delta-spec analysis (when HAS_DELTA_SPEC=true)
+
+Parse the delta-spec sections to extract behavioral elements:
+
+**Acceptance criteria / SHALL statements:**
+- Glob for lines matching the pattern: `^\*\*\d+\.\d+\*\*` (numbered normative statements like `**1.1**`).
+- Collect all `{ id, text }` pairs into `DELTA_STATEMENTS`.
+
+**Surface impact table:**
+- Find the `## Surface Impact` section (or `### Surface Impact of This Change`).
+- Parse all table rows into `SURFACE_CHANGES`: `[ { category, element, change, severity } ]`.
+
+**REST/API contract changes:**
+- Find any section with "REST API", "API Contract", or "Endpoints" in the heading.
+- Extract endpoint definitions: method + path + response shape changes.
+- Store as `API_CHANGES`.
+
+**Since there is no true baseline for a delta-spec** (it defines net-new behavior), classify every `DELTA_STATEMENTS` entry as a `"new"` addition. If the "Surface Impact" table includes rows with change type "Removal" or "BREAKING", classify those as `"modified"` or `"deleted"` accordingly.
+
+Build `DIFF_RESULT`:
+```
+{
+  addedStatements: [{ id, text }],
+  modifiedStatements: [{ id, text, changeDescription }],
+  removedStatements: [{ id, text }],
+  surfaceChanges: [{ category, element, change, severity }],
+  apiChanges: [{ method, path, description }],
+  specPairs: []
+}
+```
+
+### Step 3b: Spec-file-pair analysis (when HAS_SPEC_DIR=true)
+
+For each `SPEC_PAIR` in `SPEC_PAIRS` where `matchType !== "unchanged"`:
+
+**Line-level diff:**
+
+Compare `baselineContent` and `changeContent` line by line:
+
+1. Split each content string into lines.
+2. Identify added lines (present in change, absent in baseline) and removed lines (present in baseline, absent in change).
+3. For each changed block, compute a ±3-line context window.
+4. Mark heading lines (starting with `#`) separately — heading changes indicate structural reorganization.
+5. Mark lines containing normative language (`SHALL`, `MUST`, `SHOULD`, `MAY`, `SHALL NOT`, `MUST NOT`) as behavioral.
+
+Produce `{ specName, matchType, addedLines, removedLines, behavioralChanges, headingChanges }`.
+
+**Behavioral change classification:**
+
+- Line added + contains `SHALL`/`MUST` → new requirement.
+- Line removed + contains `SHALL`/`MUST` → removed requirement.
+- Line modified (matched by proximity) + normative keyword → modified requirement.
+- Other additions/removals → structural/non-normative.
+
+Build `DIFF_RESULT` from all `SPEC_PAIRS`.
+
+### Step 3c: Compute summary statistics
+
+```
+ADDED_COUNT    = count(addedStatements) + count(added spec files)
+MODIFIED_COUNT = count(modifiedStatements) + count(modified spec files)
+REMOVED_COUNT  = count(removedStatements) + count(deleted spec files)
+TOTAL_CHANGES  = ADDED_COUNT + MODIFIED_COUNT + REMOVED_COUNT
+```
+
+---
+
+## Phase 4: Render Output
+
+### If FORMAT = "json"
+
+Emit a single JSON object:
+
+```json
+{
+  "schema_version": "1",
+  "project": "specrails-core",
+  "change": "<CHANGE_NAME>",
+  "generated_at": "<ISO 8601 timestamp>",
+  "source": "<delta-spec | spec-files>",
+  "summary": {
+    "total_changes": <N>,
+    "added": <N>,
+    "modified": <N>,
+    "removed": <N>
+  },
+  "added_statements": [
+    { "id": "1.1", "text": "..." }
+  ],
+  "modified_statements": [
+    { "id": "2.3", "text": "...", "change_description": "..." }
+  ],
+  "removed_statements": [
+    { "id": "3.1", "text": "..." }
+  ],
+  "surface_changes": [
+    { "category": "...", "element": "...", "change": "...", "severity": "..." }
+  ],
+  "api_changes": [
+    { "method": "POST", "path": "/api/spawn", "description": "..." }
+  ],
+  "spec_pairs": [
+    {
+      "spec_name": "...",
+      "match_type": "new|modified|deleted",
+      "added_lines": ["..."],
+      "removed_lines": ["..."],
+      "behavioral_changes": ["..."],
+      "heading_changes": ["..."]
+    }
+  ]
+}
+```
+
+Stop after emitting JSON.
+
+### If FORMAT = "markdown"
+
+Render the full diff report:
+
+```
+## OpenSpec Change Diff — <CHANGE_NAME>
+Project: specrails-core | Generated: <YYYY-MM-DD HH:MM>
+
+### Summary
+
+| Metric | Count |
+|--------|-------|
+| ➕ Added requirements | <N> |
+| ✏️  Modified requirements | <N> |
+| ➖ Removed requirements | <N> |
+| **Total changes** | **<N>** |
+```
+
+**If TOTAL_CHANGES = 0:**
+```
+✅ No behavioral differences detected between the change specs and the baseline.
+```
+Stop.
+
+---
+
+Then render sections:
+
+#### Added Requirements
+
+```
+### ➕ Added Requirements (<N>)
+
+<for each added statement:>
+> **<id>** <text>
+
+<if none:>
+_No new requirements._
+```
+
+#### Modified Requirements
+
+```
+### ✏️  Modified Requirements (<N>)
+
+<for each modified statement or spec pair with matchType="modified":>
+#### <spec-name or section heading>
+
+\`\`\`diff
+- <removed line>
++ <added line>
+\`\`\`
+
+**Change:** <change_description or inferred summary>
+
+<if SUMMARY_ONLY=true: skip inline diff blocks, show only change description>
+```
+
+#### Removed Requirements
+
+```
+### ➖ Removed Requirements (<N>)
+
+<for each removed statement:>
+> ~~**<id>** <text>~~
+
+<if none:>
+_No requirements removed._
+```
+
+#### Surface Impact (when HAS_DELTA_SPEC=true and SURFACE_CHANGES is non-empty)
+
+```
+### 🗺️  Surface Impact
+
+| # | Category | Element | Change | Severity |
+|---|----------|---------|--------|----------|
+<rows from SURFACE_CHANGES>
+```
+
+#### API Contract Changes (when API_CHANGES is non-empty)
+
+```
+### 🔌 API Contract Changes
+
+<for each API_CHANGES entry:>
+- **<METHOD> <path>** — <description>
+```
+
+#### New Spec Files (when added spec files exist)
+
+```
+### 📄 New Spec Files
+
+<for each specPair where matchType="new":>
+- `<changePath>` — new spec, no baseline counterpart
+```
+
+#### Deleted Spec Files (when deleted spec files exist)
+
+```
+### 🗑️  Deleted Spec Files
+
+<for each specPair where matchType="deleted":>
+- `<baselinePath>` — removed by this change
+```
+
+---
+
+Close the report:
+
+```
+---
+_Generated by `/specrails:opsx-diff` in specrails-core_
+_Change source: <CHANGE_DIR>_
+
+**Next steps:**
+- Run `/opsx:apply <CHANGE_NAME>` to implement these changes.
+- Run `/opsx:archive <CHANGE_NAME>` after implementation to merge specs into baseline.
+```
+
+---
+
+## Phase 5: Save Snapshot (optional)
+
+After rendering, write a diff snapshot to `.claude/opsx-diff-history/`:
+
+1. Filename: `<CHANGE_NAME>-<YYYY-MM-DD>.json`
+2. Directory: `.claude/opsx-diff-history/` (create if absent, idempotent).
+3. Content: the JSON object from Phase 4 (regardless of FORMAT setting).
+
+Print: `Snapshot saved: .claude/opsx-diff-history/<CHANGE_NAME>-<YYYY-MM-DD>.json`
+
+If the write fails: print `Warning: could not write diff snapshot. Continuing.` Do not abort.
+
+**Housekeeping:** If `.claude/opsx-diff-history/` has more than 50 `.json` files, print:
+```
+Note: .claude/opsx-diff-history/ has <N> snapshots. Prune old ones with:
+  ls -t .claude/opsx-diff-history/ | tail -n +51 | xargs -I{} rm .claude/opsx-diff-history/{}
+```

--- a/.claude/commands/specrails/propose-spec.md
+++ b/.claude/commands/specrails/propose-spec.md
@@ -1,0 +1,102 @@
+---
+description: Explore a spec idea and produce a structured proposal
+---
+
+You are a senior product engineer helping evaluate and structure a spec proposal for this codebase.
+
+The user's raw idea is:
+
+$ARGUMENTS
+
+## Your Task
+
+Before proposing anything, explore the codebase to understand:
+1. What already exists that relates to this idea
+2. What the current architecture looks like in the relevant area
+3. What constraints or patterns you must respect
+
+Use Read, Glob, and Grep to explore. Take at least 3 codebase reads before writing the proposal.
+
+## Required Output
+
+Output ONLY the following structured markdown. Do not add any preamble or explanation outside these sections.
+
+## Spec Title
+[A concise, action-oriented title, e.g., "Add Real-Time Cost Alerts"]
+
+## Problem Statement
+[2-3 sentences: what problem does this solve? Who experiences it? What is the current workaround?]
+
+## Proposed Solution
+[3-5 sentences: what exactly will be built? Be specific about the UI, API, and data changes.]
+
+## Out of Scope
+[Bullet list of things this proposal deliberately does NOT cover]
+
+## Acceptance Criteria
+[Numbered list of testable outcomes. Each criterion must be independently verifiable.]
+
+## Technical Considerations
+[Bullet list of implementation notes, constraints from the existing architecture, risks, and dependencies]
+
+## Estimated Complexity
+[One of: Low (< 1 day) / Medium (1-3 days) / High (3-7 days) / Very High (> 1 week)]
+[One sentence justifying the estimate]
+
+---
+
+## Backlog Sync
+
+After generating the proposal, read `.specrails/backlog-config.json` to determine `BACKLOG_PROVIDER` and `BACKLOG_WRITE`.
+
+If `.specrails/backlog-config.json` does not exist, default to `provider=local` and `write_access=true`. Initialize `.specrails/local-tickets.json` if it does not exist (empty store with `schema_version: "1.0"`, `revision: 0`, `next_id: 1`, `tickets: {}`).
+
+### If provider=local — Create Local Ticket
+
+Create a local ticket from the proposal output:
+
+```
+
+```
+
+Set the following fields:
+- `title`: The Spec Title from the proposal
+- `description`: The full structured proposal markdown (all sections from Problem Statement through Estimated Complexity)
+- `status`: `"todo"`
+- `priority`: Map Estimated Complexity — Low → `"low"`, Medium → `"medium"`, High/Very High → `"high"`
+- `labels`: `["spec-proposal"]`
+- `source`: `"propose-spec"`
+- `created_by`: `"sr-product-engineer"`
+
+Print: `Created local ticket #{id}: {title}`
+
+### If provider=github and BACKLOG_WRITE=true — Create GitHub Issue
+
+```bash
+
+```
+
+Create a GitHub Issue with:
+- Title: The Spec Title
+- Body: Full structured proposal markdown
+- Labels: `spec-proposal`
+
+Print: `Created GitHub Issue #{number}: {title}`
+
+### If provider=jira and BACKLOG_WRITE=true — Create JIRA Story
+
+Create a JIRA Story using the same authentication and API pattern as `/specrails:auto-propose-backlog-specs`:
+- Summary: The Spec Title
+- Description: Full structured proposal in Atlassian Document Format
+- Labels: `spec-proposal`
+
+Print: `Created JIRA ticket {key}: {title}`
+
+### If BACKLOG_WRITE=false or provider=none
+
+Do NOT create any tickets. Print:
+```
+Spec proposal ready. Create a ticket manually if desired:
+  Title: {Spec Title}
+  Complexity: {Estimated Complexity}
+```

--- a/.claude/commands/specrails/reconfig.md
+++ b/.claude/commands/specrails/reconfig.md
@@ -1,0 +1,89 @@
+# Reconfig: Apply Agent Config to Generated Files
+
+Reads `.specrails/agents.yaml` and updates the `model:` frontmatter field in all generated `.claude/agents/sr-*.md` files to match. No full re-setup needed — only model frontmatter is changed.
+
+---
+
+## Step 1: Locate generated agents directory
+
+Determine `$SPECRAILS_DIR`:
+
+1. If `.codex/agents/` exists, set `cli_provider = "codex"` and `specrails_dir = ".codex"`.
+2. Otherwise set `cli_provider = "claude"` and `specrails_dir = ".claude"`.
+3. Set `$AGENTS_DIR = $SPECRAILS_DIR/agents`
+
+## Step 2: Read agent config
+
+Read `.specrails/agents.yaml`.
+
+If the file does not exist, stop and display:
+
+```
+No .specrails/agents.yaml found.
+
+Run /specrails:enrich to generate the config file, then edit it before running /specrails:reconfig.
+```
+
+If the file exists, parse it. Validate all `model:` values — only `opus`, `sonnet`, and `haiku` are accepted. If an invalid value is found, display a warning and skip that agent:
+
+```
+Warning: unknown model "gpt-4" for sr-developer — skipping (valid values: opus, sonnet, haiku)
+```
+
+## Step 3: Resolve model for each agent
+
+For each agent file found in `$AGENTS_DIR/sr-*.md`:
+
+1. Extract the agent name from the filename (e.g., `sr-developer.md` → `sr-developer`)
+2. Resolve the target model:
+   - Check `agents.<agent-name>.model` in config (per-agent override)
+   - If not present, check `defaults.model` in config (global default)
+   - If neither is present, skip this agent
+3. Read the current `model:` value from the file's YAML frontmatter
+4. If the current model matches the target model, mark as **unchanged**
+5. If they differ, record the change: `sr-<name>: <current> → <target>`
+
+## Step 4: Apply changes
+
+For each agent with a recorded change:
+
+1. Read the file
+2. Replace the `model:` line in the YAML frontmatter with the resolved value
+3. Write the file back
+
+The `model:` line is always in the frontmatter block (between the first `---` and second `---`). Replace only that specific line — do not modify any other content.
+
+**Codex format:** If `cli_provider == "codex"`, apply the same logic to `.codex/agents/sr-*.toml` files. Replace the `model = "..."` line with the mapped Codex model:
+- `sonnet` → `codex-mini-latest`
+- `opus` → `o3`
+- `haiku` → `codex-mini-latest`
+
+## Step 5: Report results
+
+Display a summary of what changed:
+
+```
+## Reconfig complete
+
+Updated 2 agent(s):
+  sr-developer:       sonnet → opus
+  sr-product-analyst: haiku  → sonnet
+
+Unchanged (3):
+  sr-architect, sr-reviewer, sr-product-manager
+
+Skipped (1):
+  sr-custom-agent (not in config)
+```
+
+If nothing changed:
+
+```
+All agents already match .specrails/agents.yaml — nothing to update.
+```
+
+If all agents were skipped due to validation errors, display:
+
+```
+No agents updated. Fix the validation errors in .specrails/agents.yaml and retry.
+```

--- a/.claude/commands/specrails/refactor-recommender.md
+++ b/.claude/commands/specrails/refactor-recommender.md
@@ -1,0 +1,212 @@
+---
+name: "Refactor Recommender"
+description: "Scan the codebase for refactoring opportunities ranked by impact/effort ratio and VPC persona value. Analyzes code for duplicates, long functions, large files, dead code, outdated patterns, and complex logic. Optionally creates GitHub Issues for tracking."
+category: Workflow
+tags: [workflow, refactoring, code-quality, tech-debt, vpc]
+---
+
+Scan the codebase for refactoring opportunities, score each by impact/effort ratio and VPC persona value, and optionally create GitHub Issues for the top findings in .
+
+**Input:** `$ARGUMENTS` — optional: comma-separated paths to scope the analysis. Flags: `--dry-run` (print findings without creating issues).
+
+---
+
+## Phase 0: Pre-flight
+
+Check whether the GitHub CLI is available:
+
+```bash
+
+```
+
+Set `GH_AVAILABLE=true` if the command succeeds, `GH_AVAILABLE=false` otherwise. Do not stop — analysis proceeds regardless. Parse `--dry-run` from `$ARGUMENTS` and set `DRY_RUN=true` if present.
+
+---
+
+## Phase 1: Scope
+
+Parse paths from `$ARGUMENTS` after stripping any flags. If no paths are provided, scan the entire repository.
+
+Always exclude the following from all analysis:
+
+- `node_modules/`
+- `.git/`
+- `.claude/`
+- `vendor/`
+- `dist/`
+- `build/`
+
+---
+
+## Phase 1.5: VPC Context
+
+Check whether persona files exist at `.claude/agents/personas/`. This path is present in any repo that has run `/specrails:enrich`.
+
+```bash
+ls .claude/agents/personas/ 2>/dev/null
+```
+
+If the directory exists and contains persona files, set `VPC_AVAILABLE=true`. Otherwise set `VPC_AVAILABLE=false` and skip all VPC steps (they are optional enrichment, not blockers).
+
+When `VPC_AVAILABLE=true`, read each persona file and extract a compact VPC summary. For each persona record:
+
+- **name** — persona display name (e.g. "Alex — The Lead Dev")
+- **top_jobs** — up to 3 functional jobs relevant to code quality and maintainability
+- **critical_pains** — up to 3 pains marked Critical or High related to code reliability, complexity, or developer experience
+- **high_gains** — up to 3 gains marked High related to code clarity, speed, or confidence
+
+Store these as an in-memory `VPC_PROFILES` list. You will use it in Phase 3 to score persona fit.
+
+---
+
+## Phase 2: Analysis
+
+Analyze the scoped files across six categories. For each finding record:
+
+- **file** — relative path
+- **line_range** — start and end line numbers
+- **current_snippet** — the problematic code as-is
+- **proposed_snippet** — concrete refactored version
+- **rationale** — one sentence explaining the improvement
+
+### Duplicate Code
+
+Find code blocks larger than 10 lines that are substantially similar across two or more files. Consolidation into a shared function or module is the expected refactoring.
+
+### Long Functions
+
+Find functions or methods exceeding 50 lines. Extraction into smaller, single-purpose functions is the expected refactoring.
+
+### Large Files
+
+Find files exceeding 300 lines. Splitting into cohesive modules is the expected refactoring.
+
+### Dead Code
+
+Find unused exports, unreferenced functions, and commented-out blocks that have not been active for the lifetime of the file. Deletion or archival is the expected refactoring.
+
+### Outdated Patterns
+
+Find deprecated APIs and old language syntax: `var` instead of `let`/`const`, callbacks instead of `async`/`await`, legacy framework APIs with documented replacements, etc. Modernisation to current idioms is the expected refactoring.
+
+### Complex Logic
+
+Find deeply nested conditionals (more than 3 levels) and functions with high cyclomatic complexity. Extraction, early-return guards, or strategy patterns are the expected refactoring.
+
+---
+
+## Phase 3: Score and Rank
+
+Score every finding on three dimensions (1–5 each):
+
+- **Impact** — how much the refactoring improves code quality, readability, or maintainability
+- **Effort** — how hard the refactoring is to implement (1 = trivial, 5 = major)
+- **VPC Value** — how directly this refactoring addresses persona jobs, pains, or gains (1 = no relevance, 5 = resolves a critical persona pain or delivers a high-value gain). Set to 3 when `VPC_AVAILABLE=false`.
+
+**Scoring VPC Value** (only when `VPC_AVAILABLE=true`):
+
+For each finding, reason over `VPC_PROFILES`:
+
+- Does fixing this reduce a **Critical/High pain** for any persona? (e.g. complex logic → harder to trust AI output → Alex's "agents go off the rails" pain) → score 4–5
+- Does fixing this deliver a **High gain** for any persona? (e.g. extracting a function → cleaner API surface → easier onboarding → Sara's gain) → score 3–4
+- Is there indirect persona value? (e.g. dead code removal → smaller codebase → easier contributor review → Kai) → score 2–3
+- No clear persona relevance → score 1–2
+
+Assign one `vpc_value` integer per finding, and note the **primary persona** and **rationale** (one sentence).
+
+**Composite score**: `impact * 2 + (6 - effort) + vpc_value`. Higher is better.
+
+Sort all findings by composite score descending. If the same code block was flagged by multiple categories, keep only the highest-scored entry and discard the duplicates.
+
+---
+
+## Phase 4: Create GitHub Issues
+
+Skip this phase if `GH_AVAILABLE=false` or `DRY_RUN=true`.
+
+First ensure the tracking labels exist:
+
+```bash
+gh label create "refactor-opportunity" --color "B60205" --force
+```
+
+Fetch existing open issues that already carry the label to avoid duplicates:
+
+```bash
+gh issue list --label "refactor-opportunity" --state open --limit 100 --json number,title
+```
+
+For each of the **top 5** findings (by composite score) that does not already have a matching open issue, create a GitHub Issue with the following body:
+
+```
+## Refactoring Opportunity: {description}
+
+**Category**: {category}
+**File**: {file}:{line_range}
+**Impact**: {impact}/5 | **Effort**: {effort}/5 | **Score**: {composite}
+{vpc_line}
+
+### Current Code
+```{lang}
+{current_snippet}
+```
+
+### Proposed Refactoring
+```{lang}
+{proposed_snippet}
+```
+
+### Rationale
+{rationale}
+
+---
+_Generated by `/specrails:refactor-recommender` in specrails-core_
+```
+
+Where `{vpc_line}` is included only when `VPC_AVAILABLE=true`:
+`**VPC Value**: {vpc_value}/5 — {vpc_persona}: {vpc_rationale}`
+
+---
+
+## Phase 5: Output Summary
+
+Print the following report:
+
+```
+## Refactoring Opportunities — specrails-core
+
+{N} opportunities found | Sorted by composite score
+{vpc_header}
+
+| # | Category | File | Impact | Effort | VPC | Score | Description |
+|---|----------|------|--------|--------|-----|-------|-------------|
+| 1 | {category} | {file}:{line_range} | {impact}/5 | {effort}/5 | {vpc_value}/5 | {composite} | {description} |
+...
+
+### Top 3 Detailed Recommendations
+
+#### 1. {description}
+**File**: {file}:{line_range}
+**Category**: {category} | **Score**: {composite}
+{vpc_detail}
+
+**Current:**
+```{lang}
+{current_snippet}
+```
+
+**Proposed:**
+```{lang}
+{proposed_snippet}
+```
+
+**Rationale:** {rationale}
+
+(repeat for #2 and #3)
+
+Issues created: {N}  (or "dry-run: no issues created")
+```
+
+Where:
+- `{vpc_header}` is `VPC personas loaded: {persona names}` when `VPC_AVAILABLE=true`, or `VPC personas: not found (run /specrails:enrich to enable)` otherwise.
+- `{vpc_detail}` is `**VPC Value**: {vpc_value}/5 — {vpc_persona}: {vpc_rationale}` when `VPC_AVAILABLE=true`, omitted otherwise.

--- a/.claude/commands/specrails/retry.md
+++ b/.claude/commands/specrails/retry.md
@@ -1,0 +1,363 @@
+---
+name: "Smart Failure Recovery"
+description: "Resume a failed /specrails:implement pipeline from the last successful phase without restarting from scratch."
+category: Workflow
+tags: [workflow, recovery, retry, resilience]
+phases:
+  - key: load
+    label: Load State
+    description: "Read pipeline state from disk and identify the resume point"
+  - key: resume
+    label: Resume
+    description: "Execute remaining phases starting from the failed phase"
+  - key: report
+    label: Report
+    description: "Print a final status report with outcomes and next steps"
+---
+
+Resume a failed `/specrails:implement` run for **specrails-core**. Reads pipeline state written by the implement pipeline to identify which phases completed and which failed, then re-executes only the remaining phases.
+
+**MANDATORY: Follow this pipeline exactly. Do NOT skip phases or re-run phases that already succeeded. Read all context from the pipeline state file — do not rely on memory. Do not re-implement anything yourself; delegate to the same agents used by `/specrails:implement`.**
+
+**Input:** $ARGUMENTS — accepted forms:
+
+1. `<feature-name>` — kebab-case feature name matching a `.claude/pipeline-state/<feature-name>.json` file
+2. `--list` — list all available pipeline state files and their current status, then exit
+3. `<feature-name> --from <phase>` — force resume from a specific phase (overrides auto-detection)
+4. `<feature-name> --dry-run` — override to resume in dry-run mode (no git/PR operations)
+
+---
+
+## Phase 0: Parse Input
+
+Scan `$ARGUMENTS` for flags:
+
+- `--list`: if present, set `LIST_ONLY=true`.
+- `--from <phase>`: if present, set `RESUME_FROM_OVERRIDE=<phase>`. Valid values: `architect`, `developer`, `test-writer`, `doc-sync`, `reviewer`, `ship`, `ci`.
+- `--dry-run`: if present, set `DRY_RUN_OVERRIDE=true`.
+
+Extract the first positional argument (not starting with `--`) as `FEATURE_NAME`.
+
+**If `--list`:** scan `.claude/pipeline-state/*.json`. For each file found, parse and print:
+
+```
+## Available Pipeline States
+
+| Feature | Last Successful Phase | Failed Phase | Updated At |
+|---------|----------------------|--------------|------------|
+| <name>  | <phase or —>         | <phase or —> | <ISO time> |
+```
+
+If no files found: print `No pipeline state files found. Run /specrails:implement first.`
+
+Exit after printing — do not proceed.
+
+**If no positional argument and no `--list`:** print the following usage and exit:
+
+```
+Usage: /specrails:retry <feature-name> [--from <phase>] [--dry-run]
+       /specrails:retry --list
+
+Phases: architect | developer | test-writer | doc-sync | reviewer | ship | ci
+```
+
+---
+
+## Phase 1: Load Pipeline State
+
+Read: `.claude/pipeline-state/<FEATURE_NAME>.json`
+
+If the file does not exist:
+
+```
+[retry] Error: no pipeline state found for "<FEATURE_NAME>".
+
+Run /specrails:retry --list to see available states, or start a new run:
+  /specrails:implement <your input>
+```
+
+Exit.
+
+Parse the state file and set the following variables:
+
+- `LAST_SUCCESSFUL_PHASE` ← `last_successful_phase` (may be `null`)
+- `FAILED_PHASE` ← `failed_phase` (may be `null`)
+- `ERROR_CONTEXT` ← `error_context` (may be `null`)
+- `OPENSPEC_ARTIFACTS` ← `openspec_artifacts` (e.g. `openspec/changes/<name>/`)
+- `IMPLEMENTED_FILES` ← `implemented_files` (array, may be empty)
+- `ORIGINAL_ISSUES` ← `input.issues` (array of issue numbers, may be `null`)
+- `ORIGINAL_INPUT_FLAGS` ← `input.flags` object
+- `SINGLE_MODE` ← `input.flags.single_mode` (default `true`)
+- `DRY_RUN` ← if `DRY_RUN_OVERRIDE=true` then `true`, else `input.flags.dry_run` (default `false`)
+- `PHASE_STATUSES` ← `phases` map (`architect`, `developer`, `test-writer`, `doc-sync`, `reviewer`, `ship`, `ci` → `"done"`, `"failed"`, `"skipped"`, or `"pending"`)
+
+**Validation:**
+
+- If all phases are `"pending"`: the pipeline never reached any execution. Print:
+  ```
+  [retry] Warning: all phases are pending — the pipeline may not have started.
+  Recommend running /specrails:implement instead.
+  ```
+  Prompt: `Proceed anyway? [y/N]`. If `n` or no response: exit.
+
+---
+
+## Phase 2: Status Report
+
+Print the pipeline status:
+
+```
+## Pipeline State: <FEATURE_NAME>
+
+| Phase        | Status  | Notes                              |
+|--------------|---------|-------------------------------------|
+| architect    | done    |                                     |
+| developer    | done    |                                     |
+| test-writer  | FAILED  | <ERROR_CONTEXT or "no details">     |
+| doc-sync     | pending |                                     |
+| reviewer     | pending |                                     |
+| ship         | pending |                                     |
+| ci           | pending |                                     |
+
+Last successful phase : <LAST_SUCCESSFUL_PHASE or "none">
+Failed phase          : <FAILED_PHASE or "—">
+Error context         : <ERROR_CONTEXT or "no details recorded">
+OpenSpec artifacts    : <OPENSPEC_ARTIFACTS>
+Implemented files     : <count> file(s) tracked
+Original input        : <issues list or "text description">
+```
+
+---
+
+## Phase 3: Determine Resume Point
+
+**Phase execution order (canonical):**
+
+```
+architect → developer → test-writer → doc-sync → reviewer → ship → ci
+```
+
+**If `RESUME_FROM_OVERRIDE` is set:** use it as `RESUME_PHASE`. Validate it is one of the canonical values; if not, print an error and exit.
+
+**Otherwise, auto-detect:**
+
+1. If `FAILED_PHASE` is set: `RESUME_PHASE = FAILED_PHASE`.
+2. Else if `LAST_SUCCESSFUL_PHASE` is set: `RESUME_PHASE` = the next phase after `LAST_SUCCESSFUL_PHASE` in canonical order.
+3. Else: `RESUME_PHASE = architect` (no phases completed).
+
+Print the resume plan:
+
+```
+## Resume Plan
+
+Resuming from phase: <RESUME_PHASE>
+
+Phases to skip (already done):
+  ✓ <phase>   (done)
+  ✓ <phase>   (done)
+
+Phases to execute:
+  ► <RESUME_PHASE>    (resuming here)
+  · <next-phase>
+  · <next-phase>
+  ...
+```
+
+Prompt the user:
+
+```
+Proceed? [Y/n]
+```
+
+If `n` or no response: exit without changes.
+
+---
+
+## Phase 4: Execute Remaining Phases
+
+Execute phases in canonical order starting from `RESUME_PHASE`. For each phase:
+
+- If its status in `PHASE_STATUSES` is `"done"` AND it precedes `RESUME_PHASE` in canonical order: **skip** — do not re-run.
+- If it equals `RESUME_PHASE` or comes after: **run** it.
+
+After each phase completes (or fails), update `.claude/pipeline-state/<FEATURE_NAME>.json`:
+1. Read the current file.
+2. Set `phases.<phase-key>` to `"done"` or `"failed"`.
+3. If `"done"`: update `last_successful_phase`.
+4. If `"failed"`: update `failed_phase` and `error_context`.
+5. Update `updated_at` to current ISO 8601 timestamp.
+6. Overwrite the file.
+
+---
+
+### 4a. Phase: architect
+
+**Only runs if `RESUME_PHASE=architect`.**
+
+Verify that `ORIGINAL_ISSUES` is non-empty or a text description is recoverable. If neither is available: print an error and stop — the original input is required to re-run the architect.
+
+Launch **sr-architect** agent(s) exactly as described in Phase 3a of the implement pipeline. Pass:
+- Original issue numbers from `ORIGINAL_ISSUES` (or text description if stored in state)
+- Same OpenSpec output directory: `OPENSPEC_ARTIFACTS`
+
+Wait for all architects to complete.
+
+**Pipeline state update:** `architect` → `done` or `failed`.
+
+---
+
+### 4b. Phase: developer
+
+**Runs if `RESUME_PHASE` is `architect` or `developer`.**
+
+Before launching, verify architect artifacts exist:
+
+```bash
+ls <OPENSPEC_ARTIFACTS>tasks.md <OPENSPEC_ARTIFACTS>context-bundle.md
+```
+
+If missing and `RESUME_PHASE=developer`: print:
+
+```
+[retry] Error: architect artifacts not found at <OPENSPEC_ARTIFACTS>.
+Retry from the architect phase: /specrails:retry <FEATURE_NAME> --from architect
+```
+
+Stop.
+
+Launch **sr-developer** agent(s) exactly as described in Phase 3b of the implement pipeline.
+
+- If `SINGLE_MODE=true`: launch in main repo, foreground.
+- If `SINGLE_MODE=false`: launch in isolated worktrees, background.
+- If `DRY_RUN=true`: use the dry-run redirect instructions from Phase 3b.
+
+Wait for all developers to complete. Collect the list of files created or modified.
+
+**Pipeline state update:** `developer` → `done` (also update `implemented_files` in state with the collected file list) or `failed`.
+
+---
+
+### 4c. Phase: test-writer
+
+**Runs if `RESUME_PHASE` is `architect`, `developer`, or `test-writer`.**
+
+If `IMPLEMENTED_FILES` is empty: warn but continue — the sr-test-writer will discover files from git diff.
+
+Launch **sr-test-writer** agent(s) exactly as in Phase 3c of the implement pipeline. Pass:
+- `IMPLEMENTED_FILES_LIST`: the `implemented_files` array from state
+- `TASK_DESCRIPTION`: derived from `ORIGINAL_ISSUES` or architect artifacts
+
+Wait for completion. Failure is **non-blocking** — record `FAILED` and continue to next phase.
+
+**Pipeline state update:** `test-writer` → `done` or `failed`.
+
+---
+
+### 4d. Phase: doc-sync
+
+**Runs if `RESUME_PHASE` is any phase up to and including `doc-sync`.**
+
+Launch **sr-doc-sync** agent(s) exactly as in Phase 3d of the implement pipeline. Pass:
+- `IMPLEMENTED_FILES_LIST`: the `implemented_files` array from state
+- `TASK_DESCRIPTION`: derived from `ORIGINAL_ISSUES` or architect artifacts
+
+Wait for completion. Failure is **non-blocking** — record `FAILED` and continue.
+
+**Pipeline state update:** `doc-sync` → `done` or `failed`.
+
+---
+
+### 4e. Phase: reviewer
+
+**Runs if `RESUME_PHASE` is any phase up to and including `reviewer`.**
+
+Launch layer reviewers and the generalist sr-reviewer exactly as in Phase 4b of the implement pipeline. Pass:
+- `MODIFIED_FILES_LIST`: the `implemented_files` array from state
+- `PIPELINE_CONTEXT`: brief description from original input and issue titles
+- Layer reports from sr-frontend-reviewer, sr-backend-reviewer, sr-security-reviewer
+
+Wait for all to complete. Parse `SECURITY_BLOCKED`, `FRONTEND_STATUS`, `BACKEND_STATUS`.
+
+**Run the Confidence Gate (Phase 4b-conf)** exactly as defined in the implement pipeline.
+
+**Pipeline state update:** `reviewer` → `done` or `failed`.
+
+---
+
+### 4f. Phase: ship
+
+**Runs if `RESUME_PHASE` is `ship` or `ci`.**
+
+If `DRY_RUN=true`: skip git operations. Record skipped operations, print dry-run summary, proceed to Phase 5.
+
+Otherwise, run Phase 4c (ship) of the implement pipeline exactly as defined:
+- Security gate check (`SECURITY_BLOCKED`)
+- Conflict pre-check (Phase 4c.0)
+- Git branch creation, commit, push, PR creation
+- Backlog updates
+
+**Pipeline state update:** `ship` → `done` or `failed`.
+
+---
+
+### 4g. Phase: ci
+
+**Runs if ship succeeded and code was pushed.**
+
+Run Phase 4d (CI monitoring) of the implement pipeline exactly as defined. Check CI status, fix failures (up to 2 retries).
+
+**Pipeline state update:** `ci` → `done` or `failed`.
+
+---
+
+## Phase 5: Report
+
+Print the final report:
+
+```
+## Retry Complete: <FEATURE_NAME>
+
+Resumed from: <RESUME_PHASE>
+Phases executed this run: <comma-separated list>
+
+| Phase        | Status  |
+|--------------|---------|
+| architect    | done    |
+| developer    | done    |
+| test-writer  | done    |
+| doc-sync     | done    |
+| reviewer     | done    |
+| ship         | done    |
+| ci           | done    |
+```
+
+Include PR URL if ship ran successfully.
+
+**If any phase failed**, add:
+
+```
+## Failures
+
+| Phase       | Error Context          |
+|-------------|------------------------|
+| <phase>     | <error_context>        |
+
+Next steps:
+- To retry from the failed phase: /specrails:retry <FEATURE_NAME> --from <failed-phase>
+- To see all pipeline states: /specrails:retry --list
+- To restart from scratch: /specrails:implement <original-input>
+```
+
+---
+
+## Error Handling
+
+| Phase | Blocking? | On failure |
+|-------|-----------|------------|
+| architect | **Yes** | Stop — cannot proceed without OpenSpec artifacts |
+| developer | **Yes** | Stop — cannot proceed without implemented files |
+| test-writer | No | Record FAILED, continue to doc-sync |
+| doc-sync | No | Record FAILED, continue to reviewer |
+| reviewer | No | Report findings, continue to ship |
+| ship | **Yes** | Stop — report failure with git/PR context |
+| ci | **Yes** | Stop — report failure with CI log and fix suggestions |

--- a/.claude/commands/specrails/telemetry.md
+++ b/.claude/commands/specrails/telemetry.md
@@ -1,0 +1,552 @@
+---
+name: "Agent Telemetry & Cost Tracker"
+description: "Inspect per-agent execution metrics: token usage (input/output/cache), estimated API cost, run count, average duration, and success/failure rate. Reads Claude CLI JSONL session logs and agent-memory files. Outputs a cost dashboard with trend indicators and optimization recommendations."
+category: Workflow
+tags: [workflow, telemetry, cost, metrics, analytics, agents]
+---
+
+Analyze **specrails-core** agent execution telemetry — token usage, API cost estimates, run throughput, and performance trends across all `sr-*` agents.
+
+**Input:** `$ARGUMENTS` — optional flags:
+
+- `--period <filter>` — time window for analysis. Values: `today`, `week`, `all`. Default: `week`.
+- `--agent <name>` — focus on a single agent (e.g. `sr-developer`). Default: all agents.
+- `--format <fmt>` — output format: `markdown` or `json`. Default: `markdown`.
+- `--save` — write a snapshot to `.claude/telemetry/` after display.
+
+---
+
+## Phase 0: Argument Parsing
+
+Parse `$ARGUMENTS` to set runtime variables.
+
+**Variables to set:**
+
+- `PERIOD` — `"today"`, `"week"`, or `"all"`. Default: `"week"`.
+- `AGENT_FILTER` — string or empty string. Default: `""` (all agents).
+- `FORMAT` — `"markdown"` or `"json"`. Default: `"markdown"`.
+- `SAVE_SNAPSHOT` — boolean. Default: `false`.
+- `PERIOD_START` — ISO datetime lower bound derived from `PERIOD` and the current date/time. Set to `null` for `"all"`.
+
+**Parsing rules:**
+
+1. Scan `$ARGUMENTS` for `--period <value>`. Valid values: `today`, `week`, `all`. If an unknown value is found: print `Error: unknown period "<value>". Valid: today, week, all` and stop. Strip from arguments.
+2. Scan for `--agent <name>`. If found, set `AGENT_FILTER=<name>` (lowercase, strip leading `sr-` if the user omitted it — always normalize to `sr-<name>` form internally). Strip from arguments.
+3. Scan for `--format <value>`. Valid: `markdown`, `json`. Unknown value: print `Error: unknown format "<value>". Valid: markdown, json` and stop. Strip from arguments.
+4. Scan for `--save`. If found, set `SAVE_SNAPSHOT=true`. Strip from arguments.
+
+**Derive `PERIOD_START`:**
+
+- `today` → start of today (00:00:00 UTC of the current date)
+- `week` → 7 days ago at 00:00:00 UTC
+- `all` → `null` (no lower bound)
+
+**Print active configuration:**
+
+```
+Period: <today | last 7 days | all time>  Agent: <AGENT_FILTER or "all">  Format: <markdown|json>  Save: <yes|no>
+```
+
+---
+
+## Phase 1: Log Discovery
+
+Collect JSONL session log files that may contain Claude CLI usage data. Search the following locations in order; collect all matching files (do not stop at the first hit):
+
+### 1a. Project-scoped logs
+
+Check for `.jsonl` files under the project `.claude/` directory (excluding `.claude/agent-memory/` and `.claude/health-history/`):
+
+```bash
+find .claude/ -name "*.jsonl" \
+  -not -path ".claude/agent-memory/*" \
+  -not -path ".claude/health-history/*" \
+  -not -path ".claude/telemetry/*" 2>/dev/null
+```
+
+### 1b. Global Claude CLI logs
+
+Claude CLI stores project sessions under `~/.claude/projects/`. Derive the project hash from the current working directory's absolute path (Claude uses a URL-encoded or base64 path as the directory name). Try:
+
+```bash
+# Attempt 1: match by cwd
+PROJECT_HASH=$(ls ~/.claude/projects/ 2>/dev/null | while read d; do
+  cwd_file="$HOME/.claude/projects/$d/.cwd"
+  [ -f "$cwd_file" ] && grep -qF "$(pwd)" "$cwd_file" && echo "$d" && break
+done)
+
+# Attempt 2: glob all projects and filter by recent mtime if Attempt 1 fails
+```
+
+If a matching project directory is found, glob for JSONL files:
+
+```bash
+find "$HOME/.claude/projects/$PROJECT_HASH/" -name "*.jsonl" 2>/dev/null
+```
+
+### 1c. Explicit log paths
+
+Also check these well-known paths:
+
+- `~/.claude/logs/*.jsonl`
+- `.claude/runs/*.jsonl`
+
+### 1d. Collect results
+
+Set `LOG_FILES` = deduplicated list of all discovered `.jsonl` paths, sorted by modification time descending.
+
+Apply time filter: if `PERIOD_START` is not null, exclude files whose last modification time is before `PERIOD_START`.
+
+**Print discovery summary:**
+
+```
+Log files discovered: N  (project-scoped: N | global: N | other: N)
+```
+
+If `LOG_FILES` is empty:
+```
+No JSONL session logs found. Telemetry will be derived from agent-memory metadata only.
+Log locations searched:
+  - .claude/**/*.jsonl
+  - ~/.claude/projects/<hash>/**/*.jsonl
+  - ~/.claude/logs/*.jsonl
+  - .claude/runs/*.jsonl
+
+To enable richer telemetry, configure Claude CLI to persist session logs.
+```
+
+Set `LOGS_AVAILABLE=false` and continue (the command falls back to agent-memory in Phase 3).
+
+---
+
+## Phase 2: Parse Session Logs
+
+Skip this phase if `LOGS_AVAILABLE=false`.
+
+For each file in `LOG_FILES`, read line-by-line and parse each valid JSON object. Extract records that match the Claude CLI session result schema.
+
+### 2a. Record schema
+
+A valid telemetry record has the following structure (fields may be absent — treat missing as null/zero):
+
+```json
+{
+  "type":            "result" | "assistant" | "tool_result" | ...,
+  "session_id":      "<uuid>",
+  "agent":           "<agent-name>",
+  "model":           "<model-id>",
+  "duration_ms":     12345,
+  "is_error":        false,
+  "usage": {
+    "input_tokens":                 1000,
+    "output_tokens":                500,
+    "cache_read_input_tokens":      200,
+    "cache_creation_input_tokens":  50
+  },
+  "timestamp":       "<ISO 8601>"
+}
+```
+
+**Extraction rules:**
+
+- Include records where `type` is `"result"` or where `usage` is present with at least one non-zero token count.
+- Infer `agent` name from:
+  1. The `agent` field directly (if present).
+  2. The source log file path (if the path contains `sr-<name>`, extract it).
+  3. A `system_prompt` field snippet (if present): match against known agent persona names (`sr-architect`, `sr-developer`, `sr-test-writer`, `sr-reviewer`, `sr-security-reviewer`, `sr-doc-sync`, `sr-product-analyst`, `sr-product-manager`).
+  4. If agent cannot be determined: assign to the bucket `"unknown"`.
+- Apply time filter: if `PERIOD_START` is not null, skip records where `timestamp < PERIOD_START`.
+- If `AGENT_FILTER` is set, skip records where the resolved agent name does not match.
+
+### 2b. Build RAW_RECORDS
+
+`RAW_RECORDS` = list of parsed records, each normalized to:
+
+```
+{ session_id, agent, model, timestamp, duration_ms, is_error, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens }
+```
+
+Where `is_error` defaults to `false` and missing token counts default to `0`.
+
+**Print:**
+
+```
+Parsed N records from N log files.
+```
+
+---
+
+## Phase 3: Agent-Memory Inventory
+
+Regardless of `LOGS_AVAILABLE`, collect metadata from `.claude/agent-memory/sr-*/`.
+
+For each directory:
+
+- `AGENT_NAME` — directory name (e.g. `sr-developer`)
+- `FILE_COUNT` — total files in the directory
+- `LAST_MODIFIED` — ISO date of the most recently modified file
+
+If `AGENT_FILTER` is set, collect only the matching directory.
+
+Set `MEMORY_AGENTS` = list of `{ agent_name, file_count, last_modified }`.
+
+**If `LOGS_AVAILABLE=false`**, synthesize a minimal telemetry record per agent from agent-memory presence only:
+
+```
+{ agent: <agent_name>, run_count: "unknown", last_active: <last_modified>, tokens: null, cost: null }
+```
+
+This allows the dashboard to at least list known agents and their last activity.
+
+---
+
+## Phase 4: Aggregate Per-Agent Metrics
+
+Group `RAW_RECORDS` by `agent`. For each agent, compute:
+
+| Metric | Derivation |
+|--------|-----------|
+| `run_count` | Count of records for this agent |
+| `success_count` | Count where `is_error=false` |
+| `failure_count` | Count where `is_error=true` |
+| `success_rate` | `success_count / run_count * 100` (%) |
+| `total_input_tokens` | Sum of `input_tokens` |
+| `total_output_tokens` | Sum of `output_tokens` |
+| `total_cache_read_tokens` | Sum of `cache_read_tokens` |
+| `total_cache_write_tokens` | Sum of `cache_write_tokens` |
+| `total_tokens` | Sum of all token types |
+| `avg_input_tokens` | `total_input_tokens / run_count` |
+| `avg_output_tokens` | `total_output_tokens / run_count` |
+| `avg_duration_ms` | Mean of non-null `duration_ms` values |
+| `p50_duration_ms` | Median of non-null `duration_ms` values |
+| `p95_duration_ms` | 95th percentile of non-null `duration_ms` values |
+| `last_active` | Max `timestamp` across all records |
+| `models_used` | Deduplicated list of `model` values observed |
+
+Set `AGENT_METRICS` = map of agent name → aggregated metrics object.
+
+Also compute `TOTALS`:
+
+| Field | Derivation |
+|-------|-----------|
+| `total_runs` | Sum of `run_count` across all agents |
+| `total_successes` | Sum of `success_count` |
+| `total_failures` | Sum of `failure_count` |
+| `overall_success_rate` | `total_successes / total_runs * 100` (%) |
+| `grand_total_input_tokens` | Sum across all agents |
+| `grand_total_output_tokens` | Sum across all agents |
+| `grand_total_cache_read_tokens` | Sum across all agents |
+| `grand_total_cache_write_tokens` | Sum across all agents |
+| `grand_total_tokens` | Sum across all agents |
+
+---
+
+## Phase 5: Cost Estimation
+
+Compute estimated API cost per agent using published Claude pricing (per million tokens). Use the `models_used` field to select the correct rate card. If multiple models were used, compute cost per-model and sum.
+
+**Default rate cards (USD per million tokens):**
+
+| Model family | Input | Output | Cache read | Cache write |
+|---|---|---|---|---|
+| `claude-opus-4*` | $15.00 | $75.00 | $1.50 | $3.75 |
+| `claude-sonnet-4*` | $3.00 | $15.00 | $0.30 | $0.75 |
+| `claude-haiku-4*` | $0.25 | $1.25 | $0.025 | $0.0625 |
+| `unknown` | $3.00 | $15.00 | $0.30 | $0.75 |
+
+Match model IDs by prefix (e.g. `claude-sonnet-4-6` → `claude-sonnet-4*`). If a model cannot be matched, use the `unknown` rate card and flag it in output.
+
+**Per-agent cost formula:**
+
+```
+cost = (input_tokens / 1_000_000 * input_rate)
+     + (output_tokens / 1_000_000 * output_rate)
+     + (cache_read_tokens / 1_000_000 * cache_read_rate)
+     + (cache_write_tokens / 1_000_000 * cache_write_rate)
+```
+
+Compute:
+
+- `agent_cost` — total cost for the agent across all records in the current period
+- `avg_cost_per_run` — `agent_cost / run_count`
+- `cache_savings` — tokens saved by cache reads, expressed as cost equivalent:
+  `cache_read_tokens / 1_000_000 * (input_rate - cache_read_rate)`
+
+Add `agent_cost`, `avg_cost_per_run`, and `cache_savings` to each agent's metrics object.
+
+Also compute:
+
+- `TOTAL_COST` — sum of `agent_cost` across all agents
+- `TOTAL_CACHE_SAVINGS` — sum of `cache_savings` across all agents
+
+---
+
+## Phase 6: Trend Analysis
+
+Compare the current period's per-agent metrics against the previous equivalent period (loaded from `.claude/telemetry/` snapshots, if available).
+
+### 6a. Load Previous Snapshot
+
+Check `.claude/telemetry/` for JSON files matching `<YYYY-MM-DD>-<period>.json`. Select the snapshot from the previous equivalent period:
+
+- `today` → yesterday's `today` snapshot
+- `week` → the `week` snapshot from 7 days ago
+- `all` → skip trend analysis (no meaningful comparison baseline for "all time")
+
+Set `PREV_SNAPSHOT` = parsed JSON or `null` if not found / period is `"all"`.
+
+### 6b. Compute Trend Indicators
+
+If `PREV_SNAPSHOT` is not null, for each agent compute deltas for these metrics vs. the previous snapshot:
+
+| Metric | Direction where higher is better |
+|--------|----------------------------------|
+| `run_count` | higher ↑ |
+| `success_rate` | higher ↑ |
+| `avg_duration_ms` | lower ↓ |
+| `total_tokens` | lower ↓ (efficiency) |
+| `agent_cost` | lower ↓ |
+| `cache_savings` | higher ↑ |
+
+Assign a trend label per metric:
+
+- `improving` — delta moves in the "better" direction by ≥ 5%
+- `degrading` — delta moves in the "worse" direction by ≥ 5%
+- `stable` — delta within ±5%
+- `new` — agent did not exist in the previous snapshot
+
+Set `TRENDS` = map of agent name → map of metric → `{ delta, direction, label }`.
+
+---
+
+## Phase 7: Display Dashboard
+
+Render output according to `FORMAT`.
+
+### FORMAT = "markdown"
+
+```
+## Agent Telemetry Dashboard — specrails-core
+Period: <today | last 7 days | all time>  |  As of: <ISO date>  |  Data source: <logs + memory | memory only>
+
+---
+
+### Summary
+
+| Metric | Value |
+|--------|-------|
+| Total runs | N |
+| Success rate | N% |
+| Total tokens consumed | N (input: N, output: N, cached: N) |
+| Estimated total cost | $N.NN |
+| Cache savings | $N.NN |
+| Active agents | N |
+
+---
+
+### Per-Agent Breakdown
+
+<For each agent, sorted by agent_cost descending:>
+
+#### <agent-name>  <trend badge: 🟢 improving | 🔴 degrading | 🟡 stable | 🆕 new>
+
+| Metric | Value | vs. Previous |
+|--------|-------|-------------|
+| Runs | N | <+N / -N / N/A> |
+| Success rate | N% | <trend indicator> |
+| Avg duration | Ns | <trend indicator> |
+| Total tokens | N | <trend indicator> |
+| — Input | N | |
+| — Output | N | |
+| — Cache reads | N | |
+| — Cache writes | N | |
+| Estimated cost | $N.NN | <trend indicator> |
+| Avg cost / run | $N.NN | |
+| Cache savings | $N.NN | <trend indicator> |
+| Models used | <model-id, ...> | |
+| Last active | <ISO date> | |
+
+<if success_rate < 80%:>
+⚠️  Low success rate detected. Check agent logs for recurring failures.
+
+<if avg_duration_ms > 120_000:>
+⚠️  Average run exceeds 2 minutes. Consider prompt optimization or task decomposition.
+
+---
+
+### Cost Distribution
+
+| Agent | Cost | % of Total | Trend |
+|-------|------|------------|-------|
+| sr-developer | $N.NN | N% | 🟢 improving |
+| ...          | ...   | ...| ...         |
+| **TOTAL**    | **$N.NN** | 100% | |
+
+---
+
+### Cache Efficiency
+
+Cache reads reduce cost compared to re-sending the same tokens as new input.
+
+| Agent | Cache Read Tokens | Savings | Hit Rate |
+|-------|------------------|---------|---------|
+| sr-developer | N | $N.NN | N% |
+| ... | ... | ... | ... |
+| **TOTAL** | N | **$N.NN** | |
+
+Cache hit rate = `cache_read_tokens / (input_tokens + cache_read_tokens) * 100`.
+
+---
+
+### Trend Summary
+
+<if PREV_SNAPSHOT is null:>
+No previous snapshot available for comparison (period: <PERIOD>).
+Run with `--save` to persist a baseline for future trend analysis.
+
+<if PREV_SNAPSHOT is not null:>
+
+| Agent | Runs Δ | Success Δ | Duration Δ | Cost Δ | Overall |
+|-------|--------|----------|-----------|--------|---------|
+| sr-developer | +N | +N% | -Ns | -$N.NN | 🟢 improving |
+| ...          | ...  | ...  | ...   | ...    | ...          |
+
+---
+
+### Recommendations
+
+<render only applicable items, in priority order:>
+
+1. **High failure rate** — if any agent has `success_rate < 80%`:
+   ```
+   ⚠️  <agent-name> has a N% success rate (N failures out of N runs).
+   Action: Review `.claude/agent-memory/<agent-name>/failure-patterns.md` for recurring errors.
+   ```
+
+2. **Cost outlier** — if any agent accounts for > 50% of total cost:
+   ```
+   💰  <agent-name> accounts for N% of total cost ($N.NN / $N.NN).
+   Action: Review average token consumption per run (avg input: N, avg output: N).
+            Consider shorter prompts, tighter context windows, or caching more aggressively.
+   ```
+
+3. **Cache underutilization** — if any agent's cache hit rate < 20% and run count ≥ 5:
+   ```
+   💡  <agent-name> cache hit rate is N% (N cache reads / N total input tokens).
+   Action: Ensure system prompts and static context are positioned where Claude can cache them.
+            Use the `--cache` flag if available in your Claude CLI version.
+   ```
+
+4. **Slow average duration** — if any agent's `avg_duration_ms > 120_000`:
+   ```
+   🐢  <agent-name> average run duration is Ns (target: <120s).
+   Action: Profile the longest phases. Consider breaking large tasks into smaller subtasks.
+   ```
+
+5. **Degrading trend** — if any agent's overall trend is "degrading":
+   ```
+   📉  <agent-name> metrics are degrading vs. the previous period.
+   Check: success rate, token usage, and cost deltas in the Per-Agent Breakdown above.
+   ```
+
+6. **Memory not cleared** — if any agent has > 50 memory files:
+   ```
+   🗂️  <agent-name> has N memory files. Large memory stores may slow context loading.
+   Action: Run `/specrails:memory-inspect --prune` to clean stale entries.
+   ```
+
+7. **Data gap warning** — if `LOGS_AVAILABLE=false`:
+   ```
+   ℹ️  Telemetry is based on agent-memory metadata only (no JSONL logs found).
+   Token and cost data are unavailable. To enable full telemetry:
+     - Run /specrails:implement with Claude CLI configured to persist session logs.
+     - Check your Claude CLI version for `--output-format` or `--log` options.
+   ```
+
+8. **No issues found** — if none of the above apply:
+   ```
+   ✅  All agents are operating within healthy parameters.
+   ```
+```
+
+### FORMAT = "json"
+
+Emit a single JSON object to stdout:
+
+```json
+{
+  "schema_version": "1",
+  "project": "specrails-core",
+  "period": "<today|week|all>",
+  "period_start": "<ISO datetime or null>",
+  "generated_at": "<ISO datetime>",
+  "data_source": "<logs+memory|memory-only>",
+  "totals": {
+    "run_count": 0,
+    "success_rate": 0.0,
+    "total_input_tokens": 0,
+    "total_output_tokens": 0,
+    "total_cache_read_tokens": 0,
+    "total_cache_write_tokens": 0,
+    "grand_total_tokens": 0,
+    "total_cost_usd": 0.0,
+    "total_cache_savings_usd": 0.0,
+    "active_agents": 0
+  },
+  "agents": {
+    "<agent-name>": {
+      "run_count": 0,
+      "success_count": 0,
+      "failure_count": 0,
+      "success_rate": 0.0,
+      "total_input_tokens": 0,
+      "total_output_tokens": 0,
+      "total_cache_read_tokens": 0,
+      "total_cache_write_tokens": 0,
+      "total_tokens": 0,
+      "avg_input_tokens": 0,
+      "avg_output_tokens": 0,
+      "avg_duration_ms": 0,
+      "p50_duration_ms": 0,
+      "p95_duration_ms": 0,
+      "agent_cost_usd": 0.0,
+      "avg_cost_per_run_usd": 0.0,
+      "cache_savings_usd": 0.0,
+      "cache_hit_rate": 0.0,
+      "models_used": [],
+      "last_active": "<ISO datetime>",
+      "trend": {
+        "run_count": "stable",
+        "success_rate": "stable",
+        "avg_duration_ms": "stable",
+        "agent_cost_usd": "stable"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Phase 8: Store Snapshot (if --save)
+
+Skip if `SAVE_SNAPSHOT=false`.
+
+1. Determine filename: `<YYYY-MM-DD>-<period>.json` using today's ISO date and the `PERIOD` value.
+2. Create `.claude/telemetry/` if it does not exist.
+3. Write the JSON telemetry object (same schema as `FORMAT=json` output) to `.claude/telemetry/<filename>`.
+4. Print: `Stored: .claude/telemetry/<filename>`
+
+**Housekeeping:** If `.claude/telemetry/` contains more than 60 files, print:
+
+```
+Note: .claude/telemetry/ has N snapshots. Consider pruning old ones:
+  ls -t .claude/telemetry/ | tail -n +61 | xargs -I{} rm .claude/telemetry/{}
+```
+
+**Gitignore advisory:** Check whether `.claude/telemetry` appears in `.gitignore`. If not:
+
+```
+Tip: Telemetry snapshots are local artifacts. Add to .gitignore:
+  echo '.claude/telemetry/' >> .gitignore
+```

--- a/.claude/commands/specrails/why.md
+++ b/.claude/commands/specrails/why.md
@@ -1,0 +1,96 @@
+# /specrails:why — In-Context Help
+
+Searches explanation records written by sr-architect, sr-developer, and sr-reviewer agents
+during the OpenSpec implementation pipeline.
+
+Records are stored in `.claude/agent-memory/explanations/` as Markdown files with
+YAML frontmatter (agent, feature, tags, date).
+
+**Usage:**
+- `/specrails:why` — list the 20 most recent explanation records
+- `/specrails:why <query>` — search records by keyword or tag
+
+---
+
+## Step 1: Find explanation records
+
+Glob all files matching `.claude/agent-memory/explanations/*.md`.
+
+If the directory does not exist or contains no files:
+Print:
+```
+No explanation records found yet.
+
+Explanation records are written by the sr-architect, sr-developer, and sr-reviewer agents
+when they make significant decisions during feature implementation.
+
+Run `/specrails:implement` on a feature to generate your first explanation records.
+```
+Then stop.
+
+## Step 2: Handle no-argument mode (listing)
+
+If `$ARGUMENTS` is empty:
+
+Read each explanation record file. Extract from frontmatter: `date`, `agent`, `feature`, `tags`.
+Extract the first sentence of the `## Decision` section as the decision summary.
+
+Sort records by `date` descending. Print the 20 most recent as a Markdown table:
+
+```
+## Recent Explanation Records
+
+| Date | Agent | Feature | Tags | Decision |
+|------|-------|---------|------|----------|
+| 2026-03-14 | sr-architect | in-context-help | [templates, commands] | Chose flat directory over per-agent subdirectories. |
+| ...  | ...   | ...     | ...  | ...      |
+```
+
+Then stop.
+
+## Step 3: Handle query mode (search)
+
+If `$ARGUMENTS` is non-empty, treat the full string as the search query.
+
+For each explanation record file:
+1. Read the full file content
+2. Score the record against the query:
+   - Filename contains a query word: +3 points per matching word
+   - Frontmatter `tags` array contains an exact query word: +3 points per matching tag
+   - Frontmatter `feature` contains a query word: +2 points
+   - Body text contains a query word: +1 point per occurrence (case-insensitive)
+3. Sum the score
+
+Sort records by score descending. Take the top 5 records with score > 0.
+
+If no records score > 0:
+Print:
+```
+No explanation records match "<query>".
+```
+Then list all unique tags from existing records:
+```
+## Available Tags
+
+[sorted list of all unique tags from all explanation records]
+
+Try `/specrails:why <tag>` with one of the tags above, or `/specrails:why` to browse all records.
+```
+
+If records match, print each matching record in full, separated by `---`:
+
+```
+## Results for "<query>" (N matches)
+
+---
+
+**[date] [agent] — [feature]**
+Tags: [tag1, tag2]
+
+[full record body]
+
+---
+
+**[date] [agent] — [feature]**
+...
+```

--- a/.claude/rules/layer.md
+++ b/.claude/rules/layer.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - "/**"
+---
+
+#  Conventions
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ dist/
 # specrails
 .claude/agent-memory/
 .specrails/
+
+# Third-party / superseded self-install artifacts (not specrails-core deliverables)
+.claude/commands/opsx/
+.claude/skills/

--- a/src/installer/__tests__/agent-lifecycle.test.ts
+++ b/src/installer/__tests__/agent-lifecycle.test.ts
@@ -7,20 +7,15 @@ import { describe, expect, it } from 'vitest'
 /**
  * Lifecycle invariant tests for the three sr-* agent templates.
  *
- * These tests assert that the Claude agent templates drive the OpenSpec
- * lifecycle through the `openspec` CLI DIRECTLY — not via the interactive
- * `/opsx:*` Skill wrappers. Those wrappers call AskUserQuestion/TodoWrite and
- * pause for input, so inside a non-interactive subagent they stall and push
- * the agent to hand-author a "simulated" (CLI-unregistered) change:
+ * These tests assert that the templates contain the structural patterns
+ * required by the fix-agent-openspec-lifecycle change:
  *
- *   - sr-architect: scaffolds via `openspec new change` + `openspec validate`
- *                   (no Skill/opsx:ff indirection); specName guard; never
- *                   hand-creates the change directory
- *   - sr-developer: drives tasks.md directly (no Skill/opsx:apply); checkbox
- *                   gate `- [ ]` checked; specName guard; Phase 4 prerequisite
- *   - sr-reviewer:  task gate present; archives via `openspec archive -y` and
- *                   `openspec validate --strict` (no Skill/opsx:archive);
- *                   specName guard
+ *   - sr-architect: scaffolds via opsx:ff only (no opsx:new — ff creates the
+ *                   change itself); specName guard; hand-authoring prohibition
+ *   - sr-developer: opsx:apply present; checkbox gate `- [ ]` checked;
+ *                   specName guard present; Phase 4 prerequisite note present
+ *   - sr-reviewer:  task gate present; opsx:archive present;
+ *                   specName guard present
  *
  * Each invariant is tested against the two live Claude sources that must
  * stay in lockstep:
@@ -28,7 +23,10 @@ import { describe, expect, it } from 'vitest'
  *   - the installed Claude subagent file (.claude/agents/)
  *
  * Codex enforces the equivalent OpenSpec-CLI lifecycle through its own
- * codex-native skills; that contract is asserted at the bottom of this file.
+ * codex-native skills. Because codex reviewers run in PARALLEL and only the
+ * orchestrator holds the aggregated verdict, the archive obligation lives in
+ * the implement ORCHESTRATOR (not the reviewer rail). The codex archive
+ * contract is asserted at the bottom of this file.
  */
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -73,23 +71,22 @@ describe('sr-architect lifecycle invariants', () => {
         expect(content).toMatch(/\[error\] specName is required/)
       })
 
-      it('scaffolds via the openspec CLI directly (no Skill/opsx:* indirection)', () => {
+      it('scaffolds via opsx:ff only and does NOT pre-call opsx:new (which would make ff fail)', () => {
+        // Strip the frontmatter block before checking — the frontmatter
+        // legitimately mentions opsx:ff (to say the agent does NOT auto-trigger
+        // on it). opsx:ff already runs `openspec new change` internally, so a
+        // separate opsx:new Skill call makes ff abort with "Change already exists".
         const bodyStart = content.indexOf('\n---\n') + 5
         const body = content.slice(bodyStart)
-        // CLI-first: the agent runs `openspec new change` and validates.
-        expect(body).toMatch(/openspec new change/)
-        expect(body).toMatch(/openspec validate/)
-        // No interactive Skill wrappers — those stall in a non-interactive subagent.
-        expect(body).not.toMatch(/Skill\("opsx:/)
+        expect(body).toMatch(/Skill\("opsx:ff"/)
+        expect(body).not.toMatch(/Skill\("opsx:new"/)
       })
 
-      it('registers the change through the CLI and never hand-creates the change dir', () => {
-        // The agent authors the artifact PROSE, but the change itself must be
-        // registered by `openspec new change` — never mkdir'd by hand.
-        expect(content).toMatch(/never create the change directory/)
-        expect(content).toMatch(/proposal/)
+      it('prohibits hand-authoring of proposal.md, design.md, tasks.md', () => {
+        expect(content).toMatch(/MUST NOT hand-author/)
+        expect(content).toMatch(/proposal\.md/)
         expect(content).toMatch(/design\.md/)
-        expect(content).toMatch(/tasks/)
+        expect(content).toMatch(/tasks\.md/)
       })
     })
   }
@@ -108,11 +105,10 @@ describe('sr-developer lifecycle invariants', () => {
         expect(content).toMatch(/\[error\] specName is required/)
       })
 
-      it('drives tasks.md directly and does NOT use the opsx:apply Skill wrapper', () => {
-        expect(content).toMatch(/read the task list directly/)
-        expect(content).toMatch(/tasks\.md/)
-        // Must NOT route through the interactive Skill wrapper.
-        expect(content).not.toMatch(/Skill\("opsx:apply"/)
+      it('invokes opsx:apply via Skill tool before writing files', () => {
+        expect(content).toMatch(/opsx:apply/)
+        // Must instruct to use Skill tool, not shell command
+        expect(content).toMatch(/Skill\("opsx:apply"/)
       })
 
       it('contains checkbox verification gate checking for - [ ] pattern', () => {
@@ -154,20 +150,14 @@ describe('sr-reviewer lifecycle invariants', () => {
         expect(content).toMatch(/BLOCK archive/)
       })
 
-      it('archives via the openspec CLI (no opsx:archive Skill wrapper)', () => {
-        expect(content).toMatch(/openspec archive "<specName>" -y/)
-        // The real CLI archive syncs delta specs + moves the dir; the Skill
-        // wrapper does a manual move that skips sync and nests a Task spawn.
-        expect(content).not.toMatch(/Skill\("opsx:archive"/)
-      })
-
-      it('runs openspec validate --strict as a structural gate', () => {
-        expect(content).toMatch(/openspec validate "<specName>" --strict/)
+      it('invokes opsx:archive via Skill tool only when gate passes', () => {
+        expect(content).toMatch(/opsx:archive/)
+        expect(content).toMatch(/Skill\("opsx:archive"/)
       })
 
       it('states archive step is only reachable when task gate passes', () => {
-        // The CLI archive command must appear AFTER the Task Completion Gate.
-        const archiveIndex = content.indexOf('openspec archive "<specName>" -y')
+        // Step 6 (Archive) should be conditional on Step 5 (gate) passing
+        const archiveIndex = content.indexOf('opsx:archive')
         const gateIndex = content.indexOf('Task Completion Gate')
         expect(archiveIndex).toBeGreaterThanOrEqual(0)
         expect(gateIndex).toBeGreaterThanOrEqual(0)

--- a/src/installer/__tests__/agent-lifecycle.test.ts
+++ b/src/installer/__tests__/agent-lifecycle.test.ts
@@ -7,15 +7,20 @@ import { describe, expect, it } from 'vitest'
 /**
  * Lifecycle invariant tests for the three sr-* agent templates.
  *
- * These tests assert that the templates contain the structural patterns
- * required by the fix-agent-openspec-lifecycle change:
+ * These tests assert that the Claude agent templates drive the OpenSpec
+ * lifecycle through the `openspec` CLI DIRECTLY — not via the interactive
+ * `/opsx:*` Skill wrappers. Those wrappers call AskUserQuestion/TodoWrite and
+ * pause for input, so inside a non-interactive subagent they stall and push
+ * the agent to hand-author a "simulated" (CLI-unregistered) change:
  *
- *   - sr-architect: scaffolds via opsx:ff only (no opsx:new — ff creates the
- *                   change itself); specName guard; hand-authoring prohibition
- *   - sr-developer: opsx:apply present; checkbox gate `- [ ]` checked;
- *                   specName guard present; Phase 4 prerequisite note present
- *   - sr-reviewer:  task gate present; opsx:archive present;
- *                   specName guard present
+ *   - sr-architect: scaffolds via `openspec new change` + `openspec validate`
+ *                   (no Skill/opsx:ff indirection); specName guard; never
+ *                   hand-creates the change directory
+ *   - sr-developer: drives tasks.md directly (no Skill/opsx:apply); checkbox
+ *                   gate `- [ ]` checked; specName guard; Phase 4 prerequisite
+ *   - sr-reviewer:  task gate present; archives via `openspec archive -y` and
+ *                   `openspec validate --strict` (no Skill/opsx:archive);
+ *                   specName guard
  *
  * Each invariant is tested against the two live Claude sources that must
  * stay in lockstep:
@@ -23,10 +28,7 @@ import { describe, expect, it } from 'vitest'
  *   - the installed Claude subagent file (.claude/agents/)
  *
  * Codex enforces the equivalent OpenSpec-CLI lifecycle through its own
- * codex-native skills. Because codex reviewers run in PARALLEL and only the
- * orchestrator holds the aggregated verdict, the archive obligation lives in
- * the implement ORCHESTRATOR (not the reviewer rail). The codex archive
- * contract is asserted at the bottom of this file.
+ * codex-native skills; that contract is asserted at the bottom of this file.
  */
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -71,22 +73,23 @@ describe('sr-architect lifecycle invariants', () => {
         expect(content).toMatch(/\[error\] specName is required/)
       })
 
-      it('scaffolds via opsx:ff only and does NOT pre-call opsx:new (which would make ff fail)', () => {
-        // Strip the frontmatter block before checking — the frontmatter
-        // legitimately mentions opsx:ff (to say the agent does NOT auto-trigger
-        // on it). opsx:ff already runs `openspec new change` internally, so a
-        // separate opsx:new Skill call makes ff abort with "Change already exists".
+      it('scaffolds via the openspec CLI directly (no Skill/opsx:* indirection)', () => {
         const bodyStart = content.indexOf('\n---\n') + 5
         const body = content.slice(bodyStart)
-        expect(body).toMatch(/Skill\("opsx:ff"/)
-        expect(body).not.toMatch(/Skill\("opsx:new"/)
+        // CLI-first: the agent runs `openspec new change` and validates.
+        expect(body).toMatch(/openspec new change/)
+        expect(body).toMatch(/openspec validate/)
+        // No interactive Skill wrappers — those stall in a non-interactive subagent.
+        expect(body).not.toMatch(/Skill\("opsx:/)
       })
 
-      it('prohibits hand-authoring of proposal.md, design.md, tasks.md', () => {
-        expect(content).toMatch(/MUST NOT hand-author/)
-        expect(content).toMatch(/proposal\.md/)
+      it('registers the change through the CLI and never hand-creates the change dir', () => {
+        // The agent authors the artifact PROSE, but the change itself must be
+        // registered by `openspec new change` — never mkdir'd by hand.
+        expect(content).toMatch(/never create the change directory/)
+        expect(content).toMatch(/proposal/)
         expect(content).toMatch(/design\.md/)
-        expect(content).toMatch(/tasks\.md/)
+        expect(content).toMatch(/tasks/)
       })
     })
   }
@@ -105,10 +108,11 @@ describe('sr-developer lifecycle invariants', () => {
         expect(content).toMatch(/\[error\] specName is required/)
       })
 
-      it('invokes opsx:apply via Skill tool before writing files', () => {
-        expect(content).toMatch(/opsx:apply/)
-        // Must instruct to use Skill tool, not shell command
-        expect(content).toMatch(/Skill\("opsx:apply"/)
+      it('drives tasks.md directly and does NOT use the opsx:apply Skill wrapper', () => {
+        expect(content).toMatch(/read the task list directly/)
+        expect(content).toMatch(/tasks\.md/)
+        // Must NOT route through the interactive Skill wrapper.
+        expect(content).not.toMatch(/Skill\("opsx:apply"/)
       })
 
       it('contains checkbox verification gate checking for - [ ] pattern', () => {
@@ -150,14 +154,20 @@ describe('sr-reviewer lifecycle invariants', () => {
         expect(content).toMatch(/BLOCK archive/)
       })
 
-      it('invokes opsx:archive via Skill tool only when gate passes', () => {
-        expect(content).toMatch(/opsx:archive/)
-        expect(content).toMatch(/Skill\("opsx:archive"/)
+      it('archives via the openspec CLI (no opsx:archive Skill wrapper)', () => {
+        expect(content).toMatch(/openspec archive "<specName>" -y/)
+        // The real CLI archive syncs delta specs + moves the dir; the Skill
+        // wrapper does a manual move that skips sync and nests a Task spawn.
+        expect(content).not.toMatch(/Skill\("opsx:archive"/)
+      })
+
+      it('runs openspec validate --strict as a structural gate', () => {
+        expect(content).toMatch(/openspec validate "<specName>" --strict/)
       })
 
       it('states archive step is only reachable when task gate passes', () => {
-        // Step 6 (Archive) should be conditional on Step 5 (gate) passing
-        const archiveIndex = content.indexOf('opsx:archive')
+        // The CLI archive command must appear AFTER the Task Completion Gate.
+        const archiveIndex = content.indexOf('openspec archive "<specName>" -y')
         const gateIndex = content.indexOf('Task Completion Gate')
         expect(archiveIndex).toBeGreaterThanOrEqual(0)
         expect(gateIndex).toBeGreaterThanOrEqual(0)

--- a/templates/agents/sr-architect.md
+++ b/templates/agents/sr-architect.md
@@ -1,6 +1,6 @@
 ---
 name: sr-architect
-description: "This agent is launched by the orchestrator with a specName argument to scaffold OpenSpec artifacts and produce an implementation design for a named change. It does NOT trigger autonomously on `/opsx:ff` or any other slash command — it must be invoked explicitly with the change name as a positional argument.\n\nExamples:\n\n<example>\nContext: The orchestrator launches the architect agent to design a named OpenSpec change.\nuser: (orchestrator) Launch sr-architect with specName=my-feature\nassistant: \"I'm going to use the openspec CLI to scaffold the OpenSpec artifacts and produce the implementation design for 'my-feature'.\"\n</example>\n\n<example>\nContext: The orchestrator resumes an in-progress change by re-launching the architect with the change name.\nuser: (orchestrator) Continue design work for specName=my-feature\nassistant: \"I'll re-examine the existing artifacts for 'my-feature' and produce updated design and task breakdown.\"\n</example>"
+description: "This agent is launched by the orchestrator with a specName argument to scaffold OpenSpec artifacts and produce an implementation design for a named change. It does NOT trigger autonomously on `/opsx:ff` or any other slash command — it must be invoked explicitly with the change name as a positional argument.\n\nExamples:\n\n<example>\nContext: The orchestrator launches the architect agent to design a named OpenSpec change.\nuser: (orchestrator) Launch sr-architect with specName=my-feature\nassistant: \"I'm going to use the Skill tool to scaffold the OpenSpec artifacts and produce the implementation design for 'my-feature'.\"\n</example>\n\n<example>\nContext: The orchestrator resumes an in-progress change by re-launching the architect with the change name.\nuser: (orchestrator) Continue design work for specName=my-feature\nassistant: \"I'll re-examine the existing artifacts for 'my-feature' and produce updated design and task breakdown.\"\n</example>"
 model: sonnet
 color: green
 memory: project
@@ -51,43 +51,22 @@ Do not proceed with any design work, file reading, or artifact creation until sp
 
 When invoked by the orchestrator with a specName argument, you must execute the following steps in order:
 
-### Step 0: Scaffold OpenSpec Artifacts via the `openspec` CLI
+### Step 0: Scaffold OpenSpec Artifacts (execute `/opsx:ff`)
 
-Before any design work, scaffold the change for `<specName>` by driving the **`openspec` CLI directly with the Bash tool**. Do NOT use the Skill tool, and do NOT invoke `opsx:ff`, `opsx:new`, or any `/opsx:*` slash command — those are interactive, human-in-the-loop wrappers (they call `AskUserQuestion`/`TodoWrite` and pause for input), so inside this non-interactive subagent they stall and push you toward hand-authoring fake artifacts. The CLI is the source of truth: it registers the change against a workflow schema so it stays trackable by `openspec status` / `validate` / `archive`.
+Your **first action — before any analysis, design, or file writing — MUST be to actually invoke the OpenSpec fast-forward skill via the Skill tool**:
 
-Run these with Bash, in order:
+```
+Skill("opsx:ff", specName)
+```
 
-1. **Create the change (idempotent):**
-   ```bash
-   openspec new change "<specName>" --schema spec-driven
-   ```
-   - If it fails because OpenSpec is not initialised here, run `openspec init . --tools claude --force` once, then re-run.
-   - If `openspec/changes/<specName>/` already exists from a prior run, **reuse it** — skip this command.
-   - If the `openspec` CLI is not installed at all, HALT with `[error] openspec CLI not available — cannot scaffold change`. Do NOT hand-create the change directory as a fallback.
+This is a real tool call, not a description of intent. Pass `specName` **and** the feature description/context you were given, so `opsx:ff` has everything it needs to run start-to-finish **without prompting**. `opsx:ff` runs `openspec new change` and then generates `proposal.md`, `design.md`, the spec deltas under `specs/`, and `tasks.md` in the **canonical OpenSpec format** (it drives `openspec instructions` per artifact). These files are the single source of truth.
 
-2. **Get the artifact build order:**
-   ```bash
-   openspec status --change "<specName>" --json
-   ```
-   Parse `applyRequires` (artifacts required before implementation) and the `artifacts` array (status + dependencies).
-
-3. **Author each artifact in dependency order** (proposal → design + specs → tasks). For each artifact whose dependencies are satisfied:
-   ```bash
-   openspec instructions <artifact-id> --change "<specName>" --json
-   ```
-   The JSON returns `template` (structure to fill), `instruction` (schema guidance), `outputPath` (where to write), `context` / `rules` (constraints for YOU — do NOT copy them into the file), and `dependencies` (completed artifacts to read first). Write the file at `outputPath`, using `template` as the skeleton and filling it with the real design content from your Steps 1–6 analysis below. Re-run `openspec status … --json` after each write; continue until every `applyRequires` artifact is `status: "done"`.
-   - `design.md` MUST contain a `Scope:` line with comma-separated labels from `frontend`, `backend`, `both`, `security-sensitive`, `performance-sensitive`. The orchestrator parses it to route the developer and reviewer phases.
-
-4. **Mandatory validation gate (do not skip):**
-   ```bash
-   openspec validate "<specName>" --strict
-   ```
-   If it reports errors, fix the offending artifact and re-run until it passes. **Do NOT hand off a change that fails `openspec validate`.**
-
-**Critical rules:**
-- Scaffold via `openspec new change` — never create the change directory or `.openspec.yaml` by hand. You DO author the artifact *prose* (that is your job), but only inside the CLI-registered change directory, following the `openspec instructions` templates.
-- This entire step runs non-interactively — never prompt the user or wait for confirmation.
-- Proceed to Steps 1–6 only after `openspec validate` passes.
+**Critical rules — non-negotiable:**
+- You MUST actually call the Skill tool and let `opsx:ff` write the files. You MUST NOT hand-author `proposal.md`, `design.md`, or `tasks.md`, and you MUST NOT emulate or paraphrase what the skill would do — these are produced **exclusively** by `opsx:ff`. A `tasks.md` in any shape other than what `opsx:ff` writes is a defect.
+- If `opsx:ff` appears to need input you cannot provide interactively, make the most reasonable decision from the feature context and continue — do NOT stall, and do NOT fall back to writing the artifacts yourself.
+- Do NOT call `opsx:new` first. `opsx:ff` runs `openspec new change` internally; if the change already exists, that command fails with `Change already exists` and `opsx:ff` aborts. `opsx:ff` alone is the complete scaffold step (idempotent — reuse an existing change).
+- Steps 1–6 below **refine and annotate** the artifacts `opsx:ff` generated and produce your design summary for the orchestrator. They do NOT replace `opsx:ff`'s `tasks.md` with a different structure.
+- Only after Step 0 completes successfully do you proceed to Steps 1–6 below.
 
 ### 1. Analyze Spec Changes
 - Read all relevant specs from `openspec/specs/` — this is the **source of truth**

--- a/templates/agents/sr-architect.md
+++ b/templates/agents/sr-architect.md
@@ -1,6 +1,6 @@
 ---
 name: sr-architect
-description: "This agent is launched by the orchestrator with a specName argument to scaffold OpenSpec artifacts and produce an implementation design for a named change. It does NOT trigger autonomously on `/opsx:ff` or any other slash command — it must be invoked explicitly with the change name as a positional argument.\n\nExamples:\n\n<example>\nContext: The orchestrator launches the architect agent to design a named OpenSpec change.\nuser: (orchestrator) Launch sr-architect with specName=my-feature\nassistant: \"I'm going to use the Skill tool to scaffold the OpenSpec artifacts and produce the implementation design for 'my-feature'.\"\n</example>\n\n<example>\nContext: The orchestrator resumes an in-progress change by re-launching the architect with the change name.\nuser: (orchestrator) Continue design work for specName=my-feature\nassistant: \"I'll re-examine the existing artifacts for 'my-feature' and produce updated design and task breakdown.\"\n</example>"
+description: "This agent is launched by the orchestrator with a specName argument to scaffold OpenSpec artifacts and produce an implementation design for a named change. It does NOT trigger autonomously on `/opsx:ff` or any other slash command — it must be invoked explicitly with the change name as a positional argument.\n\nExamples:\n\n<example>\nContext: The orchestrator launches the architect agent to design a named OpenSpec change.\nuser: (orchestrator) Launch sr-architect with specName=my-feature\nassistant: \"I'm going to use the openspec CLI to scaffold the OpenSpec artifacts and produce the implementation design for 'my-feature'.\"\n</example>\n\n<example>\nContext: The orchestrator resumes an in-progress change by re-launching the architect with the change name.\nuser: (orchestrator) Continue design work for specName=my-feature\nassistant: \"I'll re-examine the existing artifacts for 'my-feature' and produce updated design and task breakdown.\"\n</example>"
 model: sonnet
 color: green
 memory: project
@@ -51,21 +51,43 @@ Do not proceed with any design work, file reading, or artifact creation until sp
 
 When invoked by the orchestrator with a specName argument, you must execute the following steps in order:
 
-### Step 0: Scaffold OpenSpec Artifacts
+### Step 0: Scaffold OpenSpec Artifacts via the `openspec` CLI
 
-Before any design work, scaffold the required OpenSpec artifacts for `<specName>` by invoking the OpenSpec fast-forward skill via the Skill tool:
+Before any design work, scaffold the change for `<specName>` by driving the **`openspec` CLI directly with the Bash tool**. Do NOT use the Skill tool, and do NOT invoke `opsx:ff`, `opsx:new`, or any `/opsx:*` slash command — those are interactive, human-in-the-loop wrappers (they call `AskUserQuestion`/`TodoWrite` and pause for input), so inside this non-interactive subagent they stall and push you toward hand-authoring fake artifacts. The CLI is the source of truth: it registers the change against a workflow schema so it stays trackable by `openspec status` / `validate` / `archive`.
 
-```
-Skill("opsx:ff", specName)
-```
+Run these with Bash, in order:
 
-`opsx:ff` creates the change directory AND generates `proposal.md`, `design.md`, and `tasks.md` in a single pass.
+1. **Create the change (idempotent):**
+   ```bash
+   openspec new change "<specName>" --schema spec-driven
+   ```
+   - If it fails because OpenSpec is not initialised here, run `openspec init . --tools claude --force` once, then re-run.
+   - If `openspec/changes/<specName>/` already exists from a prior run, **reuse it** — skip this command.
+   - If the `openspec` CLI is not installed at all, HALT with `[error] openspec CLI not available — cannot scaffold change`. Do NOT hand-create the change directory as a fallback.
+
+2. **Get the artifact build order:**
+   ```bash
+   openspec status --change "<specName>" --json
+   ```
+   Parse `applyRequires` (artifacts required before implementation) and the `artifacts` array (status + dependencies).
+
+3. **Author each artifact in dependency order** (proposal → design + specs → tasks). For each artifact whose dependencies are satisfied:
+   ```bash
+   openspec instructions <artifact-id> --change "<specName>" --json
+   ```
+   The JSON returns `template` (structure to fill), `instruction` (schema guidance), `outputPath` (where to write), `context` / `rules` (constraints for YOU — do NOT copy them into the file), and `dependencies` (completed artifacts to read first). Write the file at `outputPath`, using `template` as the skeleton and filling it with the real design content from your Steps 1–6 analysis below. Re-run `openspec status … --json` after each write; continue until every `applyRequires` artifact is `status: "done"`.
+   - `design.md` MUST contain a `Scope:` line with comma-separated labels from `frontend`, `backend`, `both`, `security-sensitive`, `performance-sensitive`. The orchestrator parses it to route the developer and reviewer phases.
+
+4. **Mandatory validation gate (do not skip):**
+   ```bash
+   openspec validate "<specName>" --strict
+   ```
+   If it reports errors, fix the offending artifact and re-run until it passes. **Do NOT hand off a change that fails `openspec validate`.**
 
 **Critical rules:**
-- You MUST NOT hand-author `proposal.md`, `design.md`, or `tasks.md` — these are produced exclusively by `opsx:ff`
-- Do NOT call `opsx:new` first. `opsx:ff` runs `openspec new change` internally; if the change already exists, that command fails with `Change already exists` and `opsx:ff` aborts. `opsx:ff` alone is the complete scaffold step.
-- `opsx:ff` runs non-interactively — do NOT prompt the user or ask for confirmation at any point
-- Only after Step 0 completes successfully do you proceed to Steps 1–6 below
+- Scaffold via `openspec new change` — never create the change directory or `.openspec.yaml` by hand. You DO author the artifact *prose* (that is your job), but only inside the CLI-registered change directory, following the `openspec instructions` templates.
+- This entire step runs non-interactively — never prompt the user or wait for confirmation.
+- Proceed to Steps 1–6 only after `openspec validate` passes.
 
 ### 1. Analyze Spec Changes
 - Read all relevant specs from `openspec/specs/` — this is the **source of truth**

--- a/templates/agents/sr-developer.md
+++ b/templates/agents/sr-developer.md
@@ -95,19 +95,15 @@ You MUST follow Test-Driven Development. This is non-negotiable. The cycle is: *
 
 ### Phase 3: Implement (TDD cycle)
 
-**Entry point: read the task list directly — do NOT use the Skill tool or invoke `/opsx:apply`.** The `opsx:apply` slash command is an interactive wrapper that prompts the user and pauses for guidance (`AskUserQuestion`, "wait for guidance"), so inside this non-interactive subagent it stalls instead of driving the loop. Drive it yourself against the on-disk artifacts:
+**Entry point: your first action in this phase MUST be to actually invoke the apply skill via the Skill tool** — this is a real tool call, not a description of intent:
 
-1. (Optional, for context) inspect progress and the context files to read:
-   ```bash
-   openspec status --change "<specName>" --json
-   openspec instructions apply --change "<specName>" --json
-   ```
-   Read every file listed under `contextFiles` (proposal, specs, design, tasks) before writing code.
-2. Open `openspec/changes/<specName>/tasks.md` and execute each task block **in order** using the RED → GREEN → REFACTOR cycle below. The moment a task's expected test state is observed, mark it complete in `tasks.md`: `- [ ]` → `- [x]`.
+```
+Skill("opsx:apply", specName)
+```
 
-Do NOT write production code without first reading `tasks.md` and the referenced spec/design artifacts.
+`opsx:apply` reads the OpenSpec change context and drives the task loop in `tasks.md`, marking each task `- [x]` as it is implemented. Do NOT write any production files before calling `opsx:apply`, and do NOT emulate it by editing `tasks.md` yourself outside the skill. Pass `specName` so it runs non-interactively; implement each task following the RED → GREEN → REFACTOR cycle below.
 
-**After every task is processed — Checkbox Verification Gate:**
+**After `opsx:apply` exits — Checkbox Verification Gate:**
 
 1. Read `openspec/changes/<specName>/tasks.md`
 2. Search for any lines matching the pattern `- [ ]` (hyphen, space, open-bracket, space, close-bracket)

--- a/templates/agents/sr-developer.md
+++ b/templates/agents/sr-developer.md
@@ -95,15 +95,19 @@ You MUST follow Test-Driven Development. This is non-negotiable. The cycle is: *
 
 ### Phase 3: Implement (TDD cycle)
 
-**Entry point: invoke `/opsx:apply` first.** Before writing any files, invoke the apply skill via the Skill tool:
+**Entry point: read the task list directly — do NOT use the Skill tool or invoke `/opsx:apply`.** The `opsx:apply` slash command is an interactive wrapper that prompts the user and pauses for guidance (`AskUserQuestion`, "wait for guidance"), so inside this non-interactive subagent it stalls instead of driving the loop. Drive it yourself against the on-disk artifacts:
 
-```
-Skill("opsx:apply", specName)
-```
+1. (Optional, for context) inspect progress and the context files to read:
+   ```bash
+   openspec status --change "<specName>" --json
+   openspec instructions apply --change "<specName>" --json
+   ```
+   Read every file listed under `contextFiles` (proposal, specs, design, tasks) before writing code.
+2. Open `openspec/changes/<specName>/tasks.md` and execute each task block **in order** using the RED → GREEN → REFACTOR cycle below. The moment a task's expected test state is observed, mark it complete in `tasks.md`: `- [ ]` → `- [x]`.
 
-Do NOT write production files directly without first calling `opsx:apply`. The apply command drives the task loop and records task completion state in `tasks.md`.
+Do NOT write production code without first reading `tasks.md` and the referenced spec/design artifacts.
 
-**After `opsx:apply` exits — Checkbox Verification Gate:**
+**After every task is processed — Checkbox Verification Gate:**
 
 1. Read `openspec/changes/<specName>/tasks.md`
 2. Search for any lines matching the pattern `- [ ]` (hyphen, space, open-bracket, space, close-bracket)

--- a/templates/agents/sr-reviewer.md
+++ b/templates/agents/sr-reviewer.md
@@ -112,31 +112,26 @@ After running CI checks, also review for:
 
 ## Workflow
 
-1. **Validate the OpenSpec change structure first** (mandatory gate):
-   ```bash
-   openspec validate "<specName>" --strict
-   ```
-   If it reports structural errors, the change is malformed — often a sign the artifacts were hand-authored instead of CLI-scaffolded. Treat this as a blocking issue: fix the offending artifact (or report it) and re-run until it passes before continuing.
-2. **Run all CI checks** (all layers, in the exact order CI runs them)
-3. **If anything fails**: Fix it, then re-run ALL checks from scratch (not just the failing one)
-4. **Repeat** up to 3 fix-and-verify cycles
-5. **Report** a summary of what passed, what failed, and what you fixed
-6. **Task Completion Gate** — Before archiving, verify all tasks are complete:
+1. **Run all CI checks** (all layers, in the exact order CI runs them)
+2. **If anything fails**: Fix it, then re-run ALL checks from scratch (not just the failing one)
+3. **Repeat** up to 3 fix-and-verify cycles
+4. **Report** a summary of what passed, what failed, and what you fixed
+5. **Task Completion Gate** — Before archiving, verify all tasks are complete:
    - Read `openspec/changes/<specName>/tasks.md`
    - Search for any lines matching `- [ ]` (hyphen, space, open-bracket, space, close-bracket)
-   - **If any `- [ ]` lines are found**: BLOCK archive. List every incomplete task title. Report to orchestrator that archive is blocked — do NOT archive.
-   - **If no `- [ ]` lines remain** (all tasks are `- [x]`): gate passes — proceed to Step 7.
-7. **Archive via the `openspec` CLI** — Only reachable when the Step 6 gate passes. Do NOT use the Skill tool or invoke `/opsx:archive`: that wrapper prompts the user, does a manual directory move that **skips spec-sync**, and nests a `Task` spawn — all of which break in this non-interactive subagent. Run the CLI directly instead:
-   ```bash
-   openspec validate "<specName>" --strict   # final structural check
-   openspec archive "<specName>" -y          # syncs delta specs into main specs AND moves the change to openspec/changes/archive/
+   - **If any `- [ ]` lines are found**: BLOCK archive. List every incomplete task title. Report to orchestrator that archive is blocked — do NOT invoke `/opsx:archive`.
+   - **If no `- [ ]` lines remain** (all tasks are `- [x]`): gate passes — proceed to Step 6.
+6. **Archive** — Only reachable when Step 5 gate passes. Your archive action MUST be a real call to the archive skill via the Skill tool (not a manual directory move, not an emulation):
    ```
-   Then confirm the archive landed:
-   ```bash
-   ls -d openspec/changes/archive/*<specName>* 2>/dev/null   # archive dir MUST exist
-   ls openspec/changes/<specName> 2>/dev/null                # original dir MUST be gone
+   Skill("opsx:archive", specName)
    ```
-   If either check fails, archiving did not complete — report `archive failed` to the orchestrator and do NOT treat the change as done. Run non-interactively; never prompt the user.
+   `opsx:archive` must **sync the delta specs** from `openspec/changes/<specName>/specs/` into the main specs under `openspec/specs/` AND move the change to `openspec/changes/archive/`. Pass `specName` so it runs non-interactively; do NOT prompt the user.
+
+   **Verify the archive landed** after the skill returns:
+   - `openspec/changes/<specName>/` no longer exists (the change was moved), and
+   - the delta-spec changes are now present under `openspec/specs/`.
+
+   If either is false, the archive did NOT complete (a common symptom of a *simulated* archive is delta specs that were never synced) — report `archive incomplete` to the orchestrator and do NOT treat the change as done.
 
 ## Write Failure Records
 

--- a/templates/agents/sr-reviewer.md
+++ b/templates/agents/sr-reviewer.md
@@ -112,20 +112,31 @@ After running CI checks, also review for:
 
 ## Workflow
 
-1. **Run all CI checks** (all layers, in the exact order CI runs them)
-2. **If anything fails**: Fix it, then re-run ALL checks from scratch (not just the failing one)
-3. **Repeat** up to 3 fix-and-verify cycles
-4. **Report** a summary of what passed, what failed, and what you fixed
-5. **Task Completion Gate** — Before archiving, verify all tasks are complete:
+1. **Validate the OpenSpec change structure first** (mandatory gate):
+   ```bash
+   openspec validate "<specName>" --strict
+   ```
+   If it reports structural errors, the change is malformed — often a sign the artifacts were hand-authored instead of CLI-scaffolded. Treat this as a blocking issue: fix the offending artifact (or report it) and re-run until it passes before continuing.
+2. **Run all CI checks** (all layers, in the exact order CI runs them)
+3. **If anything fails**: Fix it, then re-run ALL checks from scratch (not just the failing one)
+4. **Repeat** up to 3 fix-and-verify cycles
+5. **Report** a summary of what passed, what failed, and what you fixed
+6. **Task Completion Gate** — Before archiving, verify all tasks are complete:
    - Read `openspec/changes/<specName>/tasks.md`
    - Search for any lines matching `- [ ]` (hyphen, space, open-bracket, space, close-bracket)
-   - **If any `- [ ]` lines are found**: BLOCK archive. List every incomplete task title. Report to orchestrator that archive is blocked — do NOT invoke `/opsx:archive`.
-   - **If no `- [ ]` lines remain** (all tasks are `- [x]`): gate passes — proceed to Step 6.
-6. **Archive** — Only reachable when Step 5 gate passes. Invoke the archive skill via the Skill tool:
+   - **If any `- [ ]` lines are found**: BLOCK archive. List every incomplete task title. Report to orchestrator that archive is blocked — do NOT archive.
+   - **If no `- [ ]` lines remain** (all tasks are `- [x]`): gate passes — proceed to Step 7.
+7. **Archive via the `openspec` CLI** — Only reachable when the Step 6 gate passes. Do NOT use the Skill tool or invoke `/opsx:archive`: that wrapper prompts the user, does a manual directory move that **skips spec-sync**, and nests a `Task` spawn — all of which break in this non-interactive subagent. Run the CLI directly instead:
+   ```bash
+   openspec validate "<specName>" --strict   # final structural check
+   openspec archive "<specName>" -y          # syncs delta specs into main specs AND moves the change to openspec/changes/archive/
    ```
-   Skill("opsx:archive", specName)
+   Then confirm the archive landed:
+   ```bash
+   ls -d openspec/changes/archive/*<specName>* 2>/dev/null   # archive dir MUST exist
+   ls openspec/changes/<specName> 2>/dev/null                # original dir MUST be gone
    ```
-   Run non-interactively. Do NOT prompt the user or ask for confirmation.
+   If either check fails, archiving did not complete — report `archive failed` to the orchestrator and do NOT treat the change as done. Run non-interactively; never prompt the user.
 
 ## Write Failure Records
 

--- a/templates/commands/specrails/implement.md
+++ b/templates/commands/specrails/implement.md
@@ -617,7 +617,6 @@ If no shared files: print `No shared files detected. All features modify indepen
 ### 3a.2 Pre-validate architect output
 
 Quick-check each architect's artifacts:
-0. **OpenSpec CLI validation (hard gate):** run `openspec validate "<name>" --strict`. A pass proves the change was scaffolded through the `openspec` CLI and is structurally real. A failure (or a missing `openspec/changes/<name>/.openspec.yaml`) means the architect hand-authored a *simulated* change instead of running the CLI — treat the area as failed; do NOT proceed to developers for it.
 1. tasks.md exists and has tasks
 2. context-bundle.md exists
 3. File references are real (>70% must exist)

--- a/templates/commands/specrails/implement.md
+++ b/templates/commands/specrails/implement.md
@@ -617,6 +617,7 @@ If no shared files: print `No shared files detected. All features modify indepen
 ### 3a.2 Pre-validate architect output
 
 Quick-check each architect's artifacts:
+0. **OpenSpec CLI validation (hard gate):** run `openspec validate "<name>" --strict`. A pass proves the change was scaffolded through the `openspec` CLI and is structurally real. A failure (or a missing `openspec/changes/<name>/.openspec.yaml`) means the architect hand-authored a *simulated* change instead of running the CLI — treat the area as failed; do NOT proceed to developers for it.
 1. tasks.md exists and has tasks
 2. context-bundle.md exists
 3. File references are real (>70% must exist)


### PR DESCRIPTION
## What

Migrates the specrails agent/workflow templates from the legacy **skills** format to **slash commands**, and tightens how the `sr-*` agents drive OpenSpec.

### Changes
- **`templates/skills/**` → `templates/commands/specrails/**`**: the `sr-*` rails (architect/developer/reviewer/merge-resolver) and the standalone workflows (implement, batch-implement, compat-check, refactor-recommender, why, get/auto-propose-backlog-specs, enrich) move from `SKILL.md` files to command bodies. Net −4208 / +661 lines (large dead `SKILL.md` files removed).
- **`sr-*` agents EXECUTE the `/opsx:*` skills** rather than reimplementing the OpenSpec lifecycle with raw CLI calls. The architect/developer/reviewer invoke `/opsx:ff` → `/opsx:apply` → `/opsx:archive`; archive syncs delta → specs.
- Drops the `opsx:new` pre-call in the installed `sr-architect`.
- Adjusts `scaffold.ts` (and tests) + `schemas/profile.v1.json` to match the new command layout; codex-skills mirrors updated.

### Commits
- `refactor(templates): migrate skills templates to commands`
- `fix(agents): drop opsx:new pre-call in installed sr-architect`
- `fix(agents): drive OpenSpec via CLI directly, not interactive opsx:* skills`
- `fix(agents): make sr-* strictly EXECUTE the /opsx:* skills (supersede CLI approach)`

## Notes
- Meta-tool change: template edits affect all repos that re-run `/specrails:setup` (not retroactive).
- Branch is currently behind `main`; rebase before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)