### PR TITLE
docs(plugin): mark specrails-plugin as WIP / unpublished

### DIFF
--- a/specrails-plugin/README.md
+++ b/specrails-plugin/README.md
@@ -1,0 +1,39 @@
+# specrails-plugin — Claude Code plugin packaging (WIP / NOT published)
+
+> **Status: work in progress. This directory is NOT a live distribution channel.**
+> Do not treat the agents/skills here as the runtime source of truth.
+
+This folder packages SpecRails as a [Claude Code plugin](https://docs.claude.com/en/docs/claude-code/plugins)
+(the plugin-marketplace distribution model). It is **not currently published or wired up**:
+
+- **Not on npm.** `package.json`'s `files` field ships `bin/ dist/ templates/ commands/ docs/ schemas/` only — `specrails-plugin/` is excluded. `npx specrails-core …` users never receive it.
+- **No marketplace index.** Only `.claude-plugin/plugin.json` exists; there is no `marketplace.json`, so it cannot be added via `/plugin marketplace add`.
+- **Not referenced** by the installer or any CLI/build code.
+- **Not released.** `.github/workflows/release.yml` publishes the npm package only; nothing publishes this plugin.
+
+## The live distribution is the npm installer
+
+The supported, runtime source of truth is the **npm installer**:
+
+```
+npx specrails-core@latest init
+```
+
+It renders `templates/` (agents, commands, rules) into the target repo's provider directory
+(e.g. `.claude/agents/`). When you change agent behaviour, edit **`templates/agents/`** — that is
+what actually ships and runs.
+
+## ⚠️ This packaging is stale — re-sync before publishing
+
+The agents/skills under `specrails-plugin/` were copied from `templates/` at an earlier point and
+have **drifted**: there is no generator keeping them in sync, so they lag behind recent template
+changes (for example, the forced OpenSpec-skill-execution contract in `templates/agents/sr-*.md`).
+
+Before this plugin is ever published, it needs:
+
+1. a `.claude-plugin/marketplace.json` so it can be registered as a marketplace;
+2. a re-sync of `agents/`, `skills/`, `hooks/`, `references/` from `templates/` (the current copies
+   are outdated and, for the core pipeline agents, do not invoke the official `opsx:*` skills);
+3. ideally a **generator** (`templates/` → `specrails-plugin/`) so the two can never diverge again.
+
+Until then, fixes land in `templates/` (and the installed `.claude/agents/` of this repo), not here.


### PR DESCRIPTION
## What

Adds `specrails-plugin/README.md` marking the folder as **work-in-progress / not published**. No code, agent, or skill content changed.

## Why

`specrails-plugin/` is the Claude Code **plugin-marketplace** packaging of SpecRails, but it is currently dormant and easy to mistake for the runtime source of truth. Verified:

- **Not on npm** — `package.json` `files` ships `bin/ dist/ templates/ commands/ docs/ schemas/` only; the plugin dir is excluded.
- **No `marketplace.json`** — only `.claude-plugin/plugin.json` exists, so it can't be registered via `/plugin marketplace add`.
- **Unreferenced** by the installer / CLI / build.
- **Not released** — `release.yml` publishes the npm package only.
- **Stale** — its agents/skills drifted from `templates/` (no generator syncs them); the core pipeline agents there don't invoke the official `opsx:*` skills.

The README states plainly that the **npm installer (`templates/`) is the live source**, and lists what the plugin needs before publishing: a `marketplace.json`, a re-sync from `templates/`, and ideally a generator to prevent future drift.

Leaves the plugin content untouched on purpose (per request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)