### PR TITLE
fix: rename specrails-hub references to specrails-desktop

### DIFF
--- a/.claude/commands/specrails/batch-implement.md
+++ b/.claude/commands/specrails/batch-implement.md
@@ -192,7 +192,7 @@ For each wave `W`:
 2. For each feature batch of size ≤ `CONCURRENCY` within the wave:
    - For every ref in the batch, determine the profile spawn env:
      - If `PROFILE_MAP` contains an entry for this ref, set `SPECRAILS_PROFILE_PATH=<abs path to .specrails/profiles/<mapped-name>.json>` for this invocation only.
-     - Otherwise, inherit whatever `$SPECRAILS_PROFILE_PATH` was set by the caller (e.g. specrails-hub), or leave unset so the rail falls back to `.specrails/profiles/project-default.json` or legacy mode.
+     - Otherwise, inherit whatever `$SPECRAILS_PROFILE_PATH` was set by the caller (e.g. specrails-desktop), or leave unset so the rail falls back to `.specrails/profiles/project-default.json` or legacy mode.
    - Invoke `/specrails:implement` with the feature refs and forwarded flags:
      ```
      SPECRAILS_PROFILE_PATH=<resolved-per-rail-path> /specrails:implement <ref> [--dry-run]

--- a/.claude/commands/specrails/enrich.md
+++ b/.claude/commands/specrails/enrich.md
@@ -2,11 +2,11 @@
 
 Interactive wizard to configure the full agent workflow system for this repository. Analyzes the codebase, discovers target users, generates VPC personas, and creates all agents, commands, rules, and configuration adapted to this project. Supports config-driven mode for direct installation from a pre-built config file.
 
-**Prerequisites:** Ensure this repo was initialized with `npx specrails-core@latest init` (or via specrails-hub) so `.specrails/setup-templates/` exists.
+**Prerequisites:** Ensure this repo was initialized with `npx specrails-core@latest init` (or via specrails-desktop) so `.specrails/setup-templates/` exists.
 
-### Hub Checkpoint Protocol
+### Desktop App Checkpoint Protocol
 
-When running inside specrails-hub, emit checkpoint markers at key transitions so the hub `CheckpointTracker` can display progress. Each checkpoint is a single line printed to stdout:
+When running inside specrails-desktop, emit checkpoint markers at key transitions so the desktop app `CheckpointTracker` can display progress. Each checkpoint is a single line printed to stdout:
 
 ```
 [checkpoint:phase_1_analysis] Codebase analysis complete
@@ -16,7 +16,7 @@ When running inside specrails-hub, emit checkpoint markers at key transitions so
 [checkpoint:phase_5_cleanup] Cleanup and summary complete
 ```
 
-The hub parses these via `detectCheckpointFromText()` regex patterns. Always emit checkpoints at the end of each phase, even in `--from-config` and `--quick` modes.
+The desktop app parses these via `detectCheckpointFromText()` regex patterns. Always emit checkpoints at the end of each phase, even in `--from-config` and `--quick` modes.
 
 ---
 
@@ -937,7 +937,7 @@ Local tickets are always read-write — there is no "read only" mode since the f
 **Labels:** Freeform strings following the `area:*` and `effort:*` convention
 **Source values:** `manual`, `get-backlog-specs`, `propose-spec`
 
-**Advisory file locking protocol** (CLI agents and hub server must both follow this):
+**Advisory file locking protocol** (CLI agents and desktop app server must both follow this):
 
 The `revision` counter in the JSON root enables optimistic concurrency — increment it on **every** write. The lock file prevents concurrent corruption:
 
@@ -950,7 +950,7 @@ The `revision` counter in the JSON root enables optimistic concurrency — incre
 4. **Release lock:** Delete `.specrails/local-tickets.json.lock`
 5. **Always increment `revision`** by 1 and update `last_updated` on every successful write
 
-The hub server uses `proper-lockfile` (or equivalent) to honor the same protocol via the `.lock` file path.
+The desktop app server uses `proper-lockfile` (or equivalent) to honor the same protocol via the `.lock` file path.
 
 #### If GitHub Issues
 

--- a/.claude/commands/specrails/explore-spec.md
+++ b/.claude/commands/specrails/explore-spec.md
@@ -1,8 +1,8 @@
 ---
-description: Interactive thinking partner that helps the user shape a spec through conversation. Maintains a structured live draft via fenced spec-draft JSON blocks. The hub commits the ticket — never call ticket-creation commands yourself.
+description: Interactive thinking partner that helps the user shape a spec through conversation. Maintains a structured live draft via fenced spec-draft JSON blocks. The desktop app commits the ticket — never call ticket-creation commands yourself.
 ---
 
-You are a senior product engineer helping the user shape a single spec through conversation. The user has opened the **Explore Spec** experience inside specrails-hub. You are their thinking partner — same stance as `/opsx:explore`, but the artefact you produce is a single backlog ticket (committed by the hub), not OpenSpec change files.
+You are a senior product engineer helping the user shape a single spec through conversation. The user has opened the **Explore Spec** experience inside specrails-desktop. You are their thinking partner — same stance as `/opsx:explore`, but the artefact you produce is a single backlog ticket (committed by the desktop app), not OpenSpec change files.
 
 # Your role
 
@@ -45,11 +45,11 @@ You **MUST NOT**:
 - Call `/specrails:propose-spec`, `/specrails:implement`, or other slash commands that produce side effects.
 - Run shell commands beyond read-only inspection (`ls`, `cat`-equivalents via Read).
 
-You may **read** anywhere in the project. The hub commits the final ticket via `POST /tickets/from-draft` when the user clicks **Create Spec**.
+You may **read** anywhere in the project. The desktop app commits the final ticket via `POST /tickets/from-draft` when the user clicks **Create Spec**.
 
 # The structured draft protocol
 
-After every assistant turn that has new draft information, end your message with a fenced code block tagged `spec-draft` containing JSON. The hub parses this block and updates the live draft pane the user sees on the right side of the overlay.
+After every assistant turn that has new draft information, end your message with a fenced code block tagged `spec-draft` containing JSON. The desktop app parses this block and updates the live draft pane the user sees on the right side of the overlay.
 
 ```spec-draft
 {
@@ -76,11 +76,11 @@ Field semantics:
   - `## Technical Considerations` (bullet list)
   - `## Estimated Complexity` (`Low`/`Medium`/`High`/`Very High` plus one sentence)
   - **Never include a `## Spec Title` heading inside `description`** — the title lives in its own field. Repeating it inside the body produces redundant tickets.
-  - **Never duplicate the acceptance criteria inside `description`** — they live in their own `acceptanceCriteria` array. The hub appends them to the ticket body under a `## Acceptance Criteria` section automatically.
-- **`acceptanceCriteria`** is a separate array of short, testable bullet strings. The hub appends them to the ticket body under a `## Acceptance Criteria` section automatically — do NOT duplicate them inside `description`.
+  - **Never duplicate the acceptance criteria inside `description`** — they live in their own `acceptanceCriteria` array. The desktop app appends them to the ticket body under a `## Acceptance Criteria` section automatically.
+- **`acceptanceCriteria`** is a separate array of short, testable bullet strings. The desktop app appends them to the ticket body under a `## Acceptance Criteria` section automatically — do NOT duplicate them inside `description`.
 - **`chips`** are 0-3 short replies the user can click to send as their next message. Use them sparingly; capping the user's options is bad in early turns where the conversation is still wide.
 - **`ready: true`** signals "I think the draft is in good enough shape to commit." Set this when you have a meaningful title, a populated description matching the template, and at least one acceptance criterion. Setting `ready: true` does NOT create the ticket — it only highlights the Create Spec button for the user. The user is always the commit.
-- The block is **not shown to the user**. The hub strips it before rendering your message. So put your visible reasoning above the block, in plain prose.
+- The block is **not shown to the user**. The desktop app strips it before rendering your message. So put your visible reasoning above the block, in plain prose.
 
 # Language
 

--- a/.claude/commands/specrails/implement.md
+++ b/.claude/commands/specrails/implement.md
@@ -67,7 +67,7 @@ Agent discovery runs in one of two modes: **profile mode** (a profile JSON is ac
 
 A profile is active when either condition holds:
 
-1. The environment variable `SPECRAILS_PROFILE_PATH` is set AND points to a readable file. Tools like `specrails-hub` set this to a job-scoped snapshot.
+1. The environment variable `SPECRAILS_PROFILE_PATH` is set AND points to a readable file. Tools like `specrails-desktop` set this to a job-scoped snapshot.
 2. The file `.specrails/profiles/project-default.json` exists and is readable.
 
 If condition 1 holds, use `$SPECRAILS_PROFILE_PATH` as the profile path. Otherwise, if condition 2 holds, use `.specrails/profiles/project-default.json`. Otherwise, fall through to **legacy mode**.
@@ -146,7 +146,7 @@ Also store per-agent model overrides and the orchestrator model for use in later
 
 ```bash
 # ORCHESTRATOR_MODEL is informational; the caller is responsible for spawning
-# the orchestrator with this model (e.g. specrails-hub reads this field directly).
+# the orchestrator with this model (e.g. specrails-desktop reads this field directly).
 ORCHESTRATOR_MODEL="$(jq -r '.orchestrator.model' <<<"$PROFILE")"
 
 # Per-agent model overrides keyed by agent id.
@@ -170,7 +170,7 @@ Claude Code's Agent tool determines a subagent's model from the `model:` line in
 This rewrite is safe because:
 - Multi-feature runs execute in **isolated git worktrees** (`isolation: worktree`), so each rail mutates its own copy of `.claude/agents/` without cross-rail contention.
 - Single-feature runs are sequential within a single checkout.
-- The hub writes a job-scoped snapshot of the profile and spawns `claude` with `$SPECRAILS_PROFILE_PATH` pointing at it; the frontmatter rewrite follows the snapshot, never the catalog.
+- The desktop app writes a job-scoped snapshot of the profile and spawns `claude` with `$SPECRAILS_PROFILE_PATH` pointing at it; the frontmatter rewrite follows the snapshot, never the catalog.
 
 ```bash
 for id in "${!AGENT_MODEL[@]}"; do

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,14 +106,14 @@ Profile resolution at Phase -1 (highest wins):
 
 Schema: `schemas/profile.v1.json` (shipped in the npm package). Validator error messages MUST name the offending field. Baseline agents (`sr-architect`, `sr-developer`, `sr-reviewer`) are required in every valid profile.
 
-The schema's `$id` (`https://raw.githubusercontent.com/fjpulidop/specrails-core/main/schemas/profile.v1.json`) is the **canonical** identity of the v1 profile schema — specrails-core owns it. Downstream tools that vendor a copy (e.g. specrails-hub) MUST give any diverging copy a distinct `$id`; two schemas sharing this `$id` are asserted to be byte-equivalent.
+The schema's `$id` (`https://raw.githubusercontent.com/fjpulidop/specrails-core/main/schemas/profile.v1.json`) is the **canonical** identity of the v1 profile schema — specrails-core owns it. Downstream tools that vendor a copy (e.g. specrails-desktop) MUST give any diverging copy a distinct `$id`; two schemas sharing this `$id` are asserted to be byte-equivalent.
 
 ### Reserved paths (contract with downstream tools)
 
 The following paths are **reserved** — the installer (`init` / `update`) MUST NEVER create, modify, or delete files inside them:
 
-- `.specrails/profiles/**` — owned by projects (checked into git) and by tools like specrails-hub. Holds profile JSON files.
-- `.claude/agents/custom-*.md` — owned by user-authored or hub-generated custom agents. The `custom-` prefix is reserved for this purpose.
+- `.specrails/profiles/**` — owned by projects (checked into git) and by tools like specrails-desktop. Holds profile JSON files.
+- `.claude/agents/custom-*.md` — owned by user-authored or desktop-generated custom agents. The `custom-` prefix is reserved for this purpose.
 
 Audited by `src/installer/__tests__/reserved-paths.test.ts` on every CI run.
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ When running the pipeline, the active profile is resolved in this order:
 2. `<cwd>/.specrails/profiles/project-default.json`
 3. No profile — legacy behavior (identical to pre-4.1.0)
 
-Tools such as [specrails-hub](https://github.com/fjpulidop/specrails-hub) set `$SPECRAILS_PROFILE_PATH` to a job-scoped snapshot so concurrent rails can run independent profiles.
+Tools such as [specrails-desktop](https://github.com/fjpulidop/specrails-desktop) set `$SPECRAILS_PROFILE_PATH` to a job-scoped snapshot so concurrent rails can run independent profiles.
 
 ### Schema
 
@@ -232,10 +232,10 @@ Baseline agents (`sr-architect`, `sr-developer`, `sr-reviewer`) MUST appear in `
 
 The following paths are **reserved** — `specrails-core update` will never create, modify, or delete anything inside them:
 
-- `.specrails/profiles/**` — profile JSON files (yours and hub-authored).
+- `.specrails/profiles/**` — profile JSON files (yours and desktop-authored).
 - `.claude/agents/custom-*.md` — your custom agents. Use the `custom-` prefix to opt in to this protection.
 
-This contract is what lets you safely hand-author (or let specrails-hub author) profiles and custom agents without fear of the next `update` overwriting your work. Other paths managed by specrails-core (`.specrails/install-config.yaml`, `.specrails/specrails-version`, etc.) remain under update's control. Audited by `src/installer/__tests__/reserved-paths.test.ts` on every CI run.
+This contract is what lets you safely hand-author (or let specrails-desktop author) profiles and custom agents without fear of the next `update` overwriting your work. Other paths managed by specrails-core (`.specrails/install-config.yaml`, `.specrails/specrails-version`, etc.) remain under update's control. Audited by `src/installer/__tests__/reserved-paths.test.ts` on every CI run.
 
 ---
 
@@ -342,7 +342,7 @@ Yes. Everything runs locally through Claude Code. No external services beyond th
 
 ## Related
 
-- **[specrails-hub](https://github.com/fjpulidop/specrails-hub)** — desktop dashboard that visualises specrails pipelines (macOS, open source).
+- **[specrails-desktop](https://github.com/fjpulidop/specrails-desktop)** — desktop dashboard that visualises specrails pipelines (macOS, open source).
 - **[specrails.dev](https://specrails.dev)** — landing page and documentation.
 
 ---

--- a/commands/enrich.md
+++ b/commands/enrich.md
@@ -2,11 +2,11 @@
 
 Interactive wizard to configure the full agent workflow system for this repository. Analyzes the codebase, discovers target users, generates VPC personas, and creates all agents, commands, rules, and configuration adapted to this project. Supports config-driven mode for direct installation from a pre-built config file.
 
-**Prerequisites:** Ensure this repo was initialized with `npx specrails-core@latest init` (or via specrails-hub) so `.specrails/setup-templates/` exists.
+**Prerequisites:** Ensure this repo was initialized with `npx specrails-core@latest init` (or via specrails-desktop) so `.specrails/setup-templates/` exists.
 
-### Hub Checkpoint Protocol
+### Desktop App Checkpoint Protocol
 
-When running inside specrails-hub, emit checkpoint markers at key transitions so the hub `CheckpointTracker` can display progress. Each checkpoint is a single line printed to stdout:
+When running inside specrails-desktop, emit checkpoint markers at key transitions so the desktop app `CheckpointTracker` can display progress. Each checkpoint is a single line printed to stdout:
 
 ```
 [checkpoint:phase_1_analysis] Codebase analysis complete
@@ -16,7 +16,7 @@ When running inside specrails-hub, emit checkpoint markers at key transitions so
 [checkpoint:phase_5_cleanup] Cleanup and summary complete
 ```
 
-The hub parses these via `detectCheckpointFromText()` regex patterns. Always emit checkpoints at the end of each phase, even in `--from-config` and `--quick` modes.
+The desktop app parses these via `detectCheckpointFromText()` regex patterns. Always emit checkpoints at the end of each phase, even in `--from-config` and `--quick` modes.
 
 ---
 
@@ -890,7 +890,7 @@ Local tickets are always read-write — there is no "read only" mode since the f
 **Labels:** Freeform strings following the `area:*` and `effort:*` convention
 **Source values:** `manual`, `get-backlog-specs`, `propose-spec`
 
-**Advisory file locking protocol** (CLI agents and hub server must both follow this):
+**Advisory file locking protocol** (CLI agents and desktop app server must both follow this):
 
 The `revision` counter in the JSON root enables optimistic concurrency — increment it on **every** write. The lock file prevents concurrent corruption:
 
@@ -903,7 +903,7 @@ The `revision` counter in the JSON root enables optimistic concurrency — incre
 4. **Release lock:** Delete `.specrails/local-tickets.json.lock`
 5. **Always increment `revision`** by 1 and update `last_updated` on every successful write
 
-The hub server uses `proper-lockfile` (or equivalent) to honor the same protocol via the `.lock` file path.
+The desktop app server uses `proper-lockfile` (or equivalent) to honor the same protocol via the `.lock` file path.
 
 #### If GitHub Issues
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -37,7 +37,7 @@ Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
 
 ## Known limitations
 
-- **PATH refresh after installing new tools.** Windows GUI shells (Explorer, launcher-started apps) do not re-read PATH until logout/login. If you install `claude.cmd` and launch specrails-hub immediately, the hub's sidecar may not see it. Restart the app after changes to the Env Vars dialog, or launch from a fresh PowerShell.
+- **PATH refresh after installing new tools.** Windows GUI shells (Explorer, launcher-started apps) do not re-read PATH until logout/login. If you install `claude.cmd` and launch specrails-desktop immediately, the desktop app's sidecar may not see it. Restart the app after changes to the Env Vars dialog, or launch from a fresh PowerShell.
 - **CRLF checkouts.** If you clone specrails-core with `core.autocrlf=true`, the repo's `.gitattributes` forces LF on every text file at checkout so the Node installer writes byte-identical artefacts across platforms. Running `git add --renormalize .` once after cloning fixes any pre-existing CRLF contamination.
 - **ARM64.** The x64 Node binary runs under Windows 11's native x64 emulation. All native dependencies we use (`better-sqlite3`, `node-pty`, etc.) resolve to their x64 prebuilts; performance hit is ~10-20% vs native ARM64 but fully functional.
 

--- a/schemas/profile.v1.json
+++ b/schemas/profile.v1.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/fjpulidop/specrails-core/main/schemas/profile.v1.json",
   "title": "specrails agent profile (v1)",
-  "description": "Declarative configuration for the specrails implement pipeline. Describes which agents participate, which models they run with, and how tasks are routed to specialists. Consumed by `implement.md` and produced by tools like specrails-hub.",
+  "description": "Declarative configuration for the specrails implement pipeline. Describes which agents participate, which models they run with, and how tasks are routed to specialists. Consumed by `implement.md` and produced by tools like specrails-desktop.",
   "type": "object",
   "required": ["schemaVersion", "name", "orchestrator", "agents", "routing"],
   "additionalProperties": false,

--- a/specrails-plugin/skills/explore-spec/SKILL.md
+++ b/specrails-plugin/skills/explore-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: explore-spec
-description: "Interactive thinking partner that helps the user shape a spec through conversation. Maintains a structured live draft via fenced spec-draft JSON blocks. The hub commits the ticket — never call ticket-creation commands yourself."
+description: "Interactive thinking partner that helps the user shape a spec through conversation. Maintains a structured live draft via fenced spec-draft JSON blocks. The desktop app commits the ticket — never call ticket-creation commands yourself."
     // ... 175 lines omitted
 {
     // ... 174 lines omitted
@@ -8,7 +8,7 @@ description: "Interactive thinking partner that helps the user shape a spec thro
     // ... 173 lines omitted
 {
 // ... 172 more lines (total: 178)
-You are a senior product engineer helping the user shape a single spec through conversation. The user has opened the **Explore Spec** experience inside specrails-hub. You are their thinking partner — same stance as `/opsx:explore`, but the artefact you produce is a single backlog ticket (committed by the hub), not OpenSpec change files.
+You are a senior product engineer helping the user shape a single spec through conversation. The user has opened the **Explore Spec** experience inside specrails-desktop. You are their thinking partner — same stance as `/opsx:explore`, but the artefact you produce is a single backlog ticket (committed by the desktop app), not OpenSpec change files.
 
 # Your role
 
@@ -51,11 +51,11 @@ You **MUST NOT**:
 - Call `/specrails:propose-spec`, `/specrails:implement`, or other slash commands that produce side effects.
 - Run shell commands beyond read-only inspection (`ls`, `cat`-equivalents via Read).
 
-You may **read** anywhere in the project. The hub commits the final ticket via `POST /tickets/from-draft` when the user clicks **Create Spec**.
+You may **read** anywhere in the project. The desktop app commits the final ticket via `POST /tickets/from-draft` when the user clicks **Create Spec**.
 
 # The structured draft protocol
 
-After every assistant turn that has new draft information, end your message with a fenced code block tagged `spec-draft` containing JSON. The hub parses this block and updates the live draft pane the user sees on the right side of the overlay.
+After every assistant turn that has new draft information, end your message with a fenced code block tagged `spec-draft` containing JSON. The desktop app parses this block and updates the live draft pane the user sees on the right side of the overlay.
 
 ```spec-draft
 {
@@ -82,11 +82,11 @@ Field semantics:
   - `## Technical Considerations` (bullet list)
   - `## Estimated Complexity` (`Low`/`Medium`/`High`/`Very High` plus one sentence)
   - **Never include a `## Spec Title` heading inside `description`** — the title lives in its own field. Repeating it inside the body produces redundant tickets.
-  - **Never duplicate the acceptance criteria inside `description`** — they live in their own `acceptanceCriteria` array. The hub appends them to the ticket body under a `## Acceptance Criteria` section automatically.
-- **`acceptanceCriteria`** is a separate array of short, testable bullet strings. The hub appends them to the ticket body under a `## Acceptance Criteria` section automatically — do NOT duplicate them inside `description`.
+  - **Never duplicate the acceptance criteria inside `description`** — they live in their own `acceptanceCriteria` array. The desktop app appends them to the ticket body under a `## Acceptance Criteria` section automatically.
+- **`acceptanceCriteria`** is a separate array of short, testable bullet strings. The desktop app appends them to the ticket body under a `## Acceptance Criteria` section automatically — do NOT duplicate them inside `description`.
 - **`chips`** are 0-3 short replies the user can click to send as their next message. Use them sparingly; capping the user's options is bad in early turns where the conversation is still wide.
 - **`ready: true`** signals "I think the draft is in good enough shape to commit." Set this when you have a meaningful title, a populated description matching the template, and at least one acceptance criterion. Setting `ready: true` does NOT create the ticket — it only highlights the Create Spec button for the user. The user is always the commit.
-- The block is **not shown to the user**. The hub strips it before rendering your message. So put your visible reasoning above the block, in plain prose.
+- The block is **not shown to the user**. The desktop app strips it before rendering your message. So put your visible reasoning above the block, in plain prose.
 
 # Language
 

--- a/src/installer/__tests__/reserved-paths.test.ts
+++ b/src/installer/__tests__/reserved-paths.test.ts
@@ -12,7 +12,7 @@ import { initRepo } from '../util/git.js'
 /**
  * End-to-end audit: the installer (init AND update) must NEVER mutate
  * the two reserved regions:
- *   - .specrails/profiles/**        (hub / team profile JSON)
+ *   - .specrails/profiles/**        (desktop app / team profile JSON)
  *   - .claude/agents/custom-*.md    (user-authored custom agents)
  *
  * Ports the intent of the retired tests/test-profiles.sh into vitest

--- a/src/installer/commands/init.ts
+++ b/src/installer/commands/init.ts
@@ -135,9 +135,10 @@ export async function runInit(flags: InitFlags): Promise<InitResult> {
     step('Installation complete')
     info('Quick tier: agents + rules were placed directly; enrich not required.')
   }
-  // Terminal sentinel for programmatic consumers (specrails-hub's setup
+  // Terminal sentinel for programmatic consumers (specrails-desktop's setup
   // wizard matches this exact line via regex to mark the "init complete"
-  // checkpoint). Keep the spelling stable.
+  // checkpoint). The sentinel line below is FROZEN — the downstream setup
+  // wizard regex-matches it byte-for-byte; never change its spelling.
   ok('init complete')
 
   return {

--- a/src/installer/commands/update.ts
+++ b/src/installer/commands/update.ts
@@ -99,7 +99,7 @@ export async function runUpdate(flags: UpdateFlags): Promise<UpdateResult> {
   if (scope === 'web-manager') {
     warn(
       '--only=web-manager is deprecated. The standalone web-manager has been retired; ' +
-        'specrails-hub is the supported dashboard. Skipping with no changes.',
+        'specrails-desktop is the supported dashboard. Skipping with no changes.',
     )
     return { repoRoot, previousVersion, currentVersion, provider, dryRun, scope, tier, agentTeams }
   }

--- a/src/installer/phases/manifest.ts
+++ b/src/installer/phases/manifest.ts
@@ -7,7 +7,7 @@ import { readBytes, writeFileLf } from '../util/fs.js'
 
 /**
  * Shape of the `.specrails/specrails-manifest.json` file the installer
- * writes at install time. Consumers (specrails-hub's compat check,
+ * writes at install time. Consumers (specrails-desktop's compat check,
  * the `doctor` command, update.sh) parse it to detect template drift.
  */
 export interface SpecrailsManifest {

--- a/src/installer/phases/prereqs.ts
+++ b/src/installer/phases/prereqs.ts
@@ -68,7 +68,7 @@ export async function checkPrerequisites(options: PrereqOptions): Promise<Prereq
   }
 
   // 1.1 Git repository — auto-init when --yes, otherwise assume caller
-  //     resolved the prompt upstream (bin/specrails-core.cjs / hub TUI).
+  //     resolved the prompt upstream (bin/specrails-core.cjs / desktop app TUI).
   if (!(await isGitRepo(options.repoRoot))) {
     if (!options.autoYes) {
       throw new PrerequisiteError(

--- a/src/installer/phases/scaffold.ts
+++ b/src/installer/phases/scaffold.ts
@@ -139,7 +139,7 @@ export interface ScaffoldResult {
 
 /**
  * Returns true iff any of the provider directories already contains
- * content. The hub-driven path skips the "merge existing?" prompt and
+ * content. The desktop-app-driven path skips the "merge existing?" prompt and
  * assumes `--yes`; the CLI dispatcher (bin/specrails-core.cjs) should
  * have prompted before entering this phase.
  */
@@ -486,7 +486,7 @@ interface QuickPlacement {
  * Source is setup-templates/ (not scriptDir/templates/) so the pipeline
  * is: scriptDir/templates/ → setup-templates/ (earlier scaffold step)
  * → <providerDir>/ (this function). The intermediate hop mirrors the
- * retired bash installer and lets downstream consumers (specrails-hub's
+ * retired bash installer and lets downstream consumers (specrails-desktop's
  * deployTemplates, /specrails:enrich, update flow) read from a single
  * canonical staging dir.
  */

--- a/src/installer/util/errors.ts
+++ b/src/installer/util/errors.ts
@@ -1,7 +1,7 @@
 /**
  * Typed error hierarchy for the installer. Each subclass carries an
  * `exitCode` which the CLI dispatcher translates to the process exit
- * code so callers (shells, CI, specrails-hub wizard) can distinguish
+ * code so callers (shells, CI, specrails-desktop wizard) can distinguish
  * failure modes without string-parsing stdout.
  *
  * Exit-code ranges:

--- a/src/installer/util/paths.ts
+++ b/src/installer/util/paths.ts
@@ -3,15 +3,15 @@ import path from 'node:path'
 /**
  * Paths the installer MUST NOT create, modify, or delete. These hold
  * user / team state that survives re-runs (profile JSON authored by
- * specrails-hub, custom agents authored by the user). Breaking this
+ * specrails-desktop, custom agents authored by the user). Breaking this
  * contract silently destroys user work.
  *
  * Audited by vitest spec `reserved-paths.test.ts`.
  */
 export const RESERVED_PATHS = [
   /**
-   * .specrails/profiles/** — project + hub-authored profile JSON.
-   * specrails-hub writes profile files here and expects them preserved
+   * .specrails/profiles/** — project + desktop-app-authored profile JSON.
+   * specrails-desktop writes profile files here and expects them preserved
    * across specrails-core updates.
    */
   '.specrails/profiles/',

--- a/src/installer/util/prompts.test.ts
+++ b/src/installer/util/prompts.test.ts
@@ -6,7 +6,7 @@ import { chooseOne, confirmYesNo, text } from './prompts.js'
 /**
  * We cannot reliably simulate interactive TTY input inside vitest.
  * These tests lock down the non-interactive contract — which is the
- * path specrails-hub uses when it drives the installer headlessly.
+ * path specrails-desktop uses when it drives the installer headlessly.
  */
 
 describe('prompts (non-TTY behaviour)', () => {

--- a/templates/codex-skills/enrich/SKILL.md
+++ b/templates/codex-skills/enrich/SKILL.md
@@ -21,7 +21,7 @@ it doesn't run the rail pipeline.
   generation + rail customisation + AGENTS.md refresh).
 - `$enrich --from-config` — read parameters from
   `.specrails/install-config.yaml` instead of asking. Used by
-  the hub during the install wizard's full-tier path.
+  the desktop app during the install wizard's full-tier path.
 - `$enrich --personas-only` — only regenerate personas; leave
   rail skills untouched.
 

--- a/templates/codex-skills/rails/sr-product-manager/SKILL.md
+++ b/templates/codex-skills/rails/sr-product-manager/SKILL.md
@@ -32,7 +32,7 @@ Two ways:
   don't propose duplicates).
 - A representative slice of the source code (5-10 files,
   drawn from the relevant theme).
-- The hub's own `openspec/specs/` if relevant
+- The desktop app's own `openspec/specs/` if relevant
   (cross-component changes).
 
 ### 2. Identify gaps

--- a/templates/commands/specrails/batch-implement.md
+++ b/templates/commands/specrails/batch-implement.md
@@ -192,7 +192,7 @@ For each wave `W`:
 2. For each feature batch of size ≤ `CONCURRENCY` within the wave:
    - For every ref in the batch, determine the profile spawn env:
      - If `PROFILE_MAP` contains an entry for this ref, set `SPECRAILS_PROFILE_PATH=<abs path to .specrails/profiles/<mapped-name>.json>` for this invocation only.
-     - Otherwise, inherit whatever `$SPECRAILS_PROFILE_PATH` was set by the caller (e.g. specrails-hub), or leave unset so the rail falls back to `.specrails/profiles/project-default.json` or legacy mode.
+     - Otherwise, inherit whatever `$SPECRAILS_PROFILE_PATH` was set by the caller (e.g. specrails-desktop), or leave unset so the rail falls back to `.specrails/profiles/project-default.json` or legacy mode.
    - Invoke `/specrails:implement` with the feature refs and forwarded flags:
      ```
      SPECRAILS_PROFILE_PATH=<resolved-per-rail-path> /specrails:implement <ref> [--dry-run]

--- a/templates/commands/specrails/enrich.md
+++ b/templates/commands/specrails/enrich.md
@@ -2,11 +2,11 @@
 
 Interactive wizard to configure the full agent workflow system for this repository. Analyzes the codebase, discovers target users, generates VPC personas, and creates all agents, commands, rules, and configuration adapted to this project. Supports config-driven mode for direct installation from a pre-built config file.
 
-**Prerequisites:** Ensure this repo was initialized with `npx specrails-core@latest init` (or via specrails-hub) so `.specrails/setup-templates/` exists.
+**Prerequisites:** Ensure this repo was initialized with `npx specrails-core@latest init` (or via specrails-desktop) so `.specrails/setup-templates/` exists.
 
-### Hub Checkpoint Protocol
+### Desktop App Checkpoint Protocol
 
-When running inside specrails-hub, emit checkpoint markers at key transitions so the hub `CheckpointTracker` can display progress. Each checkpoint is a single line printed to stdout:
+When running inside specrails-desktop, emit checkpoint markers at key transitions so the desktop app `CheckpointTracker` can display progress. Each checkpoint is a single line printed to stdout:
 
 ```
 [checkpoint:phase_1_analysis] Codebase analysis complete
@@ -16,7 +16,7 @@ When running inside specrails-hub, emit checkpoint markers at key transitions so
 [checkpoint:phase_5_cleanup] Cleanup and summary complete
 ```
 
-The hub parses these via `detectCheckpointFromText()` regex patterns. Always emit checkpoints at the end of each phase, even in `--from-config` and `--quick` modes.
+The desktop app parses these via `detectCheckpointFromText()` regex patterns. Always emit checkpoints at the end of each phase, even in `--from-config` and `--quick` modes.
 
 ---
 
@@ -890,7 +890,7 @@ Local tickets are always read-write — there is no "read only" mode since the f
 **Labels:** Freeform strings following the `area:*` and `effort:*` convention
 **Source values:** `manual`, `get-backlog-specs`, `propose-spec`
 
-**Advisory file locking protocol** (CLI agents and hub server must both follow this):
+**Advisory file locking protocol** (CLI agents and desktop app server must both follow this):
 
 The `revision` counter in the JSON root enables optimistic concurrency — increment it on **every** write. The lock file prevents concurrent corruption:
 
@@ -903,7 +903,7 @@ The `revision` counter in the JSON root enables optimistic concurrency — incre
 4. **Release lock:** Delete `.specrails/local-tickets.json.lock`
 5. **Always increment `revision`** by 1 and update `last_updated` on every successful write
 
-The hub server uses `proper-lockfile` (or equivalent) to honor the same protocol via the `.lock` file path.
+The desktop app server uses `proper-lockfile` (or equivalent) to honor the same protocol via the `.lock` file path.
 
 #### If GitHub Issues
 

--- a/templates/commands/specrails/explore-spec.md
+++ b/templates/commands/specrails/explore-spec.md
@@ -1,8 +1,8 @@
 ---
-description: Interactive thinking partner that helps the user shape a spec through conversation. Maintains a structured live draft via fenced spec-draft JSON blocks. The hub commits the ticket — never call ticket-creation commands yourself.
+description: Interactive thinking partner that helps the user shape a spec through conversation. Maintains a structured live draft via fenced spec-draft JSON blocks. The desktop app commits the ticket — never call ticket-creation commands yourself.
 ---
 
-You are a senior product engineer helping the user shape a single spec through conversation. The user has opened the **Explore Spec** experience inside specrails-hub. You are their thinking partner — same stance as `/opsx:explore`, but the artefact you produce is a single backlog ticket (committed by the hub), not OpenSpec change files.
+You are a senior product engineer helping the user shape a single spec through conversation. The user has opened the **Explore Spec** experience inside specrails-desktop. You are their thinking partner — same stance as `/opsx:explore`, but the artefact you produce is a single backlog ticket (committed by the desktop app), not OpenSpec change files.
 
 # Your role
 
@@ -45,11 +45,11 @@ You **MUST NOT**:
 - Call `/specrails:propose-spec`, `/specrails:implement`, or other slash commands that produce side effects.
 - Run shell commands beyond read-only inspection (`ls`, `cat`-equivalents via Read).
 
-You may **read** anywhere in the project. The hub commits the final ticket via `POST /tickets/from-draft` when the user clicks **Create Spec**.
+You may **read** anywhere in the project. The desktop app commits the final ticket via `POST /tickets/from-draft` when the user clicks **Create Spec**.
 
 # The structured draft protocol
 
-After every assistant turn that has new draft information, end your message with a fenced code block tagged `spec-draft` containing JSON. The hub parses this block and updates the live draft pane the user sees on the right side of the overlay.
+After every assistant turn that has new draft information, end your message with a fenced code block tagged `spec-draft` containing JSON. The desktop app parses this block and updates the live draft pane the user sees on the right side of the overlay.
 
 ```spec-draft
 {
@@ -76,11 +76,11 @@ Field semantics:
   - `## Technical Considerations` (bullet list)
   - `## Estimated Complexity` (`Low`/`Medium`/`High`/`Very High` plus one sentence)
   - **Never include a `## Spec Title` heading inside `description`** — the title lives in its own field. Repeating it inside the body produces redundant tickets.
-  - **Never duplicate the acceptance criteria inside `description`** — they live in their own `acceptanceCriteria` array. The hub appends them to the ticket body under a `## Acceptance Criteria` section automatically.
-- **`acceptanceCriteria`** is a separate array of short, testable bullet strings. The hub appends them to the ticket body under a `## Acceptance Criteria` section automatically — do NOT duplicate them inside `description`.
+  - **Never duplicate the acceptance criteria inside `description`** — they live in their own `acceptanceCriteria` array. The desktop app appends them to the ticket body under a `## Acceptance Criteria` section automatically.
+- **`acceptanceCriteria`** is a separate array of short, testable bullet strings. The desktop app appends them to the ticket body under a `## Acceptance Criteria` section automatically — do NOT duplicate them inside `description`.
 - **`chips`** are 0-3 short replies the user can click to send as their next message. Use them sparingly; capping the user's options is bad in early turns where the conversation is still wide.
 - **`ready: true`** signals "I think the draft is in good enough shape to commit." Set this when you have a meaningful title, a populated description matching the template, and at least one acceptance criterion. Setting `ready: true` does NOT create the ticket — it only highlights the Create Spec button for the user. The user is always the commit.
-- The block is **not shown to the user**. The hub strips it before rendering your message. So put your visible reasoning above the block, in plain prose.
+- The block is **not shown to the user**. The desktop app strips it before rendering your message. So put your visible reasoning above the block, in plain prose.
 
 # Language
 

--- a/templates/commands/specrails/implement.md
+++ b/templates/commands/specrails/implement.md
@@ -67,7 +67,7 @@ Agent discovery runs in one of two modes: **profile mode** (a profile JSON is ac
 
 A profile is active when either condition holds:
 
-1. The environment variable `SPECRAILS_PROFILE_PATH` is set AND points to a readable file. Tools like `specrails-hub` set this to a job-scoped snapshot.
+1. The environment variable `SPECRAILS_PROFILE_PATH` is set AND points to a readable file. Tools like `specrails-desktop` set this to a job-scoped snapshot.
 2. The file `.specrails/profiles/project-default.json` exists and is readable.
 
 If condition 1 holds, use `$SPECRAILS_PROFILE_PATH` as the profile path. Otherwise, if condition 2 holds, use `.specrails/profiles/project-default.json`. Otherwise, fall through to **legacy mode**.
@@ -158,7 +158,7 @@ Also store per-agent model overrides and the orchestrator model for use in later
 
 ```bash
 # ORCHESTRATOR_MODEL is informational; the caller is responsible for spawning
-# the orchestrator with this model (e.g. specrails-hub reads this field directly).
+# the orchestrator with this model (e.g. specrails-desktop reads this field directly).
 ORCHESTRATOR_MODEL="$(jq -r '.orchestrator.model' <<<"$PROFILE")"
 
 # Per-agent model overrides keyed by agent id.
@@ -182,7 +182,7 @@ Claude Code's Agent tool determines a subagent's model from the `model:` line in
 This rewrite is safe because:
 - Multi-feature runs execute in **isolated git worktrees** (`isolation: worktree`), so each rail mutates its own copy of `.claude/agents/` without cross-rail contention.
 - Single-feature runs are sequential within a single checkout.
-- The hub writes a job-scoped snapshot of the profile and spawns `claude` with `$SPECRAILS_PROFILE_PATH` pointing at it; the frontmatter rewrite follows the snapshot, never the catalog.
+- The desktop app writes a job-scoped snapshot of the profile and spawns `claude` with `$SPECRAILS_PROFILE_PATH` pointing at it; the frontmatter rewrite follows the snapshot, never the catalog.
 
 ```bash
 for id in "${!AGENT_MODEL[@]}"; do

--- a/templates/settings/codex-config.toml
+++ b/templates/settings/codex-config.toml
@@ -10,7 +10,7 @@ model = "{{MODEL_NAME}}"
 model_reasoning_effort = "medium"
 
 # Sandbox mode applied to interactive `codex` sessions launched from this
-# project. The hub passes `--sandbox workspace-write` per-spawn so this
+# project. The desktop app passes `--sandbox workspace-write` per-spawn so this
 # setting only affects manual terminal use of codex inside this repo.
 # Values: "read-only" | "workspace-write" | "danger-full-access".
 sandbox_mode = "workspace-write"


### PR DESCRIPTION
## Summary
Companion change to the Specrails Desktop rebrand (specrails-desktop PR #374). Pure prose/branding pass — no behavior change:

- Installer source comments, the `update` deprecation message, and the profile schema description now say `specrails-desktop`
- All four command templates (`implement`, `enrich`, `batch-implement`, `explore-spec`) and their tracked mirrors (`.claude/commands/`, `commands/enrich.md`) renamed in lockstep, including the `Hub Checkpoint Protocol` heading → `Desktop App Checkpoint Protocol` and remaining "the hub" prose in codex skill templates
- README/CLAUDE.md/docs links point at `github.com/fjpulidop/specrails-desktop`

## Intentionally untouched (frozen contracts)
- The `init complete` sentinel string (desktop's setup wizard regex-matches it) — its comment now marks it FROZEN
- The `hub-json` CLI flag key (programmatic flag-name contract)
- CHANGELOG, archived openspec changes, dated research docs (historical records)

## Test plan
- `npm run typecheck` ✓
- `npm test` — 216/216 ✓
- Sweep grep for `specrails-hub` / "the hub" over tracked files: zero non-historical hits
- Template-mirror lockstep verified by pair-diff vs main

🤖 Generated with [Claude Code](https://claude.com/claude-code)