### PR TITLE
feat(installer): Gemini provider target — foundation (detection + OpenSpec)

### DIFF
--- a/integration-contract.json
+++ b/integration-contract.json
@@ -43,7 +43,7 @@
     "version": 1,
     "fields": {
       "version": "number — schema version, currently 1",
-      "provider": "string — claude | codex | auto",
+      "provider": "string — claude | codex | gemini | auto",
       "tier": "string — full | quick",
       "agents.selected": "string[] — agent names to install",
       "agents.excluded": "string[] — agent names to skip",

--- a/src/installer/commands/doctor.ts
+++ b/src/installer/commands/doctor.ts
@@ -93,7 +93,7 @@ export async function runDoctor(flags: DoctorFlags = {}): Promise<DoctorResult> 
   } else {
     addFail(
       `${instructionsFile}: missing`,
-      provider === 'codex'
+      provider !== 'claude'
         ? 'Run specrails-core init to regenerate the provider instructions.'
         : 'Run /specrails:enrich inside Claude Code to regenerate.',
     )
@@ -157,6 +157,7 @@ async function resolveCommandPath(cmd: string): Promise<string | null> {
 }
 
 function resolveInstalledProvider(projectRoot: string): Provider {
+  if (isDir(path.join(projectRoot, '.gemini'))) return 'gemini'
   if (isDir(path.join(projectRoot, '.codex'))) return 'codex'
   return 'claude'
 }

--- a/src/installer/commands/init.test.ts
+++ b/src/installer/commands/init.test.ts
@@ -149,7 +149,7 @@ describe('runInit', () => {
     await initRepo(repoRoot)
     await expect(
       runInit({ 'root-dir': repoRoot, yes: true, provider: 'turbofake' as never }),
-    ).rejects.toThrow(/must be 'claude' or 'codex'/)
+    ).rejects.toThrow(/must be 'claude', 'codex', or 'gemini'/)
   })
 
   // Uses a POSIX shell script as a fake openspec binary, pointed at via

--- a/src/installer/commands/init.ts
+++ b/src/installer/commands/init.ts
@@ -83,9 +83,9 @@ export async function runInit(flags: InitFlags): Promise<InitResult> {
       info(`install-config.yaml not found at ${resolved} — falling back to auto-detection`)
     }
   } else if (typeof flags.provider === 'string') {
-    if (flags.provider !== 'claude' && flags.provider !== 'codex') {
+    if (flags.provider !== 'claude' && flags.provider !== 'codex' && flags.provider !== 'gemini') {
       throw new InstallerError(
-        `--provider value must be 'claude' or 'codex', got: ${flags.provider}`,
+        `--provider value must be 'claude', 'codex', or 'gemini', got: ${flags.provider}`,
         40,
       )
     }

--- a/src/installer/commands/update.ts
+++ b/src/installer/commands/update.ts
@@ -196,7 +196,8 @@ function resolveScope(only: string | boolean | undefined): OnlyComponent {
 async function resolveExistingProvider(repoRoot: string): Promise<Provider> {
   if (pathExists(path.join(repoRoot, '.claude'))) return 'claude'
   if (pathExists(path.join(repoRoot, '.codex'))) return 'codex'
-  // Neither present — fall back to resolving via CLI availability.
+  if (pathExists(path.join(repoRoot, '.gemini'))) return 'gemini'
+  // None present — fall back to resolving via CLI availability.
   const avail = await detectAvailability()
   try {
     return await resolveProvider(avail, { skipPrereqs: true })

--- a/src/installer/phases/install-config.test.ts
+++ b/src/installer/phases/install-config.test.ts
@@ -51,6 +51,15 @@ describe('install-config', () => {
       expect(result.agents.selected).toEqual(['sr-architect'])
     })
 
+    it('accepts gemini as a valid provider', () => {
+      const result = validateInstallConfig({
+        version: 1,
+        provider: 'gemini',
+        agents: { selected: ['sr-architect'] },
+      })
+      expect(result.provider).toBe('gemini')
+    })
+
     it('accepts an optional agent_teams, tier, and preset', () => {
       const result = validateInstallConfig({
         version: 1,

--- a/src/installer/phases/install-config.ts
+++ b/src/installer/phases/install-config.ts
@@ -6,11 +6,9 @@ import { FilesystemError, InstallerError } from '../util/errors.js'
 import { pathExists, readTextFile, writeFileLf } from '../util/fs.js'
 
 /**
- * Provider identifier. `codex` is gated — the CLI rejects it with a
- * "coming soon" error message — but the type exists so we can carry
- * the same validation diagnostics the bash installer emitted.
+ * Provider identifier. Kept in lock-step with `provider-detect.ts` `Provider`.
  */
-export type Provider = 'claude' | 'codex'
+export type Provider = 'claude' | 'codex' | 'gemini'
 
 /** Install tier selected at install time. */
 export type Tier = 'full' | 'quick'
@@ -93,8 +91,8 @@ export function validateInstallConfig(raw: unknown): InstallConfig {
 
   if (doc.provider === undefined) {
     errors.push(`missing required 'provider' field`)
-  } else if (doc.provider !== 'claude' && doc.provider !== 'codex') {
-    errors.push(`unsupported provider '${String(doc.provider)}' (expected: claude or codex)`)
+  } else if (doc.provider !== 'claude' && doc.provider !== 'codex' && doc.provider !== 'gemini') {
+    errors.push(`unsupported provider '${String(doc.provider)}' (expected: claude, codex, or gemini)`)
   }
 
   if (doc.tier !== undefined && doc.tier !== 'full' && doc.tier !== 'quick') {

--- a/src/installer/phases/provider-detect.test.ts
+++ b/src/installer/phases/provider-detect.test.ts
@@ -49,4 +49,22 @@ describe('provider-detect.derivedPaths', () => {
   it('Codex uses .codex + AGENTS.md', () => {
     expect(derivedPaths('codex')).toEqual({ providerDir: '.codex', instructionsFile: 'AGENTS.md' })
   })
+
+  it('Gemini uses .gemini + GEMINI.md', () => {
+    expect(derivedPaths('gemini')).toEqual({ providerDir: '.gemini', instructionsFile: 'GEMINI.md' })
+  })
+})
+
+describe('provider-detect.resolveProvider — gemini', () => {
+  it('uses explicit gemini flag unconditionally', async () => {
+    expect(await resolveProvider({ claude: false, codex: false }, { explicit: 'gemini' })).toBe('gemini')
+  })
+
+  it('returns gemini when only gemini is installed', async () => {
+    expect(await resolveProvider({ claude: false, codex: false, gemini: true })).toBe('gemini')
+  })
+
+  it('still prefers claude over gemini when both are installed', async () => {
+    expect(await resolveProvider({ claude: true, codex: false, gemini: true })).toBe('claude')
+  })
 })

--- a/src/installer/phases/provider-detect.ts
+++ b/src/installer/phases/provider-detect.ts
@@ -12,17 +12,19 @@ import { pathExists, readTextFile } from '../util/fs.js'
  * user has only codex installed.
  */
 
-export type Provider = 'claude' | 'codex'
+export type Provider = 'claude' | 'codex' | 'gemini'
 
 export interface ProviderAvailability {
   claude: boolean
   codex: boolean
+  /** Optional so callers/tests predating Gemini still typecheck; absent = false. */
+  gemini?: boolean
 }
 
 export interface ProviderDerivedPaths {
-  /** Root directory inside the user's repo: `.claude` for Claude, `.codex` for Codex. */
+  /** Root directory inside the user's repo: `.claude` / `.codex` / `.gemini`. */
   providerDir: string
-  /** Top-level instructions file: `CLAUDE.md` for Claude, `AGENTS.md` for Codex. */
+  /** Top-level instructions file: `CLAUDE.md` / `AGENTS.md` / `GEMINI.md`. */
   instructionsFile: string
 }
 
@@ -31,8 +33,12 @@ export interface ProviderDerivedPaths {
  * `which` on POSIX via the cross-platform commandExists helper.
  */
 export async function detectAvailability(): Promise<ProviderAvailability> {
-  const [claude, codex] = await Promise.all([commandExists('claude'), commandExists('codex')])
-  return { claude, codex }
+  const [claude, codex, gemini] = await Promise.all([
+    commandExists('claude'),
+    commandExists('codex'),
+    commandExists('gemini'),
+  ])
+  return { claude, codex, gemini }
 }
 
 /**
@@ -64,18 +70,20 @@ export async function resolveProvider(
 ): Promise<Provider> {
   if (options.explicit === 'codex') return 'codex'
   if (options.explicit === 'claude') return 'claude'
+  if (options.explicit === 'gemini') return 'gemini'
 
-  // Both installed: prefer Claude (the historical default) so existing
-  // projects don't get re-bootstrapped onto a different provider when the
-  // user just runs `npx specrails-core init` without `--provider`. Users
-  // who want codex pass --provider codex or set it in install-config.yaml.
-  if (availability.claude && availability.codex) return 'claude'
+  // No multi-provider auto-pick beyond the historical Claude-first default: when
+  // several CLIs are installed and no provider was requested, prefer Claude so
+  // existing projects don't get re-bootstrapped onto a different provider. Users
+  // pick codex/gemini via --provider or install-config.yaml.
   if (availability.claude) return 'claude'
   if (availability.codex) return 'codex'
+  if (availability.gemini) return 'gemini'
   if (options.skipPrereqs) return 'claude'
   throw new ProviderError(
-    'No AI CLI found. Install Claude Code (https://claude.ai/download) or ' +
-      'Codex CLI (https://developers.openai.com/codex) before running specrails-core init.',
+    'No AI CLI found. Install Claude Code (https://claude.ai/download), ' +
+      'Codex CLI (https://developers.openai.com/codex), or ' +
+      'Gemini CLI (https://github.com/google-gemini/gemini-cli) before running specrails-core init.',
   )
 }
 
@@ -87,6 +95,9 @@ export async function resolveProvider(
 export function derivedPaths(provider: Provider): ProviderDerivedPaths {
   if (provider === 'codex') {
     return { providerDir: '.codex', instructionsFile: 'AGENTS.md' }
+  }
+  if (provider === 'gemini') {
+    return { providerDir: '.gemini', instructionsFile: 'GEMINI.md' }
   }
   return { providerDir: '.claude', instructionsFile: 'CLAUDE.md' }
 }

--- a/src/installer/phases/scaffold.test.ts
+++ b/src/installer/phases/scaffold.test.ts
@@ -130,6 +130,23 @@ describe('scaffold', () => {
       expect(isDir(path.join(repoRoot, '.specrails', 'setup-templates', 'rules'))).toBe(true)
     })
 
+    it('throws a clear error for the gemini provider (rails scaffold not implemented yet)', () => {
+      const scriptDir = path.join(tmpDir, 'core')
+      const repoRoot = path.join(tmpDir, 'repo-gemini')
+      setupFakeSource(scriptDir)
+
+      expect(() =>
+        scaffoldInstallation({
+          scriptDir,
+          repoRoot,
+          provider: 'gemini',
+          providerDir: '.gemini',
+          agentTeams: false,
+          tier: 'full',
+        }),
+      ).toThrow(/Gemini provider scaffold is not implemented yet/)
+    })
+
     it('copies templates into setup-templates/', () => {
       const scriptDir = path.join(tmpDir, 'core')
       const repoRoot = path.join(tmpDir, 'repo')

--- a/src/installer/phases/scaffold.test.ts
+++ b/src/installer/phases/scaffold.test.ts
@@ -130,21 +130,90 @@ describe('scaffold', () => {
       expect(isDir(path.join(repoRoot, '.specrails', 'setup-templates', 'rules'))).toBe(true)
     })
 
-    it('throws a clear error for the gemini provider (rails scaffold not implemented yet)', () => {
+    function setupGeminiFakeSource(scriptDir: string): void {
+      setupRichFakeSource(scriptDir)
+      writeFileLf(
+        path.join(scriptDir, 'templates', 'gemini-commands', 'implement.toml'),
+        "description = \"Implementation Pipeline\"\nprompt = '''GEMINI_IMPLEMENT_SENTINEL invoke_agent sr-architect'''\n",
+      )
+      writeFileLf(
+        path.join(scriptDir, 'templates', 'gemini-commands', 'batch-implement.toml'),
+        "description = \"Batch\"\nprompt = '''GEMINI_BATCH_SENTINEL'''\n",
+      )
+      writeFileLf(
+        path.join(scriptDir, 'templates', 'settings', 'gemini-settings.json'),
+        '{\n  "experimental": { "enableAgents": true }\n}\n',
+      )
+    }
+
+    function scaffoldGemini(scriptDir: string, repoRoot: string): void {
+      scaffoldInstallation({
+        scriptDir,
+        repoRoot,
+        provider: 'gemini',
+        providerDir: '.gemini',
+        agentTeams: false,
+        tier: 'quick',
+      })
+    }
+
+    it('emits the gemini artifact tree (agents .md + commands .toml + settings + GEMINI.md)', () => {
       const scriptDir = path.join(tmpDir, 'core')
       const repoRoot = path.join(tmpDir, 'repo-gemini')
-      setupFakeSource(scriptDir)
+      setupGeminiFakeSource(scriptDir)
+      scaffoldGemini(scriptDir, repoRoot)
 
-      expect(() =>
-        scaffoldInstallation({
-          scriptDir,
-          repoRoot,
-          provider: 'gemini',
-          providerDir: '.gemini',
-          agentTeams: false,
-          tier: 'full',
-        }),
-      ).toThrow(/Gemini provider scaffold is not implemented yet/)
+      // Agents: .gemini/agents/sr-*.md with gemini frontmatter (model + tools), no claude color/memory keys.
+      const arch = readTextFile(path.join(repoRoot, '.gemini', 'agents', 'sr-architect.md'))
+      expect(arch.startsWith('---\nname: sr-architect\n')).toBe(true)
+      expect(arch).toContain('model: gemini-2.5-pro')
+      expect(arch).toContain('tools: [read_file, write_file, run_shell_command, glob, search_file_content]')
+      expect(isDir(path.join(repoRoot, '.gemini', 'agent-memory', 'sr-architect'))).toBe(true)
+      expect(pathExists(path.join(repoRoot, '.gemini', 'agents', 'sr-developer.md'))).toBe(true)
+      expect(pathExists(path.join(repoRoot, '.gemini', 'agents', 'sr-reviewer.md'))).toBe(true)
+      // VPC-dependent agent excluded from the quick tier.
+      expect(pathExists(path.join(repoRoot, '.gemini', 'agents', 'sr-product-manager.md'))).toBe(false)
+
+      // Commands: hand-authored orchestrator override copied verbatim; others transformed to TOML.
+      const impl = readTextFile(path.join(repoRoot, '.gemini', 'commands', 'specrails', 'implement.toml'))
+      expect(impl).toContain('GEMINI_IMPLEMENT_SENTINEL')
+      const why = readTextFile(path.join(repoRoot, '.gemini', 'commands', 'specrails', 'why.toml'))
+      expect(why.startsWith('description = ')).toBe(true)
+      expect(why).toContain("prompt = '''")
+      expect(why).toContain('/specrails:why')
+
+      // Settings + GEMINI.md.
+      const settings = JSON.parse(readTextFile(path.join(repoRoot, '.gemini', 'settings.json')))
+      expect(settings.experimental.enableAgents).toBe(true)
+      const gmd = readTextFile(path.join(repoRoot, 'GEMINI.md'))
+      expect(gmd).toContain('specrails-managed:start')
+      expect(gmd).toContain('.gemini/')
+      expect(gmd).toContain('.specrails/local-tickets.json')
+      // No throw, no codex/claude leakage.
+      expect(isDir(path.join(repoRoot, '.gemini', 'skills'))).toBe(false)
+    })
+
+    it('deep-merges .gemini/settings.json (preserves user keys) and upserts GEMINI.md', () => {
+      const scriptDir = path.join(tmpDir, 'core')
+      const repoRoot = path.join(tmpDir, 'repo-gemini-merge')
+      setupGeminiFakeSource(scriptDir)
+      // Pre-seed a user settings.json + a user-authored GEMINI.md.
+      writeFileLf(
+        path.join(repoRoot, '.gemini', 'settings.json'),
+        '{\n  "theme": "GitHub",\n  "experimental": { "vimMode": true }\n}\n',
+      )
+      writeFileLf(path.join(repoRoot, 'GEMINI.md'), '# My notes\nkeep this\n')
+
+      scaffoldGemini(scriptDir, repoRoot)
+
+      const settings = JSON.parse(readTextFile(path.join(repoRoot, '.gemini', 'settings.json')))
+      expect(settings.theme).toBe('GitHub') // user key survives
+      expect(settings.experimental.vimMode).toBe(true) // nested user key survives
+      expect(settings.experimental.enableAgents).toBe(true) // ours added
+      const gmd = readTextFile(path.join(repoRoot, 'GEMINI.md'))
+      expect(gmd).toContain('# My notes') // user content preserved
+      expect(gmd).toContain('keep this')
+      expect(gmd).toContain('specrails-managed:start') // managed block appended
     })
 
     it('copies templates into setup-templates/', () => {

--- a/src/installer/phases/scaffold.ts
+++ b/src/installer/phases/scaffold.ts
@@ -26,6 +26,22 @@ export const CORE_AGENTS = new Set([
  * /specrails:enrich persona pass to function correctly.
  */
 const QUICK_EXCLUDED_AGENTS = new Set(['sr-product-manager', 'sr-product-analyst'])
+
+/**
+ * Gemini built-in tool ids granted to every `.gemini/agents/sr-*.md` subagent.
+ * (Validated headless in the desktop spike — read/write/shell/glob/grep.) Because
+ * gemini TOML commands cannot carry per-command tool/model routing, the tool +
+ * model gating migrates into the subagent frontmatter.
+ */
+const GEMINI_AGENT_TOOLS = ['read_file', 'write_file', 'run_shell_command', 'glob', 'search_file_content']
+
+/** Per-role gemini model (claude templates all use `sonnet`; mirror the top tier). */
+const GEMINI_MODEL_BY_AGENT: Record<string, string> = {
+  'sr-architect': 'gemini-2.5-pro',
+  'sr-developer': 'gemini-2.5-pro',
+  'sr-reviewer': 'gemini-2.5-pro',
+}
+const GEMINI_DEFAULT_MODEL = 'gemini-2.5-pro'
 /**
  * Skills excluded from the quick tier because they depend on
  * VPC-only agents (sr-product-manager, sr-product-analyst).
@@ -161,19 +177,6 @@ export function detectExistingSetup(input: Pick<ScaffoldInput, 'repoRoot' | 'pro
  * .gitignore. Returns a summary for logging / tests.
  */
 export function scaffoldInstallation(input: ScaffoldInput): ScaffoldResult {
-  // Gemini target is in progress: the type/detection/validation layer + OpenSpec
-  // (`openspec init --tools gemini`) already support gemini, but the specrails
-  // rails artifact emission (`.gemini/commands/*.toml` + `.gemini/agents/sr-*.md`
-  // + GEMINI.md/settings) is not implemented yet. Fail loudly here rather than
-  // fall through the Claude branch and write Claude-format files into `.gemini/`.
-  if (input.provider === 'gemini') {
-    throw new Error(
-      'The Gemini provider scaffold is not implemented yet. ' +
-        'Gemini support currently covers detection + OpenSpec (`openspec init --tools gemini`); ' +
-        'the specrails rails commands/agents for Gemini are coming in a follow-up.',
-    )
-  }
-
   const createdDirs: string[] = []
   let copiedFiles = 0
 
@@ -191,6 +194,11 @@ export function scaffoldInstallation(input: ScaffoldInput): ScaffoldResult {
     mk(path.join(input.repoRoot, input.providerDir, 'skills', 'enrich'))
     mk(path.join(input.repoRoot, input.providerDir, 'skills', 'doctor'))
     mk(path.join(input.repoRoot, input.providerDir, 'skills', 'rails'))
+  } else if (input.provider === 'gemini') {
+    // Gemini: TOML commands under .gemini/commands/specrails/ + native
+    // subagents under .gemini/agents/. No skills/ tree.
+    mk(path.join(input.repoRoot, input.providerDir, 'commands', 'specrails'))
+    mk(path.join(input.repoRoot, input.providerDir, 'agents'))
   } else {
     mk(path.join(input.repoRoot, input.providerDir, 'commands', 'specrails'))
     mk(path.join(input.repoRoot, input.providerDir, 'skills'))
@@ -205,7 +213,9 @@ export function scaffoldInstallation(input: ScaffoldInput): ScaffoldResult {
   mk(path.join(setupTemplates, 'settings'))
 
   // --- .gitignore hygiene ---
-  ensureGitignore(input.repoRoot, ['.claude/agent-memory/', '.specrails/'])
+  const gitignoreEntries = ['.claude/agent-memory/', '.specrails/']
+  if (input.provider === 'gemini') gitignoreEntries.push('.gemini/agent-memory/')
+  ensureGitignore(input.repoRoot, gitignoreEntries)
 
   // --- Copy bundled templates into setup-templates/ ---
   const templatesSrc = path.join(input.scriptDir, 'templates')
@@ -248,8 +258,10 @@ export function scaffoldInstallation(input: ScaffoldInput): ScaffoldResult {
     const skills = placeSkills(input)
     copiedFiles += skills.filesCopied
     const skillSkipNote = skills.skipped > 0 ? ` (skipped ${skills.skipped} VPC-dependent)` : ''
+    const skillsLabel = input.provider === 'gemini' ? 'agent' : 'skill'
+    const skillsSubdir = input.provider === 'gemini' ? 'agents' : 'skills'
     info(
-      `Placed ${skills.placed} skill(s) into ${input.providerDir}/skills/${skillSkipNote}`,
+      `Placed ${skills.placed} ${skillsLabel}(s) into ${input.providerDir}/${skillsSubdir}/${skillSkipNote}`,
     )
   }
 
@@ -260,11 +272,18 @@ export function scaffoldInstallation(input: ScaffoldInput): ScaffoldResult {
     if (written > 0) {
       info(`Codex provider: wrote ${written} setting file(s) (config.toml, AGENTS.md)`)
     }
+  } else if (input.provider === 'gemini') {
+    const written = applyGeminiSettings(input)
+    copiedFiles += written
+    if (written > 0) {
+      info(`Gemini provider: wrote ${written} setting file(s) (settings.json, GEMINI.md)`)
+    }
   }
 
   // --- Full-tier hint: enrich is required to generate VPC artefacts ---
   if (input.tier === 'full') {
-    const cliName = input.provider === 'codex' ? 'Codex CLI' : 'Claude Code'
+    const cliName =
+      input.provider === 'codex' ? 'Codex CLI' : input.provider === 'gemini' ? 'Gemini CLI' : 'Claude Code'
     info(
       `Full tier staged. Run \`/specrails:enrich\` in ${cliName} to generate ` +
         'VPC personas and adapt agents (including sr-product-manager and ' +
@@ -317,6 +336,26 @@ function copyBundledCommands(input: ScaffoldInput & { copiedIncrement: (n: numbe
           name: skillName,
         })
       }
+      count++
+    }
+    input.copiedIncrement(count)
+    return
+  }
+
+  if (input.provider === 'gemini') {
+    // Gemini: each bundled command becomes a TOML custom command under
+    // .gemini/commands/specrails/<name>.toml.
+    const destDir = path.join(input.repoRoot, input.providerDir, 'commands', 'specrails')
+    let count = 0
+    for (const entry of listDir(commandsSrc)) {
+      const name = path.basename(entry)
+      if (!name.endsWith('.md')) continue
+      if (name === 'setup.md') continue
+      if (!input.agentTeams && /^team-/.test(name)) continue
+      writeGeminiCommandFromCommand({
+        src: entry,
+        dest: path.join(destDir, `${name.replace(/\.md$/, '')}.toml`),
+      })
       count++
     }
     input.copiedIncrement(count)
@@ -456,6 +495,179 @@ function stripFrontmatter(raw: string): { body: string; description?: string } {
   return { body, description }
 }
 
+/**
+ * Convert a claude slash-command markdown file into a gemini custom command TOML
+ * (`.gemini/commands/specrails/<name>.toml`). Gemini commands carry ONLY
+ * `prompt` + `description` (no per-command tool/model keys — that routing lives
+ * in the subagent frontmatter). Keeps gemini's native `/specrails:<name>` slash
+ * form (unlike codex's `$name`); only `.claude/` paths are rewritten.
+ */
+function writeGeminiCommandFromCommand(args: { src: string; dest: string; description?: string }): void {
+  if (!pathExists(args.src)) return
+  const { body, description: srcDescription } = stripFrontmatter(readTextFile(args.src))
+  const name = path.basename(args.dest).replace(/\.toml$/, '')
+  const description = args.description ?? srcDescription ?? `specrails ${name} command`
+  const translatedBody = body.replace(/\.claude\//g, '.gemini/')
+  // TOML literal multiline strings ('''…''') need no escaping — unless the body
+  // itself contains ''', in which case fall back to a basic escaped string.
+  let promptToml: string
+  if (translatedBody.includes("'''")) {
+    const escaped = translatedBody.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n')
+    promptToml = `prompt = "${escaped}"\n`
+  } else {
+    promptToml = `prompt = '''\n${translatedBody}\n'''\n`
+  }
+  writeFileLf(args.dest, `description = ${JSON.stringify(description)}\n${promptToml}`)
+}
+
+/**
+ * Emit a gemini subagent (`.gemini/agents/<id>.md`) from a claude persona
+ * template. Re-emits gemini YAML frontmatter (name/description/model/tools),
+ * dropping claude `color:`/`memory:`; the persona body is reused, `.claude/`
+ * paths rewritten and `{{MEMORY_PATH}}` pointed at `.gemini/agent-memory/`.
+ */
+function writeGeminiAgentFromTemplate(args: {
+  repoRoot: string
+  src: string
+  agentId: string
+  placeholders: Record<string, string>
+}): void {
+  if (!pathExists(args.src)) return
+  const { body, description } = stripFrontmatter(readTextFile(args.src))
+  const model = GEMINI_MODEL_BY_AGENT[args.agentId] ?? GEMINI_DEFAULT_MODEL
+  const frontmatter = [
+    '---',
+    `name: ${args.agentId}`,
+    `description: ${JSON.stringify(description ?? args.agentId)}`,
+    `model: ${model}`,
+    `tools: [${GEMINI_AGENT_TOOLS.join(', ')}]`,
+    '---',
+    '',
+  ].join('\n')
+  const renderedBody = renderPlaceholders(body, {
+    ...args.placeholders,
+    MEMORY_PATH: `.gemini/agent-memory/${args.agentId}/`,
+  }).replace(/\.claude\//g, '.gemini/')
+  writeFileLf(path.join(args.repoRoot, '.gemini', 'agents', `${args.agentId}.md`), frontmatter + renderedBody)
+  mkdirp(path.join(args.repoRoot, '.gemini', 'agent-memory', args.agentId))
+}
+
+/**
+ * Place the gemini subagents under `.gemini/agents/` from the staged persona
+ * templates (both tiers). Honours the agent selection; defaults to CORE_AGENTS.
+ */
+function placeGeminiAgents(input: ScaffoldInput): SkillsPlacement {
+  const result: SkillsPlacement = { placed: 0, skipped: 0, filesCopied: 0 }
+  const agentsSrc = path.join(input.repoRoot, '.specrails', 'setup-templates', 'agents')
+  if (!isDir(agentsSrc)) return result
+  mkdirp(path.join(input.repoRoot, '.gemini', 'agents'))
+  const selectedAgents = input.selectedAgents
+    ? new Set([...input.selectedAgents, ...CORE_AGENTS])
+    : new Set([...CORE_AGENTS])
+  const placeholders = {
+    PROJECT_NAME: path.basename(input.repoRoot),
+    SECURITY_EXEMPTIONS_PATH: '.gemini/security-exemptions.yaml',
+    PERSONA_DIR: '.gemini/agents/personas/',
+  }
+  for (const src of listDir(agentsSrc)) {
+    const name = path.basename(src)
+    if (!name.endsWith('.md')) continue
+    const agentId = name.slice(0, -3)
+    if (!selectedAgents.has(agentId)) continue
+    if (QUICK_EXCLUDED_AGENTS.has(agentId)) {
+      result.skipped++
+      continue
+    }
+    writeGeminiAgentFromTemplate({ repoRoot: input.repoRoot, src, agentId, placeholders })
+    result.placed++
+    result.filesCopied++
+  }
+  return result
+}
+
+/** Recursive JSON object merge; source wins on scalars/arrays. */
+function deepMergeJson(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...target }
+  for (const [k, v] of Object.entries(source)) {
+    const cur = out[k]
+    if (v && typeof v === 'object' && !Array.isArray(v) && cur && typeof cur === 'object' && !Array.isArray(cur)) {
+      out[k] = deepMergeJson(cur as Record<string, unknown>, v as Record<string, unknown>)
+    } else {
+      out[k] = v
+    }
+  }
+  return out
+}
+
+/**
+ * Gemini provider settings: `.gemini/settings.json` (deep-merged so user keys
+ * survive — adds `experimental.enableAgents`) and `GEMINI.md` (sentinel-block
+ * upsert, identical mechanism to codex AGENTS.md). Returns files written.
+ */
+function applyGeminiSettings(input: ScaffoldInput): number {
+  let written = 0
+  const settingsSrc = path.join(input.scriptDir, 'templates', 'settings', 'gemini-settings.json')
+  if (pathExists(settingsSrc)) {
+    const dest = path.join(input.repoRoot, input.providerDir, 'settings.json')
+    const template = JSON.parse(readTextFile(settingsSrc)) as Record<string, unknown>
+    if (pathExists(dest)) {
+      try {
+        const existing = JSON.parse(readTextFile(dest)) as Record<string, unknown>
+        writeFileLf(dest, JSON.stringify(deepMergeJson(existing, template), null, 2) + '\n')
+        written++
+      } catch (err) {
+        warn(`existing ${dest} is not valid JSON — leaving it untouched: ${(err as Error).message}`)
+      }
+    } else {
+      writeFileLf(dest, JSON.stringify(template, null, 2) + '\n')
+      written++
+    }
+  }
+
+  const geminiMdPath = path.join(input.repoRoot, 'GEMINI.md')
+  const content = renderInitialGeminiMd(input.repoRoot)
+  if (!pathExists(geminiMdPath)) {
+    writeFileLf(geminiMdPath, content)
+    written++
+  } else {
+    const existing = readTextFile(geminiMdPath)
+    const next = upsertAgentsMdManagedBlock(existing, extractManagedBlock(content))
+    if (next !== existing) {
+      writeFileLf(geminiMdPath, next)
+      written++
+    }
+  }
+  return written
+}
+
+function renderInitialGeminiMd(repoRoot: string): string {
+  const projectName = path.basename(repoRoot)
+  return [
+    AGENTS_MD_START,
+    '',
+    `# ${projectName} — agent instructions`,
+    '',
+    'This project uses the **specrails** agent workflow under `.gemini/`.',
+    'See `.gemini/commands/specrails/` for the slash commands and `.gemini/agents/`',
+    'for the `sr-*` subagents available to gemini sessions in this repository.',
+    '',
+    '## Conventions',
+    '',
+    '- Read specs from `.specrails/local-tickets.json` when implementing',
+    '  numbered tickets (`#42`, `#71` etc.).',
+    '- Prefer the `/specrails:*` commands (implement, batch-implement, …) over',
+    '  ad-hoc edits when one covers the task.',
+    '- Agent execution is enabled via `.gemini/settings.json`',
+    '  (`experimental.enableAgents: true`).',
+    '',
+    AGENTS_MD_END,
+    '',
+  ].join('\n')
+}
+
 function pruneLegacyArtifacts(input: Pick<ScaffoldInput, 'repoRoot' | 'provider' | 'providerDir'>): void {
   const legacyPaths = [
     path.join(input.repoRoot, '.specrails', 'bin', 'doctor.sh'),
@@ -469,6 +681,11 @@ function pruneLegacyArtifacts(input: Pick<ScaffoldInput, 'repoRoot' | 'provider'
     // legacy install before settling on the canonical `.codex/skills/`.
     legacyPaths.push(path.join(input.repoRoot, '.agents'))
     legacyPaths.push(path.join(input.repoRoot, input.providerDir, 'skills', 'setup'))
+  } else if (input.provider === 'gemini') {
+    // Prune a stale WIP skills/ tree + any setup command leftovers.
+    legacyPaths.push(path.join(input.repoRoot, input.providerDir, 'skills'))
+    legacyPaths.push(path.join(input.repoRoot, input.providerDir, 'commands', 'setup.toml'))
+    legacyPaths.push(path.join(input.repoRoot, input.providerDir, 'commands', 'specrails', 'setup.toml'))
   } else {
     legacyPaths.push(path.join(input.repoRoot, input.providerDir, 'commands', 'setup.md'))
     legacyPaths.push(path.join(input.repoRoot, input.providerDir, 'commands', 'specrails', 'setup.md'))
@@ -547,6 +764,35 @@ function placeQuickTierArtefacts(input: ScaffoldInput): QuickPlacement {
           dest,
           name: skillName,
         })
+        commandsPlaced++
+      }
+    }
+    return { agents: 0, commands: commandsPlaced, rules: 0, skippedAgents: 0 }
+  }
+
+  if (input.provider === 'gemini') {
+    // Gemini: port the slash-command catalogue to .gemini/commands/specrails/
+    // <name>.toml. Hand-authored orchestrator overrides (implement,
+    // batch-implement) under templates/gemini-commands/ win verbatim. Agents
+    // are placed by placeSkills → placeGeminiAgents (both tiers).
+    const geminiSetupTemplates = path.join(input.repoRoot, '.specrails', 'setup-templates')
+    const commandsSrc = path.join(geminiSetupTemplates, 'commands', 'specrails')
+    const overridesSrc = path.join(input.scriptDir, 'templates', 'gemini-commands')
+    let commandsPlaced = 0
+    if (isDir(commandsSrc)) {
+      for (const src of listDir(commandsSrc)) {
+        const name = path.basename(src)
+        if (!name.endsWith('.md')) continue
+        if (name === 'setup.md') continue
+        if (!input.agentTeams && /^team-/.test(name)) continue
+        const cmdName = name.slice(0, -3)
+        const dest = path.join(input.repoRoot, input.providerDir, 'commands', 'specrails', `${cmdName}.toml`)
+        const overrideToml = path.join(overridesSrc, `${cmdName}.toml`)
+        if (pathExists(overrideToml)) {
+          copyFile(overrideToml, dest)
+        } else {
+          writeGeminiCommandFromCommand({ src, dest })
+        }
         commandsPlaced++
       }
     }
@@ -777,7 +1023,7 @@ function placeSkills(input: ScaffoldInput): SkillsPlacement {
   const result: SkillsPlacement = { placed: 0, skipped: 0, filesCopied: 0 }
 
   // Top-level skills — Claude only, generated from the canonical command body.
-  if (input.provider !== 'codex') {
+  if (input.provider === 'claude') {
     const commandsSrc = path.join(input.repoRoot, '.specrails', 'setup-templates', 'commands', 'specrails')
     const skillEntries = Object.entries(SKILL_FROM_COMMAND) as Array<
       [string, { command: string; description: string }]
@@ -837,6 +1083,14 @@ function placeSkills(input: ScaffoldInput): SkillsPlacement {
       result.placed++
       result.filesCopied += countFiles(dest)
     }
+  }
+
+  // Gemini: place the `sr-*` subagents under .gemini/agents/ (both tiers).
+  if (input.provider === 'gemini') {
+    const g = placeGeminiAgents(input)
+    result.placed += g.placed
+    result.skipped += g.skipped
+    result.filesCopied += g.filesCopied
   }
 
   return result

--- a/src/installer/phases/scaffold.ts
+++ b/src/installer/phases/scaffold.ts
@@ -161,6 +161,19 @@ export function detectExistingSetup(input: Pick<ScaffoldInput, 'repoRoot' | 'pro
  * .gitignore. Returns a summary for logging / tests.
  */
 export function scaffoldInstallation(input: ScaffoldInput): ScaffoldResult {
+  // Gemini target is in progress: the type/detection/validation layer + OpenSpec
+  // (`openspec init --tools gemini`) already support gemini, but the specrails
+  // rails artifact emission (`.gemini/commands/*.toml` + `.gemini/agents/sr-*.md`
+  // + GEMINI.md/settings) is not implemented yet. Fail loudly here rather than
+  // fall through the Claude branch and write Claude-format files into `.gemini/`.
+  if (input.provider === 'gemini') {
+    throw new Error(
+      'The Gemini provider scaffold is not implemented yet. ' +
+        'Gemini support currently covers detection + OpenSpec (`openspec init --tools gemini`); ' +
+        'the specrails rails commands/agents for Gemini are coming in a follow-up.',
+    )
+  }
+
   const createdDirs: string[] = []
   let copiedFiles = 0
 

--- a/templates/gemini-commands/batch-implement.toml
+++ b/templates/gemini-commands/batch-implement.toml
@@ -1,0 +1,39 @@
+description = "Batch Implementation Orchestrator — runs the implement pipeline over multiple tickets, headless."
+
+prompt = '''
+You are the **batch-implement orchestrator**. The user invoked you to apply the
+implement pipeline to multiple tickets in one session. This is fully headless /
+non-interactive — every phase runs with `--yes` semantics.
+
+How the user invokes you:
+- `/specrails:batch-implement #1 #2 #3 --yes` — sequential.
+- `/specrails:batch-implement --status todo` — every todo ticket, ascending id.
+- `/specrails:batch-implement #1 #2 --parallel` — opt-in parallel, only when the
+  tickets touch disjoint files (run a safety check first; fall back to sequential).
+
+## Why this drives the spawns at the ROOT level
+
+Do NOT delegate to a nested `/specrails:implement` subagent per ticket that then
+delegates to architect/developer/reviewer. Subagents are FLAT — a subagent
+cannot invoke another subagent (and nested depth-2 delegation is unreliable,
+silently dropping the reviewer phase). Instead, YOU (the root orchestrator) drive
+the three `invoke_agent` calls — `sr-architect`, `sr-developer`, `sr-reviewer` —
+directly, at depth 1, per ticket. Three real subagent calls per ticket, no
+nesting. The same delegation contract as `/specrails:implement` applies: every
+phase MUST be a real `invoke_agent` call; never inline the work.
+
+## Steps
+
+0. **Bootstrap.** Confirm `pwd` is the git repo root. Resolve the ticket list
+   (explicit ids, or `--status`/`--priority` filters over `.specrails/local-tickets.json`).
+
+1. **Per ticket, in order, run the three-phase pipeline at depth 1:**
+   a. `invoke_agent` `sr-architect` → creates + validates the OpenSpec change.
+      If `BLOCKED`, record the failure and move to the next ticket.
+   b. `invoke_agent` `sr-developer` → applies the change (implements + checks off tasks).
+   c. `invoke_agent` `sr-reviewer` → validates; on pass, `openspec archive <id> -y`.
+   d. Update the ticket to `done` (or record the failure verdict).
+
+2. **Aggregate.** After all tickets, report a single table: ticket, change id,
+   verdict (done / blocked / failed), with a one-line reason for non-done ones.
+'''

--- a/templates/gemini-commands/implement.toml
+++ b/templates/gemini-commands/implement.toml
@@ -1,0 +1,53 @@
+description = "Implementation Pipeline — architect → developer → reviewer over an OpenSpec change, via subagent delegation."
+
+prompt = '''
+You are the **implement orchestrator**. The user invoked you as a multi-agent
+SDD pipeline. Your job is to load the ticket, drive a three-phase pipeline by
+delegating to dedicated subagents, aggregate their verdicts, and close the
+ticket. You ONLY route — the role work lives in the subagents.
+
+How the user invokes you:
+- `/specrails:implement #N` — implement ticket `N` from `.specrails/local-tickets.json`.
+- `/specrails:implement #N --yes` — non-interactive (skip confirmations).
+- `/specrails:implement <free-form>` — a free-form description (no ticket id; skip the ticket-update step).
+
+**Single ticket only.** If more than one `#N` is passed, do NOT improvise a
+multi-ticket flow — reply telling the user to use
+`/specrails:batch-implement #N #M --yes` and stop.
+
+## Delegation contract (mandatory)
+
+Each phase MUST be a real `invoke_agent` call to the named subagent
+(`sr-architect`, `sr-developer`, `sr-reviewer`) — these are available to you as
+tools. You are FORBIDDEN from doing a phase's work inline "to save time" or
+"because the ticket looks small". If your final report says "implemented this
+myself" anywhere, you violated this contract. Subagents are flat: they do their
+phase and report back to you; you sequence them.
+
+A `clean` run is NOT finished until the OpenSpec change is **archived**
+(`openspec archive`) — that is a hard obligation, not an optional epilogue.
+
+## Pipeline
+
+0. **Bootstrap.** Confirm `pwd` is the git repo root. Load the ticket from
+   `.specrails/local-tickets.json` (or use the free-form description).
+
+1. **DESIGN — `invoke_agent` `sr-architect`.** Pass it the ticket/description.
+   It creates an OpenSpec change (proposal + spec deltas + tasks) under
+   `openspec/changes/<id>/` and validates it (`openspec validate <id> --strict`).
+   Wait for it to report back. If it returns `BLOCKED: <reason>`, stop and report.
+
+2. **APPLY — `invoke_agent` `sr-developer`.** Only after the architect reports
+   back. It implements the tasks in TDD order and checks them off in `tasks.md`.
+   Wait for it. If it returns `BLOCKED: <reason>`, stop and report.
+
+3. **REVIEW — `invoke_agent` `sr-reviewer`.** Only after the developer reports
+   back. It validates the change, runs the project checks, and confirms the
+   implementation matches the spec. Wait for its verdict.
+
+4. **ARCHIVE.** When the reviewer passes, ensure the change is archived
+   (`openspec archive <id> -y`) so it lands under `openspec/changes/archive/`.
+
+5. **Close the ticket.** Update `.specrails/local-tickets.json` (status `done`)
+   unless this was a free-form run. Report concisely: ticket, change id, verdict.
+'''

--- a/templates/settings/gemini-settings.json
+++ b/templates/settings/gemini-settings.json
@@ -1,0 +1,5 @@
+{
+  "experimental": {
+    "enableAgents": true
+  }
+}


### PR DESCRIPTION
Adds **Gemini** as a full provider target in the installer. Pairs with specrails-desktop #397 (the Gemini ProviderAdapter, beta-gated). Claude/codex paths are byte-identical.

## What this delivers — a gemini project installs a working specrails rails surface
**Foundation** (commit 1): `Provider` type, `detectAvailability`, `resolveProvider`, `derivedPaths('gemini')→.gemini/GEMINI.md`, install-config + `--provider gemini` validation, and OpenSpec wired through (`openspec init --tools gemini` is native).

**Rails scaffold** (commit 2) — `scaffoldInstallation` emits, for gemini:
- `.gemini/commands/specrails/*.toml` — each slash command → TOML custom command (`prompt`+`description`, native `/specrails:<name>` form). Hand-authored orchestrators `implement.toml` + `batch-implement.toml` (`templates/gemini-commands/`) win verbatim; the latter ROOT-flattens like codex (gemini subagents are flat, depth-1).
- `.gemini/agents/sr-*.md` — personas re-emitted with gemini frontmatter (`model` + `tools` — routing migrates here because TOML commands can't carry it) + `agent-memory/` dirs.
- `.gemini/settings.json` (`experimental.enableAgents: true`, deep-merged) + `GEMINI.md` (sentinel-managed).
- `doctor` / `update` provider probes; integration-contract provider string.

## Validation
A headless spike (specrails-desktop) confirmed gemini runs the full architect→developer→reviewer **OpenSpec SDD pipeline** via depth-1 `invoke_agent` subagent delegation (change authored → applied → archived). Design + file:line plan: specrails-desktop `docs/gemini-core-support-evaluation.md`.

## Verification
`npm test` (typecheck + 223 tests) ✅ + coverage gate ✅ (scaffold.ts new functions 91% stmt / 100% func).

## Deferred (follow-ups, flagged)
- Full-tier gemini **enrich** flow + the `integration-contract.json` `providers.gemini` block (only the `configSchema` provider string is updated now).
- doctor Checks 1–2 gemini CLI-presence probe (no auth check in v1).
- Per-role model split (all three agents use `gemini-2.5-pro`; a pro/flash split is tuning).