### PR TITLE
fix(installer): default Gemini scaffold model to gemini-3.5-flash

### DIFF
--- a/src/installer/phases/scaffold.test.ts
+++ b/src/installer/phases/scaffold.test.ts
@@ -166,7 +166,7 @@ describe('scaffold', () => {
       // Agents: .gemini/agents/sr-*.md with gemini frontmatter (model + tools), no claude color/memory keys.
       const arch = readTextFile(path.join(repoRoot, '.gemini', 'agents', 'sr-architect.md'))
       expect(arch.startsWith('---\nname: sr-architect\n')).toBe(true)
-      expect(arch).toContain('model: gemini-2.5-pro')
+      expect(arch).toContain('model: gemini-3.5-flash')
       expect(arch).toContain('tools: [read_file, write_file, run_shell_command, glob, search_file_content]')
       expect(isDir(path.join(repoRoot, '.gemini', 'agent-memory', 'sr-architect'))).toBe(true)
       expect(pathExists(path.join(repoRoot, '.gemini', 'agents', 'sr-developer.md'))).toBe(true)

--- a/src/installer/phases/scaffold.ts
+++ b/src/installer/phases/scaffold.ts
@@ -35,13 +35,18 @@ const QUICK_EXCLUDED_AGENTS = new Set(['sr-product-manager', 'sr-product-analyst
  */
 const GEMINI_AGENT_TOOLS = ['read_file', 'write_file', 'run_shell_command', 'glob', 'search_file_content']
 
-/** Per-role gemini model (claude templates all use `sonnet`; mirror the top tier). */
+/**
+ * Per-role gemini model. Defaults to `gemini-3.5-flash` — the stable flagship
+ * (June 2026): strong agentic/coding, high quota, and unlike `gemini-2.5-pro`
+ * it is NOT removed from the free tier (the old default produced 429
+ * "exhausted capacity" errors on free/limited keys).
+ */
 const GEMINI_MODEL_BY_AGENT: Record<string, string> = {
-  'sr-architect': 'gemini-2.5-pro',
-  'sr-developer': 'gemini-2.5-pro',
-  'sr-reviewer': 'gemini-2.5-pro',
+  'sr-architect': 'gemini-3.5-flash',
+  'sr-developer': 'gemini-3.5-flash',
+  'sr-reviewer': 'gemini-3.5-flash',
 }
-const GEMINI_DEFAULT_MODEL = 'gemini-2.5-pro'
+const GEMINI_DEFAULT_MODEL = 'gemini-3.5-flash'
 /**
  * Skills excluded from the quick tier because they depend on
  * VPC-only agents (sr-product-manager, sr-product-analyst).


### PR DESCRIPTION
## Why

The Gemini rails scaffold pins all baseline agents (`sr-architect`, `sr-developer`, `sr-reviewer`) to **`gemini-2.5-pro`**. That model was **removed from the free tier** (Dec 2025) and returns `429` *"You have exhausted your capacity on this model"* on free/limited keys — so a fresh `npx specrails-core` gemini install can't run `implement` out of the box.

## Change

Switch the per-role map + default to **`gemini-3.5-flash`** — the current stable flagship (June 2026): strong agentic/coding performance, much higher quota, and available on the free tier.

```
src/installer/phases/scaffold.ts   GEMINI_MODEL_BY_AGENT + GEMINI_DEFAULT_MODEL → gemini-3.5-flash
src/installer/phases/scaffold.test.ts  assertion updated
```

Matches the refreshed default in specrails-desktop (PR #399 there).

## Verification
- `npm run typecheck` ✅
- `scaffold.test.ts` ✅ (and the rest of the suite; the only failures are pre-existing flakes in `doctor`/`prereqs`/`reserved-paths` that pass in isolation — network/subprocess timeouts under parallel load, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)