### PR TITLE
feat: relocate artifacts to $HOME + install framework once (bundled)

### DIFF
--- a/bin/specrails-core.mjs
+++ b/bin/specrails-core.mjs
@@ -50,6 +50,8 @@ const KNOWN_SUBCOMMANDS = new Set([
   'init',
   'update',
   'doctor',
+  'install-framework',
+  'assemble',
   'enrich',
   'version',
   'profile',
@@ -58,7 +60,9 @@ const KNOWN_SUBCOMMANDS = new Set([
 
 if (!KNOWN_SUBCOMMANDS.has(subcommand)) {
   console.error(`Unknown command: ${subcommand}\n`)
-  console.error('Available commands: init, update, doctor, enrich, version, profile, help')
+  console.error(
+    'Available commands: init, update, doctor, install-framework, assemble, enrich, version, profile, help',
+  )
   process.exit(1)
 }
 

--- a/pinned-versions.json
+++ b/pinned-versions.json
@@ -1,4 +1,4 @@
 {
   "$comment": "Pinned versions of third-party tools the installer fetches via npx. Edit and commit to bump deliberately.",
-  "openspec": "1.3.1"
+  "openspec": "1.4.1"
 }

--- a/specrails-plugin/skills/opsx-apply/SKILL.md
+++ b/specrails-plugin/skills/opsx-apply/SKILL.md
@@ -9,6 +9,14 @@ metadata:
   generatedBy: "1.1.1"
 ---
 
+> **OpenSpec project root.** The `openspec/` directory lives in the REPO, not
+> the workspace this skill is driven from. The repo root is `${SPECRAILS_REPO_DIR:-.}`
+> (a default-unset env var: when unset it resolves to `.`, i.e. the current
+> directory, so a classic in-repo run is unchanged). Run EVERY `openspec`
+> command against that root — wrap each invocation as
+> `(cd "${SPECRAILS_REPO_DIR:-.}" && openspec …)`. Treat `${SPECRAILS_REPO_DIR:-.}`
+> as the OpenSpec project root for any path the CLI prints or you read/write.
+
 Implement tasks from an OpenSpec change.
 
 **Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
@@ -26,7 +34,7 @@ Implement tasks from an OpenSpec change.
 
 2. **Check status to understand the schema**
    ```bash
-   openspec status --change "<name>" --json
+   (cd "${SPECRAILS_REPO_DIR:-.}" && openspec status --change "<name>" --json)
    ```
    Parse the JSON to understand:
    - `schemaName`: The workflow being used (e.g., "spec-driven")
@@ -35,7 +43,7 @@ Implement tasks from an OpenSpec change.
 3. **Get apply instructions**
 
    ```bash
-   openspec instructions apply --change "<name>" --json
+   (cd "${SPECRAILS_REPO_DIR:-.}" && openspec instructions apply --change "<name>" --json)
    ```
 
    This returns:

--- a/specrails-plugin/skills/opsx-archive/SKILL.md
+++ b/specrails-plugin/skills/opsx-archive/SKILL.md
@@ -9,6 +9,14 @@ metadata:
   generatedBy: "1.1.1"
 ---
 
+> **OpenSpec project root.** The `openspec/` directory lives in the REPO, not
+> the workspace this skill is driven from. The repo root is `${SPECRAILS_REPO_DIR:-.}`
+> (a default-unset env var: when unset it resolves to `.`, i.e. the current
+> directory, so a classic in-repo run is unchanged). Run EVERY `openspec`
+> command against that root — wrap each invocation as
+> `(cd "${SPECRAILS_REPO_DIR:-.}" && openspec …)`. Treat `${SPECRAILS_REPO_DIR:-.}`
+> as the OpenSpec project root for any path the CLI prints or you read/write.
+
 Archive a completed change in the experimental workflow.
 
 **Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.

--- a/specrails-plugin/skills/opsx-bulk-archive/SKILL.md
+++ b/specrails-plugin/skills/opsx-bulk-archive/SKILL.md
@@ -9,6 +9,14 @@ metadata:
   generatedBy: "1.1.1"
 ---
 
+> **OpenSpec project root.** The `openspec/` directory lives in the REPO, not
+> the workspace this skill is driven from. The repo root is `${SPECRAILS_REPO_DIR:-.}`
+> (a default-unset env var: when unset it resolves to `.`, i.e. the current
+> directory, so a classic in-repo run is unchanged). Run EVERY `openspec`
+> command against that root — wrap each invocation as
+> `(cd "${SPECRAILS_REPO_DIR:-.}" && openspec …)`. Treat `${SPECRAILS_REPO_DIR:-.}`
+> as the OpenSpec project root for any path the CLI prints or you read/write.
+
 Archive multiple completed changes in a single operation.
 
 This skill allows you to batch-archive changes, handling spec conflicts intelligently by checking the codebase to determine what's actually implemented.

--- a/specrails-plugin/skills/opsx-continue/SKILL.md
+++ b/specrails-plugin/skills/opsx-continue/SKILL.md
@@ -9,6 +9,14 @@ metadata:
   generatedBy: "1.1.1"
 ---
 
+> **OpenSpec project root.** The `openspec/` directory lives in the REPO, not
+> the workspace this skill is driven from. The repo root is `${SPECRAILS_REPO_DIR:-.}`
+> (a default-unset env var: when unset it resolves to `.`, i.e. the current
+> directory, so a classic in-repo run is unchanged). Run EVERY `openspec`
+> command against that root — wrap each invocation as
+> `(cd "${SPECRAILS_REPO_DIR:-.}" && openspec …)`. Treat `${SPECRAILS_REPO_DIR:-.}`
+> as the OpenSpec project root for any path the CLI prints or you read/write.
+
 Continue working on a change by creating the next artifact.
 
 **Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
@@ -31,7 +39,7 @@ Continue working on a change by creating the next artifact.
 
 2. **Check current status**
    ```bash
-   openspec status --change "<name>" --json
+   (cd "${SPECRAILS_REPO_DIR:-.}" && openspec status --change "<name>" --json)
    ```
    Parse the JSON to understand current state. The response includes:
    - `schemaName`: The workflow schema being used (e.g., "spec-driven")
@@ -54,7 +62,7 @@ Continue working on a change by creating the next artifact.
    - Pick the FIRST artifact with `status: "ready"` from the status output
    - Get its instructions:
      ```bash
-     openspec instructions <artifact-id> --change "<name>" --json
+     (cd "${SPECRAILS_REPO_DIR:-.}" && openspec instructions <artifact-id> --change "<name>" --json)
      ```
    - Parse the JSON. The key fields are:
      - `context`: Project background (constraints for you - do NOT include in output)
@@ -79,7 +87,7 @@ Continue working on a change by creating the next artifact.
 
 4. **After creating an artifact, show progress**
    ```bash
-   openspec status --change "<name>"
+   (cd "${SPECRAILS_REPO_DIR:-.}" && openspec status --change "<name>")
    ```
 
 **Output**

--- a/specrails-plugin/skills/opsx-diff/SKILL.md
+++ b/specrails-plugin/skills/opsx-diff/SKILL.md
@@ -8,6 +8,14 @@ metadata:
   version: "1.0"
 ---
 
+> **OpenSpec project root.** The `openspec/` directory lives in the REPO, not
+> the workspace this skill is driven from. The repo root is `${SPECRAILS_REPO_DIR:-.}`
+> (a default-unset env var: when unset it resolves to `.`, i.e. the current
+> directory, so a classic in-repo run is unchanged). Run EVERY `openspec`
+> command against that root — wrap each invocation as
+> `(cd "${SPECRAILS_REPO_DIR:-.}" && openspec …)`. Treat `${SPECRAILS_REPO_DIR:-.}`
+> as the OpenSpec project root for any path the CLI prints or you read/write.
+
 Visualize spec changes for this project (read name from CLAUDE.md or package.json): compare the current specs against a named OpenSpec change to show exactly what behavioral requirements are being added, modified, or removed.
 
 **Input:** $ARGUMENTS — accepts:
@@ -35,7 +43,7 @@ Parse `$ARGUMENTS` to set runtime variables.
 4. If `CHANGE_NAME` is empty after parsing:
    - Run:
      ```bash
-     openspec list --json
+     (cd "${SPECRAILS_REPO_DIR:-.}" && openspec list --json)
      ```
    - If the result shows available changes, use the **AskUserQuestion tool** (open-ended, show the list) to ask which change to diff.
    - If no changes exist, print:

--- a/specrails-plugin/skills/opsx-explore/SKILL.md
+++ b/specrails-plugin/skills/opsx-explore/SKILL.md
@@ -9,6 +9,14 @@ metadata:
   generatedBy: "1.1.1"
 ---
 
+> **OpenSpec project root.** The `openspec/` directory lives in the REPO, not
+> the workspace this skill is driven from. The repo root is `${SPECRAILS_REPO_DIR:-.}`
+> (a default-unset env var: when unset it resolves to `.`, i.e. the current
+> directory, so a classic in-repo run is unchanged). Run EVERY `openspec`
+> command against that root — wrap each invocation as
+> `(cd "${SPECRAILS_REPO_DIR:-.}" && openspec …)`. Treat `${SPECRAILS_REPO_DIR:-.}`
+> as the OpenSpec project root for any path the CLI prints or you read/write.
+
 Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
 
 **IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first (e.g., start a change with `/opsx:new` or `/opsx:ff`). You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
@@ -83,7 +91,7 @@ You have full context of the OpenSpec system. Use it naturally, don't force it.
 
 At the start, quickly check what exists:
 ```bash
-openspec list --json
+(cd "${SPECRAILS_REPO_DIR:-.}" && openspec list --json)
 ```
 
 This tells you:

--- a/specrails-plugin/skills/opsx-ff/SKILL.md
+++ b/specrails-plugin/skills/opsx-ff/SKILL.md
@@ -9,6 +9,14 @@ metadata:
   generatedBy: "1.1.1"
 ---
 
+> **OpenSpec project root.** The `openspec/` directory lives in the REPO, not
+> the workspace this skill is driven from. The repo root is `${SPECRAILS_REPO_DIR:-.}`
+> (a default-unset env var: when unset it resolves to `.`, i.e. the current
+> directory, so a classic in-repo run is unchanged). Run EVERY `openspec`
+> command against that root — wrap each invocation as
+> `(cd "${SPECRAILS_REPO_DIR:-.}" && openspec …)`. Treat `${SPECRAILS_REPO_DIR:-.}`
+> as the OpenSpec project root for any path the CLI prints or you read/write.
+
 Fast-forward through artifact creation - generate everything needed to start implementation in one go.
 
 **Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
@@ -26,13 +34,13 @@ Fast-forward through artifact creation - generate everything needed to start imp
 
 2. **Create the change directory**
    ```bash
-   openspec new change "<name>"
+   (cd "${SPECRAILS_REPO_DIR:-.}" && openspec new change "<name>")
    ```
    This creates a scaffolded change at `openspec/changes/<name>/`.
 
 3. **Get the artifact build order**
    ```bash
-   openspec status --change "<name>" --json
+   (cd "${SPECRAILS_REPO_DIR:-.}" && openspec status --change "<name>" --json)
    ```
    Parse the JSON to get:
    - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
@@ -47,7 +55,7 @@ Fast-forward through artifact creation - generate everything needed to start imp
    a. **For each artifact that is `ready` (dependencies satisfied)**:
       - Get instructions:
         ```bash
-        openspec instructions <artifact-id> --change "<name>" --json
+        (cd "${SPECRAILS_REPO_DIR:-.}" && openspec instructions <artifact-id> --change "<name>" --json)
         ```
       - The instructions JSON includes:
         - `context`: Project background (constraints for you - do NOT include in output)
@@ -72,7 +80,7 @@ Fast-forward through artifact creation - generate everything needed to start imp
 
 5. **Show final status**
    ```bash
-   openspec status --change "<name>"
+   (cd "${SPECRAILS_REPO_DIR:-.}" && openspec status --change "<name>")
    ```
 
 **Output**

--- a/specrails-plugin/skills/opsx-new/SKILL.md
+++ b/specrails-plugin/skills/opsx-new/SKILL.md
@@ -9,6 +9,14 @@ metadata:
   generatedBy: "1.1.1"
 ---
 
+> **OpenSpec project root.** The `openspec/` directory lives in the REPO, not
+> the workspace this skill is driven from. The repo root is `${SPECRAILS_REPO_DIR:-.}`
+> (a default-unset env var: when unset it resolves to `.`, i.e. the current
+> directory, so a classic in-repo run is unchanged). Run EVERY `openspec`
+> command against that root — wrap each invocation as
+> `(cd "${SPECRAILS_REPO_DIR:-.}" && openspec …)`. Treat `${SPECRAILS_REPO_DIR:-.}`
+> as the OpenSpec project root for any path the CLI prints or you read/write.
+
 Start a new change using the experimental artifact-driven approach.
 
 **Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
@@ -36,14 +44,14 @@ Start a new change using the experimental artifact-driven approach.
 
 3. **Create the change directory**
    ```bash
-   openspec new change "<name>"
+   (cd "${SPECRAILS_REPO_DIR:-.}" && openspec new change "<name>")
    ```
    Add `--schema <name>` only if the user requested a specific workflow.
    This creates a scaffolded change at `openspec/changes/<name>/` with the selected schema.
 
 4. **Show the artifact status**
    ```bash
-   openspec status --change "<name>"
+   (cd "${SPECRAILS_REPO_DIR:-.}" && openspec status --change "<name>")
    ```
    This shows which artifacts need to be created and which are ready (dependencies satisfied).
 
@@ -51,7 +59,7 @@ Start a new change using the experimental artifact-driven approach.
    The first artifact depends on the schema (e.g., `proposal` for spec-driven).
    Check the status output to find the first artifact with status "ready".
    ```bash
-   openspec instructions <first-artifact-id> --change "<name>"
+   (cd "${SPECRAILS_REPO_DIR:-.}" && openspec instructions <first-artifact-id> --change "<name>")
    ```
    This outputs the template and context for creating the first artifact.
 

--- a/specrails-plugin/skills/opsx-onboard/SKILL.md
+++ b/specrails-plugin/skills/opsx-onboard/SKILL.md
@@ -9,6 +9,14 @@ metadata:
   generatedBy: "1.1.1"
 ---
 
+> **OpenSpec project root.** The `openspec/` directory lives in the REPO, not
+> the workspace this skill is driven from. The repo root is `${SPECRAILS_REPO_DIR:-.}`
+> (a default-unset env var: when unset it resolves to `.`, i.e. the current
+> directory, so a classic in-repo run is unchanged). Run EVERY `openspec`
+> command against that root — wrap each invocation as
+> `(cd "${SPECRAILS_REPO_DIR:-.}" && openspec …)`. Treat `${SPECRAILS_REPO_DIR:-.}`
+> as the OpenSpec project root for any path the CLI prints or you read/write.
+
 Guide the user through their first complete OpenSpec workflow cycle. This is a teaching experience—you'll do real work in their codebase while explaining each step.
 
 ---
@@ -18,7 +26,7 @@ Guide the user through their first complete OpenSpec workflow cycle. This is a t
 Before starting, check if OpenSpec is initialized:
 
 ```bash
-openspec status --json 2>&1 || echo "NOT_INITIALIZED"
+(cd "${SPECRAILS_REPO_DIR:-.}" && openspec status --json) 2>&1 || echo "NOT_INITIALIZED"
 ```
 
 **If not initialized:**
@@ -168,7 +176,7 @@ Let me create one for our task.
 
 **DO:** Create the change with a derived kebab-case name:
 ```bash
-openspec new change "<derived-name>"
+(cd "${SPECRAILS_REPO_DIR:-.}" && openspec new change "<derived-name>")
 ```
 
 **SHOW:**
@@ -237,7 +245,7 @@ Does this capture the intent? I can adjust before we save it.
 
 After approval, save the proposal:
 ```bash
-openspec instructions proposal --change "<name>" --json
+(cd "${SPECRAILS_REPO_DIR:-.}" && openspec instructions proposal --change "<name>" --json)
 ```
 Then write the content to `openspec/changes/<name>/proposal.md`.
 
@@ -423,7 +431,7 @@ Archived changes become your project's decision history—you can always find th
 
 **DO:**
 ```bash
-openspec archive "<name>"
+(cd "${SPECRAILS_REPO_DIR:-.}" && openspec archive "<name>")
 ```
 
 **SHOW:**

--- a/specrails-plugin/skills/opsx-sync/SKILL.md
+++ b/specrails-plugin/skills/opsx-sync/SKILL.md
@@ -9,6 +9,14 @@ metadata:
   generatedBy: "1.1.1"
 ---
 
+> **OpenSpec project root.** The `openspec/` directory lives in the REPO, not
+> the workspace this skill is driven from. The repo root is `${SPECRAILS_REPO_DIR:-.}`
+> (a default-unset env var: when unset it resolves to `.`, i.e. the current
+> directory, so a classic in-repo run is unchanged). Run EVERY `openspec`
+> command against that root — wrap each invocation as
+> `(cd "${SPECRAILS_REPO_DIR:-.}" && openspec …)`. Treat `${SPECRAILS_REPO_DIR:-.}`
+> as the OpenSpec project root for any path the CLI prints or you read/write.
+
 Sync delta specs from a change to main specs.
 
 This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).

--- a/specrails-plugin/skills/opsx-verify/SKILL.md
+++ b/specrails-plugin/skills/opsx-verify/SKILL.md
@@ -9,6 +9,14 @@ metadata:
   generatedBy: "1.1.1"
 ---
 
+> **OpenSpec project root.** The `openspec/` directory lives in the REPO, not
+> the workspace this skill is driven from. The repo root is `${SPECRAILS_REPO_DIR:-.}`
+> (a default-unset env var: when unset it resolves to `.`, i.e. the current
+> directory, so a classic in-repo run is unchanged). Run EVERY `openspec`
+> command against that root — wrap each invocation as
+> `(cd "${SPECRAILS_REPO_DIR:-.}" && openspec …)`. Treat `${SPECRAILS_REPO_DIR:-.}`
+> as the OpenSpec project root for any path the CLI prints or you read/write.
+
 Verify that an implementation matches the change artifacts (specs, tasks, design).
 
 **Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
@@ -27,7 +35,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
 
 2. **Check status to understand the schema**
    ```bash
-   openspec status --change "<name>" --json
+   (cd "${SPECRAILS_REPO_DIR:-.}" && openspec status --change "<name>" --json)
    ```
    Parse the JSON to understand:
    - `schemaName`: The workflow being used (e.g., "spec-driven")
@@ -36,7 +44,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
 3. **Get the change directory and load artifacts**
 
    ```bash
-   openspec instructions apply --change "<name>" --json
+   (cd "${SPECRAILS_REPO_DIR:-.}" && openspec instructions apply --change "<name>" --json)
    ```
 
    This returns the change directory and context files. Read all available artifacts from `contextFiles`.

--- a/src/installer/__tests__/reserved-paths.test.ts
+++ b/src/installer/__tests__/reserved-paths.test.ts
@@ -8,6 +8,7 @@ import { runInit } from '../commands/init.js'
 import { runUpdate } from '../commands/update.js'
 import { mkdirp, readTextFile, writeFileLf } from '../util/fs.js'
 import { initRepo } from '../util/git.js'
+import { resolveArtifacts } from '../util/registry.js'
 
 /**
  * End-to-end audit: the installer (init AND update) must NEVER mutate
@@ -34,17 +35,20 @@ interface ReservedFixtures {
   customAgent: { abs: string; contents: string }
 }
 
-function sprinkleReservedFixtures(repoRoot: string): ReservedFixtures {
+// The reserved regions now live under the relocated artifact workspace
+// (`artifactRoot`), not the repo. The preservation contract is unchanged —
+// only the base directory moved.
+function sprinkleReservedFixtures(artifactRoot: string): ReservedFixtures {
   const profileJson = {
-    abs: path.join(repoRoot, '.specrails', 'profiles', 'team.json'),
+    abs: path.join(artifactRoot, '.specrails', 'profiles', 'team.json'),
     contents: JSON.stringify({ name: 'team', owner: 'alice' }, null, 2) + '\n',
   }
   const profileInNested = {
-    abs: path.join(repoRoot, '.specrails', 'profiles', 'env', 'prod.json'),
+    abs: path.join(artifactRoot, '.specrails', 'profiles', 'env', 'prod.json'),
     contents: JSON.stringify({ env: 'prod' }) + '\n',
   }
   const customAgent = {
-    abs: path.join(repoRoot, '.claude', 'agents', 'custom-reviewer.md'),
+    abs: path.join(artifactRoot, '.claude', 'agents', 'custom-reviewer.md'),
     contents: '# custom reviewer\nuser-authored content\n',
   }
   writeFileLf(profileJson.abs, profileJson.contents)
@@ -61,21 +65,35 @@ function assertReservedUntouched(fx: ReservedFixtures): void {
 
 describe('reserved paths audit', () => {
   let tmpDir: string
+  let registryHome: string
   let prevSkipPrereqs: string | undefined
   let prevSkipOpenSpecInit: string | undefined
   let prevScriptDirOverride: string | undefined
+  let prevRegistryHome: string | undefined
   let prevCwd: string
+
+  /** The relocated artifact workspace where reserved regions live. */
+  function workspaceFor(repoRoot: string): string {
+    return resolveArtifacts(repoRoot, {
+      allocate: true,
+      home: registryHome,
+      providers: ['claude'],
+    }).artifactRoot
+  }
 
   beforeEach(() => {
     tmpDir = mkdtempSync(path.join(os.tmpdir(), 'specrails-reserved-test-'))
+    registryHome = mkdtempSync(path.join(os.tmpdir(), 'specrails-reserved-home-'))
     prevCwd = process.cwd()
     prevSkipPrereqs = process.env.SPECRAILS_SKIP_PREREQS
     prevSkipOpenSpecInit = process.env.SPECRAILS_SKIP_OPENSPEC_INIT
     prevScriptDirOverride = process.env.SPECRAILS_CORE_SCRIPT_DIR
+    prevRegistryHome = process.env.SPECRAILS_REGISTRY_HOME
     process.env.SPECRAILS_SKIP_PREREQS = '1'
     // Reserved-paths audit doesn't depend on OpenSpec; skip the npx
     // fetch so the test stays fast and Windows CI doesn't time out.
     process.env.SPECRAILS_SKIP_OPENSPEC_INIT = '1'
+    process.env.SPECRAILS_REGISTRY_HOME = registryHome
   })
 
   afterEach(() => {
@@ -86,7 +104,10 @@ describe('reserved paths audit', () => {
     else process.env.SPECRAILS_SKIP_OPENSPEC_INIT = prevSkipOpenSpecInit
     if (prevScriptDirOverride === undefined) delete process.env.SPECRAILS_CORE_SCRIPT_DIR
     else process.env.SPECRAILS_CORE_SCRIPT_DIR = prevScriptDirOverride
+    if (prevRegistryHome === undefined) delete process.env.SPECRAILS_REGISTRY_HOME
+    else process.env.SPECRAILS_REGISTRY_HOME = prevRegistryHome
     rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+    rmSync(registryHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
   })
 
   it('init preserves profile JSON and custom-* agents when they pre-exist', async () => {
@@ -97,7 +118,7 @@ describe('reserved paths audit', () => {
     await initRepo(repoRoot)
     process.env.SPECRAILS_CORE_SCRIPT_DIR = scriptDir
 
-    const fx = sprinkleReservedFixtures(repoRoot)
+    const fx = sprinkleReservedFixtures(workspaceFor(repoRoot))
 
     await runInit({
       'root-dir': repoRoot,
@@ -117,15 +138,16 @@ describe('reserved paths audit', () => {
     await initRepo(repoRoot)
     process.env.SPECRAILS_CORE_SCRIPT_DIR = scriptDir
 
-    // Simulate a prior install with specrails-version + old manifest.
-    writeFileLf(path.join(repoRoot, '.specrails', 'specrails-version'), '4.0.0\n')
+    // Simulate a prior relocate-always install: marker + manifest in the workspace.
+    const ws = workspaceFor(repoRoot)
+    writeFileLf(path.join(ws, '.specrails', 'specrails-version'), '4.0.0\n')
     writeFileLf(
-      path.join(repoRoot, '.specrails', 'specrails-manifest.json'),
+      path.join(ws, '.specrails', 'specrails-manifest.json'),
       JSON.stringify({ version: '4.0.0', installed_at: '2026-01-01T00:00:00Z', artifacts: {} }),
     )
-    mkdirp(path.join(repoRoot, '.claude', 'commands', 'specrails'))
+    mkdirp(path.join(ws, '.claude', 'commands', 'specrails'))
 
-    const fx = sprinkleReservedFixtures(repoRoot)
+    const fx = sprinkleReservedFixtures(ws)
 
     await runUpdate({ 'root-dir': repoRoot })
 
@@ -140,7 +162,7 @@ describe('reserved paths audit', () => {
     await initRepo(repoRoot)
     process.env.SPECRAILS_CORE_SCRIPT_DIR = scriptDir
 
-    const fx = sprinkleReservedFixtures(repoRoot)
+    const fx = sprinkleReservedFixtures(workspaceFor(repoRoot))
 
     await runInit({ 'root-dir': repoRoot, yes: true, provider: 'claude' })
     assertReservedUntouched(fx)

--- a/src/installer/__tests__/scaffold.test.ts
+++ b/src/installer/__tests__/scaffold.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { CORE_AGENTS, scaffoldInstallation } from '../phases/scaffold.js'
 import { listDir, mkdirp, pathExists, writeFileLf } from '../util/fs.js'
 import { initRepo } from '../util/git.js'
+import { resolveArtifacts } from '../util/registry.js'
 
 /**
  * Tests for the CORE_AGENTS constant and the default agent-selection
@@ -120,7 +121,8 @@ describe('placeQuickTierArtefacts — default agent placement', () => {
 
     scaffoldInstallation({
       scriptDir,
-      repoRoot: testRepoRoot,
+      artifactRoot: testRepoRoot,
+      codeRoot: testRepoRoot,
       provider: 'claude',
       providerDir: '.claude',
       agentTeams: false,
@@ -144,7 +146,8 @@ describe('placeQuickTierArtefacts — default agent placement', () => {
 
     scaffoldInstallation({
       scriptDir,
-      repoRoot: testRepoRoot,
+      artifactRoot: testRepoRoot,
+      codeRoot: testRepoRoot,
       provider: 'claude',
       providerDir: '.claude',
       agentTeams: false,
@@ -171,7 +174,8 @@ describe('placeQuickTierArtefacts — default agent placement', () => {
 
     scaffoldInstallation({
       scriptDir,
-      repoRoot: testRepoRoot,
+      artifactRoot: testRepoRoot,
+      codeRoot: testRepoRoot,
       provider: 'claude',
       providerDir: '.claude',
       agentTeams: false,
@@ -190,19 +194,32 @@ describe('placeQuickTierArtefacts — default agent placement', () => {
 
 describe('update — optional-agent preservation', () => {
   let tmpDir: string
+  let registryHome: string
   let prevSkipPrereqs: string | undefined
   let prevSkipOpenSpecInit: string | undefined
   let prevScriptDirOverride: string | undefined
+  let prevRegistryHome: string | undefined
   let prevCwd: string
+
+  function workspaceFor(repoRoot: string): string {
+    return resolveArtifacts(repoRoot, {
+      allocate: true,
+      home: registryHome,
+      providers: ['claude'],
+    }).artifactRoot
+  }
 
   beforeEach(() => {
     tmpDir = mkdtempSync(path.join(os.tmpdir(), 'specrails-update-test-'))
+    registryHome = mkdtempSync(path.join(os.tmpdir(), 'specrails-update-home-'))
     prevCwd = process.cwd()
     prevSkipPrereqs = process.env.SPECRAILS_SKIP_PREREQS
     prevSkipOpenSpecInit = process.env.SPECRAILS_SKIP_OPENSPEC_INIT
     prevScriptDirOverride = process.env.SPECRAILS_CORE_SCRIPT_DIR
+    prevRegistryHome = process.env.SPECRAILS_REGISTRY_HOME
     process.env.SPECRAILS_SKIP_PREREQS = '1'
     process.env.SPECRAILS_SKIP_OPENSPEC_INIT = '1'
+    process.env.SPECRAILS_REGISTRY_HOME = registryHome
   })
 
   afterEach(() => {
@@ -213,7 +230,10 @@ describe('update — optional-agent preservation', () => {
     else process.env.SPECRAILS_SKIP_OPENSPEC_INIT = prevSkipOpenSpecInit
     if (prevScriptDirOverride === undefined) delete process.env.SPECRAILS_CORE_SCRIPT_DIR
     else process.env.SPECRAILS_CORE_SCRIPT_DIR = prevScriptDirOverride
+    if (prevRegistryHome === undefined) delete process.env.SPECRAILS_REGISTRY_HOME
+    else process.env.SPECRAILS_REGISTRY_HOME = prevRegistryHome
     rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+    rmSync(registryHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
   })
 
   it('re-places a previously-selected optional agent (sr-test-writer) on update', async () => {
@@ -228,15 +248,16 @@ describe('update — optional-agent preservation', () => {
     await initRepo(testRepoRoot)
     process.env.SPECRAILS_CORE_SCRIPT_DIR = scriptDir
 
-    // Simulate an existing install
-    writeFileLf(path.join(testRepoRoot, '.specrails', 'specrails-version'), '4.0.0\n')
+    // Simulate an existing relocate-always install: marker/manifest in workspace.
+    const ws = workspaceFor(testRepoRoot)
+    writeFileLf(path.join(ws, '.specrails', 'specrails-version'), '4.0.0\n')
     writeFileLf(
-      path.join(testRepoRoot, '.specrails', 'specrails-manifest.json'),
+      path.join(ws, '.specrails', 'specrails-manifest.json'),
       JSON.stringify({ version: '4.0.0', installed_at: '2026-01-01T00:00:00Z', artifacts: {} }),
     )
-    mkdirp(path.join(testRepoRoot, '.claude', 'commands', 'specrails'))
+    mkdirp(path.join(ws, '.claude', 'commands', 'specrails'))
 
-    // Write install-config.yaml that includes sr-test-writer as selected
+    // install-config.yaml is a USER file → stays in the repo (read from repoRoot).
     const installConfigYaml = [
       'version: 1',
       'provider: claude',
@@ -258,7 +279,7 @@ describe('update — optional-agent preservation', () => {
 
     await runUpdate({ 'root-dir': testRepoRoot })
 
-    const placed = placedAgentIds(testRepoRoot)
+    const placed = placedAgentIds(ws)
     // Optional agent that was in install-config must be re-placed
     expect(placed).toContain('sr-test-writer')
     // Core agents always placed

--- a/src/installer/__tests__/template-repo-dir.test.ts
+++ b/src/installer/__tests__/template-repo-dir.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Guard test for STAGE 3 (runtime template re-pointing).
+ *
+ * Background: at runtime a rail spawns with `cwd = <workspace>` (where the
+ * relocated `.claude/agents`, profiles, `.specrails/local-tickets.json` and
+ * run-state live and resolve correctly cwd-relative) while the user's SOURCE
+ * code, `openspec/**`, `.git`, and the GitHub remote stay in the REPO, reached
+ * via `${SPECRAILS_REPO_DIR:-.}`. The spawner sets `SPECRAILS_REPO_DIR` to the
+ * repo path; UNSET defaults to `.` so a classic in-repo run is byte-identical.
+ *
+ * This test is the cheapest insurance against a regression that points a
+ * repo-resident read/write or a git/gh command at the workspace cwd. It greps
+ * the IN-SCOPE runtime prompt templates for repo-resident literals that MUST be
+ * wrapped in `${SPECRAILS_REPO_DIR` (or scoped via `cd "${SPECRAILS_REPO_DIR…`)
+ * and FAILS if any operative occurrence is neither wrapped nor explicitly
+ * allow-listed.
+ *
+ * It is deliberately scoped to the implement / retry / ship pipeline templates
+ * (Claude + the mirrored codex/gemini skills) — the ones the spawner runs with
+ * `cwd = <workspace>`. Other templates (`compat-check`, `opsx-diff`,
+ * `explore-spec`, `merge-resolve`, …) are out of this change's scope and are not
+ * scanned.
+ *
+ * The allow-list is tight on purpose: each entry pairs a file with a stable
+ * substring of the exact line that is allowed to mention a repo-resident literal
+ * WITHOUT the wrapper — always because the mention is prose, a stored relative
+ * descriptor, a Skill-internal behaviour note, a report/summary line, or a
+ * worktree-relative `git -C <worktree-path>` (where the worktree IS the cwd-side
+ * repo copy). A real miss (an operative read/write or git mutation pointed at
+ * the workspace) is NOT on the list and therefore fails.
+ */
+
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..')
+const T = (rel: string) => path.join(REPO_ROOT, 'templates', rel)
+
+/** The runtime prompt templates re-pointed by STAGE 3. */
+const IN_SCOPE_FILES = [
+  // Claude agents
+  'agents/sr-developer.md',
+  'agents/sr-architect.md',
+  'agents/sr-reviewer.md',
+  'agents/sr-backend-developer.md',
+  'agents/sr-frontend-developer.md',
+  // Claude commands
+  'commands/specrails/implement.md',
+  'commands/specrails/retry.md',
+  // Codex skills (orchestrators + baseline trio + layer devs)
+  'codex-skills/implement/SKILL.md',
+  'codex-skills/retry/SKILL.md',
+  'codex-skills/rails/sr-architect/SKILL.md',
+  'codex-skills/rails/sr-developer/SKILL.md',
+  'codex-skills/rails/sr-reviewer/SKILL.md',
+  'codex-skills/rails/sr-backend-developer/SKILL.md',
+  'codex-skills/rails/sr-frontend-developer/SKILL.md',
+  // Gemini commands
+  'gemini-commands/implement.toml',
+] as const
+
+/** The exact token every repo-resident reference must carry. */
+const WRAPPER = '${SPECRAILS_REPO_DIR'
+
+/**
+ * Lines allowed to mention a repo-resident openspec literal WITHOUT the wrapper.
+ * Key = in-scope file; value = list of stable substrings. A scanned line is
+ * exempt when it CONTAINS any of the file's substrings. Reasons are inline.
+ */
+const OPENSPEC_ALLOW: Record<string, string[]> = {
+  'agents/sr-reviewer.md': [
+    // `opsx:archive` is a Skill that resolves openspec itself — these describe
+    // what the SKILL does internally, not the reviewer's own on-disk access.
+    '`opsx:archive` **syncs the delta specs**',
+    '**You are EMULATING (a CRITICAL FAILURE) if you** run `mkdir`/`mv`',
+    '**4 — Execution receipt.** Finish with an `## OpenSpec Skill Execution Receipt`',
+  ],
+  'commands/specrails/implement.md': [
+    // Stored pipeline-state JSON value: a repo-RELATIVE descriptor consumed via
+    // wrapped sites (retry prefixes it at read time). Wrapping the stored value
+    // would bake an unexpanded shell token into the JSON.
+    '"openspec_artifacts": "openspec/changes/<feature-name>/"',
+    // Human-facing log/report lines (printed, not executed).
+    'Resolution report: openspec/changes/<feature>/merge-resolution-report.md',
+    '| OpenSpec proposal | openspec/changes/',
+    '| OpenSpec design | openspec/changes/',
+    '| OpenSpec tasks | openspec/changes/',
+    '| OpenSpec context-bundle | openspec/changes/',
+    '| Score file | `openspec/changes/<name>/confidence-score.json` |',
+  ],
+  'commands/specrails/retry.md': [
+    // Documents the shape of the stored relative descriptor (prefixed on read).
+    '- `OPENSPEC_ARTIFACTS` ← `openspec_artifacts` (e.g. `openspec/changes/<name>/`)',
+  ],
+  'codex-skills/implement/SKILL.md': [
+    // Contract prose + ASCII pipeline diagram + report summary line.
+    'without an archived change under `openspec/changes/archive/`',
+    'produces openspec/changes/<slug>/{proposal,design,tasks,specs}',
+    'archived (`openspec/changes/archive/<slug>/` exists)',
+    'Archive:   archived → openspec/changes/archive/<slug>',
+  ],
+  'codex-skills/retry/SKILL.md': [
+    // State-summary output lines (printed to the user).
+    'Change pkg:  openspec/changes/<slug>/ (<found / missing>)',
+    'change package at `openspec/changes/<slug>/` (<found|missing>)',
+  ],
+  'codex-skills/rails/sr-architect/SKILL.md': [
+    // Frontmatter description + the architect's structured REPORT fields
+    // (descriptive locations, not operative reads).
+    'description: "Architect role for the specrails implement pipeline.',
+    '- Path: `openspec/changes/<change-slug>/`',
+    '- Proposal: `openspec/changes/<change-slug>/proposal.md`',
+    '- Design: `openspec/changes/<change-slug>/design.md`',
+    '- Tasks: `openspec/changes/<change-slug>/tasks.md`',
+    'OpenSpec change: openspec/changes/<slug>/',
+  ],
+  'codex-skills/rails/sr-developer/SKILL.md': [
+    // "Changed:" report block listing the touched artefact (descriptive).
+    '- openspec/changes/<slug>/tasks.md',
+  ],
+  'codex-skills/rails/sr-frontend-developer/SKILL.md': [
+    // "Changed:" report block listing the touched artefact (descriptive).
+    '- openspec/changes/<slug>/tasks.md',
+  ],
+}
+
+/**
+ * Lines allowed to carry a `git`/`gh` command WITHOUT the wrapper. Same shape
+ * as OPENSPEC_ALLOW.
+ */
+const GIT_ALLOW: Record<string, string[]> = {
+  'commands/specrails/implement.md': [
+    // `<worktree-path>` is an absolute git-worktree path supplied by the runtime
+    // — `git -C <worktree-path>` already targets it directly.
+    'git -C <worktree-path> diff main --name-only',
+    'git -C <worktree-path> diff main -- <file>',
+    'git worktree remove <worktree-path> --force',
+    'git-worktree path supplied by the runtime', // the explanatory sentence
+    // Prose: describes that multi-feature runs execute in isolated git worktrees.
+    'Multi-feature runs execute in **isolated git worktrees**',
+    // Prose error-context strings (printed, not executed).
+    '**Pipeline state:** update `ship` → `done` if git operations',
+  ],
+  'commands/specrails/retry.md': [
+    // Prose: "discover files from git diff".
+    'the sr-test-writer will discover files from git diff',
+  ],
+  'codex-skills/implement/SKILL.md': [
+    // Prose forbidding speculative inspection during a wait.
+    'Run `find`, `git status`, `git diff`, `npm test`, `ls`, or',
+  ],
+  'gemini-commands/implement.toml': [
+    // Read-only inspection examples listed as prose (backtick references).
+    '`git status`, `openspec status`) and to CONFIRM what the',
+  ],
+}
+
+/**
+ * Lines allowed to carry a verb-form `openspec <verb>` invocation WITHOUT the
+ * wrapper — always because the mention is descriptive prose (a backtick-quoted
+ * reference inside a sentence, a report field, or a contract note), NOT an
+ * operative shell invocation. An operative `openspec <verb>` that actually runs
+ * MUST be wrapped as `(cd "${SPECRAILS_REPO_DIR:-.}" && openspec <verb> …)`.
+ */
+const OPENSPEC_VERB_ALLOW: Record<string, string[]> = {
+  'agents/sr-architect.md': [
+    // Prose describing what the opsx:ff Skill does internally + a report field.
+    '`opsx:ff` runs `openspec new change` and then drives `openspec instructions`',
+    'verified artifacts (paths + `openspec status` result)',
+  ],
+  'codex-skills/implement/SKILL.md': [
+    // Contract prose: archiving is an obligation; failure-mode enumeration.
+    'Archiving (`openspec archive`) is a hard obligation',
+    'If `openspec validate`, `openspec archive`, or the step-3',
+  ],
+  'codex-skills/rails/sr-architect/SKILL.md': [
+    // Prose: "stays trackable by `openspec status`" + a re-run hint + a
+    // do-not-hand-off note. The operative calls on the surrounding lines ARE
+    // wrapped; these are descriptive references.
+    'stays trackable by `openspec status`',
+    're-run `openspec new change …`',
+    'that fails `openspec validate`',
+  ],
+  'codex-skills/rails/sr-reviewer/SKILL.md': [
+    // Prose describing the archive step + the named "only mutation" note.
+    'confirm all tasks are checked, run `openspec archive`, and',
+    'mutation is `openspec archive "<slug>" -y` during Step 7 when',
+  ],
+  'gemini-commands/implement.toml': [
+    // Read-only inspection examples + failure-mode prose (backtick references).
+    '`git status`, `openspec status`) and to CONFIRM what the',
+    '(`openspec validate <id> --strict`).',
+    'running `openspec archive` (or moving files) to get past a failing',
+  ],
+}
+
+/** Regexes for the literals we scan for. */
+const OPENSPEC_RE = /openspec\/(changes|specs)/
+/**
+ * Verb-form openspec invocations. A line that matches MUST carry the
+ * `${SPECRAILS_REPO_DIR` wrapper (operative, repo-scoped) or be on the curated
+ * OPENSPEC_VERB_ALLOW prose allow-list — otherwise it would run `openspec`
+ * against the workspace cwd, where there is no OpenSpec project.
+ */
+const OPENSPEC_VERB_RE = /\bopenspec\s+(validate|status|instructions|archive|new|init|update)\b/
+const GIT_MUTATION_RE =
+  /\b(git (checkout|commit|push|diff|add|worktree|rev-parse|status)|gh (issue|pr) )/
+
+function isAllowed(allow: Record<string, string[]>, file: string, line: string): boolean {
+  const subs = allow[file]
+  if (!subs) return false
+  return subs.some((s) => line.includes(s))
+}
+
+describe('STAGE 3 — runtime templates point repo-resident artifacts at ${SPECRAILS_REPO_DIR:-.}', () => {
+  it('every in-scope runtime template exists and is non-empty', () => {
+    for (const rel of IN_SCOPE_FILES) {
+      const body = readFileSync(T(rel), 'utf8')
+      expect(body.length, `${rel} should be a non-empty template`).toBeGreaterThan(0)
+    }
+  })
+
+  it('every operative openspec/** reference is wrapped in ${SPECRAILS_REPO_DIR (or allow-listed)', () => {
+    const misses: string[] = []
+    for (const rel of IN_SCOPE_FILES) {
+      const lines = readFileSync(T(rel), 'utf8').split('\n')
+      lines.forEach((line, i) => {
+        if (!OPENSPEC_RE.test(line)) return
+        if (line.includes(WRAPPER)) return // wrapped — good
+        if (isAllowed(OPENSPEC_ALLOW, rel, line)) return // prose/report/stored
+        misses.push(`${rel}:${i + 1}  ${line.trim()}`)
+      })
+    }
+    expect(
+      misses,
+      `Bare openspec/** literal(s) found that must be wrapped in \`${WRAPPER}:-.}/openspec/...\`\n` +
+        `(or added to OPENSPEC_ALLOW with a reason if genuinely prose):\n` +
+        misses.join('\n'),
+    ).toEqual([])
+  })
+
+  it('every operative `openspec <verb>` invocation is repo-scoped via ${SPECRAILS_REPO_DIR (or allow-listed)', () => {
+    // Catches the verb FORMS the path-only OPENSPEC_RE misses: a bare
+    // `openspec validate|status|instructions|archive|new|init|update` runs the
+    // CLI from cwd=workspace, where there is no OpenSpec project → it fails with
+    // "not an OpenSpec project". Operative calls MUST carry the repo-dir wrapper;
+    // descriptive prose is curated in OPENSPEC_VERB_ALLOW.
+    const misses: string[] = []
+    for (const rel of IN_SCOPE_FILES) {
+      const lines = readFileSync(T(rel), 'utf8').split('\n')
+      lines.forEach((line, i) => {
+        if (!OPENSPEC_VERB_RE.test(line)) return
+        if (line.includes(WRAPPER)) return // repo-scoped — good
+        if (isAllowed(OPENSPEC_VERB_ALLOW, rel, line)) return // prose/report
+        misses.push(`${rel}:${i + 1}  ${line.trim()}`)
+      })
+    }
+    expect(
+      misses,
+      `Operative \`openspec <verb>\` invocation(s) found that must be repo-scoped as ` +
+        `\`(cd "${WRAPPER}:-.}" && openspec <verb> …)\`\n` +
+        `(or added to OPENSPEC_VERB_ALLOW with a reason if genuinely prose):\n` +
+        misses.join('\n'),
+    ).toEqual([])
+  })
+
+  it('every git/gh command is scoped to the repo via -C/cd "${SPECRAILS_REPO_DIR (or allow-listed)', () => {
+    const misses: string[] = []
+    for (const rel of IN_SCOPE_FILES) {
+      const lines = readFileSync(T(rel), 'utf8').split('\n')
+      lines.forEach((line, i) => {
+        if (!GIT_MUTATION_RE.test(line)) return
+        if (line.includes(WRAPPER)) return // `git -C "${SPECRAILS_REPO_DIR..."` or `(cd "${SPECRAILS_REPO_DIR..." && gh ...)`
+        if (isAllowed(GIT_ALLOW, rel, line)) return
+        misses.push(`${rel}:${i + 1}  ${line.trim()}`)
+      })
+    }
+    expect(
+      misses,
+      `git/gh command(s) found that must be scoped to the repo via ` +
+        `\`git -C "${WRAPPER}:-.}"\` or \`(cd "${WRAPPER}:-.}" && gh ...)\`\n` +
+        `(or added to GIT_ALLOW with a reason if genuinely prose/worktree):\n` +
+        misses.join('\n'),
+    ).toEqual([])
+  })
+
+  it('positively confirms the canonical wrapped tokens are present where expected', () => {
+    // A sanity anchor so the test cannot pass merely because everything is
+    // allow-listed: assert the real wrapping landed in the key spots.
+    const implement = readFileSync(T('commands/specrails/implement.md'), 'utf8')
+    expect(implement).toContain('${SPECRAILS_REPO_DIR:-.}/openspec/changes/<name>/tasks.md')
+    expect(implement).toContain('git -C "${SPECRAILS_REPO_DIR:-.}" checkout -b feat/')
+    expect(implement).toContain('git -C "${SPECRAILS_REPO_DIR:-.}" push -u origin')
+    expect(implement).toContain('(cd "${SPECRAILS_REPO_DIR:-.}" && gh issue view')
+    expect(implement).toContain('cp <worktree-path>/<file> "${SPECRAILS_REPO_DIR:-.}"/<file>')
+
+    const dev = readFileSync(T('agents/sr-developer.md'), 'utf8')
+    expect(dev).toContain('${SPECRAILS_REPO_DIR:-.}/openspec/changes/<name>/')
+    // The explicit source-edit instruction the developer needs.
+    expect(dev).toContain('${SPECRAILS_REPO_DIR:-.}/<path>')
+
+    const retry = readFileSync(T('commands/specrails/retry.md'), 'utf8')
+    expect(retry).toContain('${SPECRAILS_REPO_DIR:-.}/<OPENSPEC_ARTIFACTS>tasks.md')
+  })
+
+  it('does NOT wrap run-state paths — they follow the workspace (cwd-relative)', () => {
+    // pipeline-state, agent-memory, backlog-cache, and the dry-run cache are
+    // run-state: they FOLLOW the workspace and must stay cwd-relative. A regression
+    // that prefixed them with ${SPECRAILS_REPO_DIR would send them to the repo.
+    const RUN_STATE_RE = /(pipeline-state|agent-memory|backlog-cache|\.dry-run)/
+    const offenders: string[] = []
+    for (const rel of IN_SCOPE_FILES) {
+      const lines = readFileSync(T(rel), 'utf8').split('\n')
+      lines.forEach((line, i) => {
+        if (!RUN_STATE_RE.test(line)) return
+        // Offender = a run-state literal that has the repo-dir wrapper applied to
+        // it. We detect the wrapper immediately preceding the run-state segment.
+        const wrappedRunState =
+          /\$\{SPECRAILS_REPO_DIR[^`'"\s]*\/?[^`'"\s]*(pipeline-state|agent-memory|backlog-cache|\.dry-run)/
+        if (wrappedRunState.test(line)) {
+          offenders.push(`${rel}:${i + 1}  ${line.trim()}`)
+        }
+      })
+    }
+    expect(
+      offenders,
+      `Run-state literal(s) were wrapped in \`${WRAPPER}\` but MUST stay cwd-relative ` +
+        `(they follow the workspace, not the repo):\n` + offenders.join('\n'),
+    ).toEqual([])
+  })
+
+  it('UNSET ${SPECRAILS_REPO_DIR:-.} default keeps the token resolving to "." (byte-identical to today)', () => {
+    // The contract: the default `-.` makes an unset env resolve to the current
+    // directory. Assert every wrapped occurrence uses the `:-.` default form, so
+    // a classic in-repo run (var unset, cwd=repo) is byte-identical to before.
+    const offenders: string[] = []
+    for (const rel of IN_SCOPE_FILES) {
+      const lines = readFileSync(T(rel), 'utf8').split('\n')
+      lines.forEach((line, i) => {
+        // Find each ${SPECRAILS_REPO_DIR...} occurrence and require the :-. default.
+        const re = /\$\{SPECRAILS_REPO_DIR(:-\.)?\}/g
+        let m: RegExpExecArray | null
+        while ((m = re.exec(line)) !== null) {
+          if (m[1] !== ':-.') {
+            offenders.push(`${rel}:${i + 1}  ${line.trim()}`)
+            break
+          }
+        }
+      })
+    }
+    expect(
+      offenders,
+      `Every \`\${SPECRAILS_REPO_DIR...}\` MUST use the \`:-.\` default so an unset ` +
+        `environment resolves to "." (byte-identical to a classic in-repo run):\n` +
+        offenders.join('\n'),
+    ).toEqual([])
+  })
+})

--- a/src/installer/__tests__/vitest-setup.ts
+++ b/src/installer/__tests__/vitest-setup.ts
@@ -1,0 +1,20 @@
+import { mkdtempSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+/**
+ * Test safety net: NEVER let a test write the relocation registry (or scaffold
+ * a workspace) into the developer's real `$HOME/.specrails`.
+ *
+ * `resolveArtifacts({ allocate: true })` — reached via `runInit`/`runUpdate` —
+ * resolves the registry + workspace base from `resolveHome()`, which falls back
+ * to `os.homedir()` when neither a `home` arg nor `SPECRAILS_REGISTRY_HOME` is
+ * set. A test that drives init/update without pinning a tmp home would then
+ * pollute the real `~/.specrails/registry.json`. This setup file (run once per
+ * test file by vitest `setupFiles`) points `SPECRAILS_REGISTRY_HOME` at a
+ * throwaway tmp dir unless the test has already set its own, so the real home
+ * is unreachable from tests by construction.
+ */
+if (!process.env.SPECRAILS_REGISTRY_HOME) {
+  process.env.SPECRAILS_REGISTRY_HOME = mkdtempSync(path.join(os.tmpdir(), 'specrails-test-home-'))
+}

--- a/src/installer/cli-direct-run.test.ts
+++ b/src/installer/cli-direct-run.test.ts
@@ -1,0 +1,61 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, readlinkSync, rmSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, it, expect } from 'vitest'
+
+/**
+ * Direct-run guard: `node dist/installer/cli.js <subcommand>` must auto-invoke
+ * main() (the bundled-core path in specrails-desktop spawns the CLI exactly this
+ * way). We run against the COMPILED dist when present; skipped when the package
+ * has not been built (unit-only CI runs `vitest` without `build`).
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const distCli = path.resolve(here, '..', '..', 'dist', 'installer', 'cli.js')
+
+const maybe = existsSync(distCli) ? describe : describe.skip
+
+maybe('cli direct-run guard (compiled dist)', () => {
+  it('install-framework run as `node cli.js …` materializes the framework + current', () => {
+    const tmp = mkdtempSync(path.join(os.tmpdir(), 'cli-direct-'))
+    try {
+      const res = spawnSync(
+        process.execPath,
+        [distCli, 'install-framework', '--framework-dir', path.join(tmp, 'fw'), '--provider', 'claude', '--version', '9.9.9'],
+        { encoding: 'utf8' },
+      )
+      expect(res.status).toBe(0)
+      const fw = path.join(tmp, 'fw')
+      expect(existsSync(path.join(fw, '9.9.9', '.claude', 'agents'))).toBe(true)
+      expect(readlinkSync(path.join(fw, 'current'))).toContain('9.9.9')
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('assemble run as `node cli.js …` symlinks the workspace + writes the version marker', () => {
+    const tmp = mkdtempSync(path.join(os.tmpdir(), 'cli-direct-asm-'))
+    try {
+      const fw = path.join(tmp, 'fw')
+      const ws = path.join(tmp, 'ws')
+      const repo = path.join(tmp, 'repo')
+      spawnSync(
+        process.execPath,
+        [distCli, 'install-framework', '--framework-dir', fw, '--provider', 'claude', '--version', '9.9.9'],
+        { encoding: 'utf8' },
+      )
+      const res = spawnSync(
+        process.execPath,
+        [distCli, 'assemble', '--workspace', ws, '--framework-dir', fw, '--provider', 'claude', '--version', '9.9.9', '--code-root', repo],
+        { encoding: 'utf8' },
+      )
+      expect(res.status).toBe(0)
+      expect(readFileSync(path.join(ws, '.specrails', 'specrails-version'), 'utf8').trim()).toBe('9.9.9')
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/installer/cli.ts
+++ b/src/installer/cli.ts
@@ -11,9 +11,17 @@
 
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 import { runDoctor, type DoctorFlags } from './commands/doctor.js'
+import {
+  runAssemble,
+  runInstallFramework,
+  runSwapCurrent,
+  type AssembleFlags,
+  type InstallFrameworkFlags,
+  type SwapCurrentFlags,
+} from './commands/framework.js'
 import { runInit, type InitFlags } from './commands/init.js'
 import { runUpdate, type UpdateFlags } from './commands/update.js'
 import { isInstallerError } from './util/errors.js'
@@ -83,11 +91,14 @@ function usageText(): string {
     '  specrails-core <command> [options]',
     '',
     'Commands:',
-    '  init           Install specrails into a repository',
-    '  update         Update an existing specrails installation',
-    '  doctor         Diagnose the health of an existing installation',
-    '  help           Show this help message',
-    '  version        Print the installed version',
+    '  init                Install specrails into a repository',
+    '  update              Update an existing specrails installation',
+    '  doctor              Diagnose the health of an existing installation',
+    '  install-framework   Materialize the versioned framework (offline)',
+    '  swap-current        Point framework/current at a version (offline)',
+    '  assemble            Symlink the framework into a workspace (offline)',
+    '  help                Show this help message',
+    '  version             Print the installed version',
     '',
     'Global options:',
     '  -h, --help     Show this help',
@@ -137,6 +148,15 @@ async function dispatch(
       const result = await runDoctor(flags as DoctorFlags)
       return result.failed === 0 ? 0 : 1
     }
+    case 'install-framework':
+      await runInstallFramework(flags as InstallFrameworkFlags)
+      return 0
+    case 'swap-current':
+      await runSwapCurrent(flags as SwapCurrentFlags)
+      return 0
+    case 'assemble':
+      await runAssemble(flags as AssembleFlags)
+      return 0
     case 'help':
     case '':
       process.stdout.write(usageText())
@@ -174,4 +194,31 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
     fatal(e.message || 'unexpected error', e.stack)
     return 1
   }
+}
+
+/**
+ * Auto-run guard: when this module is executed DIRECTLY as a script
+ * (`node dist/installer/cli.js <subcommand>`), run `main()` and propagate its
+ * exit code. specrails-desktop's bundled-core path (server/framework-manager.ts)
+ * spawns `node <core>/dist/installer/cli.js install-framework|assemble …` and
+ * relies on this — the legacy bin dispatcher (bin/specrails-core.mjs) imports
+ * `main` and is unaffected (it never executes this file as argv[1]).
+ *
+ * Comparing `import.meta.url` against `process.argv[1]` keeps the guard inert on
+ * import (so unit tests that `import { main }` never trigger a process.exit).
+ */
+const isDirectRun = (() => {
+  try {
+    const entry = process.argv[1]
+    if (!entry) return false
+    return import.meta.url === pathToFileURL(entry).href
+  } catch {
+    return false
+  }
+})()
+
+if (isDirectRun) {
+  void main().then((code) => {
+    process.exitCode = code
+  })
 }

--- a/src/installer/commands/doctor.ts
+++ b/src/installer/commands/doctor.ts
@@ -8,6 +8,7 @@ import { isDir, isFile, listDir, mkdirp } from '../util/fs.js'
 
 import { assertClaudeAuthenticated } from '../phases/provider-detect.js'
 import { derivedPaths, type Provider } from '../phases/provider-detect.js'
+import { resolveArtifacts } from '../util/registry.js'
 
 /**
  * `npx specrails-core doctor` — health check for a specrails install.
@@ -32,6 +33,15 @@ export async function runDoctor(flags: DoctorFlags = {}): Promise<DoctorResult> 
     typeof flags['root-dir'] === 'string' ? flags['root-dir'] : process.cwd(),
   )
 
+  // Relocate-always: Specrails artifacts (provider dir, agent files, instructions
+  // file) live under `artifactRoot`. Git stays in the repo (codeRoot). Readers
+  // pass allocate:false → falls back to the in-repo legacy layout when there is
+  // no registry entry (so a never-installed / legacy repo still reports cleanly).
+  const { artifactRoot, codeRoot } = resolveArtifacts(projectRoot, {
+    allocate: false,
+    home: process.env.SPECRAILS_REGISTRY_HOME,
+  })
+
   rawOut('\nspecrails doctor\n\n')
 
   const results: DoctorResult['results'] = []
@@ -41,7 +51,7 @@ export async function runDoctor(flags: DoctorFlags = {}): Promise<DoctorResult> 
   const addFail = (message: string, fix: string): void => {
     results.push({ kind: 'fail', message, fix })
   }
-  const provider = resolveInstalledProvider(projectRoot)
+  const provider = resolveInstalledProvider(artifactRoot)
   const { providerDir, instructionsFile } = derivedPaths(provider)
 
   // Check 1: Claude Code CLI
@@ -66,7 +76,7 @@ export async function runDoctor(flags: DoctorFlags = {}): Promise<DoctorResult> 
   }
 
   // Check 3: Agent files present in the active provider directory.
-  const agentsDir = path.join(projectRoot, providerDir, 'agents')
+  const agentsDir = path.join(artifactRoot, providerDir, 'agents')
   if (isDir(agentsDir)) {
     const agentFiles = findInstalledAgentFiles(agentsDir, provider)
     if (agentFiles.length >= 1) {
@@ -88,7 +98,7 @@ export async function runDoctor(flags: DoctorFlags = {}): Promise<DoctorResult> 
   }
 
   // Check 4: provider instructions file present
-  if (isFile(path.join(projectRoot, instructionsFile))) {
+  if (isFile(path.join(artifactRoot, instructionsFile))) {
     addPass(`${instructionsFile}: present`)
   } else {
     addFail(
@@ -99,8 +109,8 @@ export async function runDoctor(flags: DoctorFlags = {}): Promise<DoctorResult> 
     )
   }
 
-  // Check 5: Git initialized
-  if (isDir(path.join(projectRoot, '.git'))) {
+  // Check 5: Git initialized (in the repo — codeRoot, not the artifact root)
+  if (isDir(path.join(codeRoot, '.git'))) {
     addPass('Git: initialized')
   } else {
     addFail('Git: not a git repository', 'Initialize with: git init')

--- a/src/installer/commands/framework.test.ts
+++ b/src/installer/commands/framework.test.ts
@@ -1,0 +1,264 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { isDir, isSymlink, pathExists, readTextFile, realpathSafe, writeFileLf } from '../util/fs.js'
+import { main } from '../cli.js'
+import { runAssemble, runInstallFramework, runSwapCurrent, readPackageVersion } from './framework.js'
+
+/**
+ * Command-level tests for the offline framework subcommands
+ * (`install-framework` / `assemble`). They drive the same code path the desktop
+ * bundled-core shell-out uses (`node dist/installer/cli.js install-framework …`)
+ * and assert the framework is materialized + the workspace is SYMLINKED with NO
+ * network and NO openspec init.
+ *
+ * Platform-aware: on Windows a per-FILE agent link is a COPY (not a symlink) and
+ * a whole-DIR link is a junction (still reported as a symlink by lstat). So the
+ * agent-file check verifies placement + content; the dir-link check verifies it
+ * resolves into the framework. POSIX-only symlink assertions stay guarded.
+ */
+
+const IS_WIN = process.platform === 'win32'
+
+function setupFakeScriptDir(scriptDir: string): void {
+  writeFileLf(path.join(scriptDir, 'package.json'), `${JSON.stringify({ version: '5.0.0' })}\n`)
+  writeFileLf(path.join(scriptDir, 'templates', 'agents', 'sr-architect.md'), '# arch\n')
+  writeFileLf(path.join(scriptDir, 'templates', 'agents', 'sr-developer.md'), '# dev\n')
+  writeFileLf(path.join(scriptDir, 'templates', 'agents', 'sr-reviewer.md'), '# reviewer\n')
+  writeFileLf(path.join(scriptDir, 'templates', 'rules', 'general.md'), '# rules\n')
+  writeFileLf(
+    path.join(scriptDir, 'templates', 'commands', 'specrails', 'implement.md'),
+    '/specrails:implement\n',
+  )
+  writeFileLf(path.join(scriptDir, 'commands', 'enrich.md'), 'enrich')
+  writeFileLf(path.join(scriptDir, 'commands', 'doctor.md'), 'doctor')
+}
+
+describe('framework subcommands (install-framework / assemble)', () => {
+  let tmpDir: string
+  let scriptDir: string
+  let fwDir: string
+  let originalHome: string | undefined
+  let originalUserProfile: string | undefined
+  let originalScriptDirOverride: string | undefined
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'specrails-fw-cmd-test-'))
+    scriptDir = path.join(tmpDir, 'core')
+    fwDir = path.join(tmpDir, 'framework')
+    setupFakeScriptDir(scriptDir)
+    originalHome = process.env.HOME
+    originalUserProfile = process.env.USERPROFILE
+    originalScriptDirOverride = process.env.SPECRAILS_CORE_SCRIPT_DIR
+    const fakeHome = path.join(tmpDir, 'fake-home')
+    process.env.HOME = fakeHome
+    process.env.USERPROFILE = fakeHome
+    // Point the framework commands at the fake package dir.
+    process.env.SPECRAILS_CORE_SCRIPT_DIR = scriptDir
+  })
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME
+    else process.env.HOME = originalHome
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE
+    else process.env.USERPROFILE = originalUserProfile
+    if (originalScriptDirOverride === undefined) delete process.env.SPECRAILS_CORE_SCRIPT_DIR
+    else process.env.SPECRAILS_CORE_SCRIPT_DIR = originalScriptDirOverride
+    rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+  })
+
+  describe('runInstallFramework', () => {
+    it('materializes the framework and points current at the version', async () => {
+      const out = await runInstallFramework({
+        'framework-dir': fwDir,
+        provider: 'claude',
+        version: '5.0.0',
+      })
+      expect(out.providerDir).toBe('.claude')
+      const fwClaude = path.join(fwDir, '5.0.0', '.claude')
+      expect(isDir(path.join(fwClaude, 'agents'))).toBe(true)
+      expect(pathExists(path.join(fwClaude, 'agents', 'sr-architect.md'))).toBe(true)
+      // current → 5.0.0. `current` is a dir link (symlink on POSIX, junction on
+      // Windows); assert it RESOLVES to the version dir (holds for both kinds),
+      // keep the stronger symlink check POSIX-only.
+      expect(realpathSafe(path.join(fwDir, 'current'))).toBe(realpathSafe(path.join(fwDir, '5.0.0')))
+      if (!IS_WIN) expect(isSymlink(path.join(fwDir, 'current'))).toBe(true)
+      expect(isDir(path.join(fwDir, 'current', '.claude', 'agents'))).toBe(true)
+    })
+
+    it('is idempotent — a second call does not throw and keeps the framework', async () => {
+      await runInstallFramework({ 'framework-dir': fwDir, provider: 'claude', version: '5.0.0' })
+      await runInstallFramework({ 'framework-dir': fwDir, provider: 'claude', version: '5.0.0' })
+      expect(isDir(path.join(fwDir, '5.0.0', '.claude', 'agents'))).toBe(true)
+    })
+
+    it('rejects a missing --framework-dir', async () => {
+      await expect(
+        runInstallFramework({ provider: 'claude', version: '5.0.0' }),
+      ).rejects.toThrow(/framework-dir is required/)
+    })
+
+    it('rejects an invalid provider', async () => {
+      await expect(
+        runInstallFramework({ 'framework-dir': fwDir, provider: 'bogus', version: '5.0.0' }),
+      ).rejects.toThrow(/provider value must be/)
+    })
+  })
+
+  describe('runAssemble', () => {
+    it('symlinks the framework subtrees into the workspace and seeds the project layer', async () => {
+      await runInstallFramework({ 'framework-dir': fwDir, provider: 'claude', version: '5.0.0' })
+
+      const workspace = path.join(tmpDir, 'ws')
+      const codeRoot = path.join(tmpDir, 'repo')
+      writeFileLf(path.join(codeRoot, 'README.md'), '# repo')
+
+      const out = await runAssemble({
+        workspace,
+        'framework-dir': fwDir,
+        provider: 'claude',
+        version: '5.0.0',
+        'code-root': codeRoot,
+      })
+      expect(out.providerDir).toBe('.claude')
+
+      // agents/ is a real dir holding per-file links into the framework (symlink
+      // on POSIX, copy on Windows). Assert placement + content (holds for both);
+      // the stronger symlink check is POSIX-only.
+      const wsAgents = path.join(workspace, '.claude', 'agents')
+      expect(isDir(wsAgents)).toBe(true)
+      const wsArch = path.join(wsAgents, 'sr-architect.md')
+      const fwArch = path.join(fwDir, 'current', '.claude', 'agents', 'sr-architect.md')
+      expect(pathExists(wsArch)).toBe(true)
+      expect(readTextFile(wsArch)).toBe(readTextFile(fwArch))
+      if (!IS_WIN) expect(isSymlink(wsArch)).toBe(true)
+      // commands/ is a whole-dir link (symlink on POSIX, junction on Windows) →
+      // resolves into the framework on both.
+      expect(realpathSafe(path.join(workspace, '.claude', 'commands'))).toBe(
+        realpathSafe(path.join(fwDir, 'current', '.claude', 'commands')),
+      )
+      // agent-memory is a REAL writable dir, never linked.
+      const memDir = path.join(workspace, '.claude', 'agent-memory', 'sr-architect')
+      expect(isDir(memDir)).toBe(true)
+      expect(isSymlink(memDir)).toBe(false)
+      // The version marker the gate checks for is written.
+      expect(pathExists(path.join(workspace, '.specrails', 'specrails-version'))).toBe(true)
+    })
+
+    it('fails when the framework was not materialized first', async () => {
+      const workspace = path.join(tmpDir, 'ws')
+      const codeRoot = path.join(tmpDir, 'repo')
+      await expect(
+        runAssemble({
+          workspace,
+          'framework-dir': fwDir,
+          provider: 'claude',
+          version: '5.0.0',
+          'code-root': codeRoot,
+        }),
+      ).rejects.toThrow(/not materialized/)
+    })
+
+    it('rejects a missing --workspace', async () => {
+      await expect(
+        runAssemble({ 'framework-dir': fwDir, provider: 'claude', version: '5.0.0', 'code-root': tmpDir }),
+      ).rejects.toThrow(/workspace is required/)
+    })
+  })
+
+  describe('--no-swap + swap-current (multi-provider materialize-all-then-swap-once)', () => {
+    it('install-framework --no-swap materializes without swapping; swap-current finalises', async () => {
+      // Existing version + current pointed at it.
+      await runInstallFramework({ 'framework-dir': fwDir, provider: 'claude', version: '5.0.0' })
+      const before = realpathSafe(path.join(fwDir, 'current'))
+
+      // Materialize a new version with --no-swap → current stays put.
+      const out = await runInstallFramework({
+        'framework-dir': fwDir, provider: 'claude', version: '6.0.0', 'no-swap': true,
+      })
+      expect(out.swapped).toBe(false)
+      expect(realpathSafe(path.join(fwDir, 'current'))).toBe(before) // unchanged
+      expect(isDir(path.join(fwDir, '6.0.0', '.claude', 'agents'))).toBe(true)
+
+      // The single explicit swap makes 6.0.0 visible.
+      const swapOut = await runSwapCurrent({ 'framework-dir': fwDir, version: '6.0.0' })
+      expect(swapOut.version).toBe('6.0.0')
+      expect(realpathSafe(path.join(fwDir, 'current'))).toBe(realpathSafe(path.join(fwDir, '6.0.0')))
+    })
+
+    it('default install-framework still swaps current (single-provider init unchanged)', async () => {
+      const out = await runInstallFramework({ 'framework-dir': fwDir, provider: 'claude', version: '5.0.0' })
+      expect(out.swapped).toBe(true)
+      expect(realpathSafe(path.join(fwDir, 'current'))).toBe(realpathSafe(path.join(fwDir, '5.0.0')))
+    })
+
+    it('swap-current rejects a missing --framework-dir', async () => {
+      await expect(runSwapCurrent({ version: '5.0.0' })).rejects.toThrow(/framework-dir is required/)
+    })
+  })
+
+  describe('cli.main dispatch', () => {
+    it('routes install-framework + assemble through main() with exit 0', async () => {
+      const ifCode = await main([
+        'install-framework',
+        '--framework-dir',
+        fwDir,
+        '--provider',
+        'claude',
+        '--version',
+        '5.0.0',
+      ])
+      expect(ifCode).toBe(0)
+
+      const workspace = path.join(tmpDir, 'ws2')
+      const codeRoot = path.join(tmpDir, 'repo2')
+      writeFileLf(path.join(codeRoot, 'README.md'), '# repo')
+      const asmCode = await main([
+        'assemble',
+        '--workspace',
+        workspace,
+        '--framework-dir',
+        fwDir,
+        '--provider',
+        'claude',
+        '--version',
+        '5.0.0',
+        '--code-root',
+        codeRoot,
+      ])
+      expect(asmCode).toBe(0)
+      expect(isDir(path.join(workspace, '.claude', 'agents'))).toBe(true)
+    })
+
+    it('routes install-framework --no-swap then swap-current through main()', async () => {
+      const ifCode = await main([
+        'install-framework', '--framework-dir', fwDir, '--provider', 'claude', '--version', '5.0.0', '--no-swap',
+      ])
+      expect(ifCode).toBe(0)
+      // --no-swap means current was NOT created yet.
+      expect(pathExists(path.join(fwDir, 'current'))).toBe(false)
+
+      const swapCode = await main(['swap-current', '--framework-dir', fwDir, '--version', '5.0.0'])
+      expect(swapCode).toBe(0)
+      expect(realpathSafe(path.join(fwDir, 'current'))).toBe(realpathSafe(path.join(fwDir, '5.0.0')))
+    })
+
+    it('returns non-zero exit when a required flag is missing', async () => {
+      const code = await main(['install-framework', '--provider', 'claude', '--version', '5.0.0'])
+      expect(code).toBe(40)
+    })
+  })
+
+  describe('readPackageVersion', () => {
+    it('reads the package version from the script dir', () => {
+      expect(readPackageVersion(scriptDir)).toBe('5.0.0')
+    })
+
+    it('returns unknown for a dir without package.json', () => {
+      expect(readPackageVersion(path.join(tmpDir, 'nope'))).toBe('unknown')
+    })
+  })
+})

--- a/src/installer/commands/framework.ts
+++ b/src/installer/commands/framework.ts
@@ -1,0 +1,216 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { InstallerError } from '../util/errors.js'
+import { ok, step } from '../util/logger.js'
+import { pathExists, readTextFile } from '../util/fs.js'
+
+import { type Provider } from '../phases/provider-detect.js'
+import { derivedPaths } from '../phases/provider-detect.js'
+import { assembleProjectWorkspace, ensureCurrentSymlink } from '../phases/scaffold.js'
+import { ensureFramework } from './init.js'
+
+/**
+ * Offline framework subcommands consumed by specrails-desktop's bundled-core
+ * path. They expose the already-built `ensureFramework` (installFramework +
+ * ensureCurrentSymlink) and `assembleProjectWorkspace` as thin CLI handlers so
+ * the desktop app can materialize + assemble WITHOUT npx or any network.
+ *
+ *   specrails-core install-framework --framework-dir <dir> --provider <p> --version <v>
+ *   specrails-core assemble --workspace <ws> --framework-dir <dir> --provider <p> --version <v> --code-root <repo>
+ *
+ * Both are idempotent and perform NO network I/O and NO openspec init.
+ */
+
+export interface InstallFrameworkFlags {
+  'framework-dir'?: string | boolean
+  provider?: string | boolean
+  version?: string | boolean
+  'agent-teams'?: boolean
+  /**
+   * Materialize the provider subtree but do NOT swap `current`. The caller
+   * materializes EVERY provider first (each with `--no-swap`), then issues ONE
+   * `swap-current` so a later provider's failure never leaves `current` pointed
+   * at a version dir missing that provider.
+   */
+  'no-swap'?: boolean
+}
+
+export interface SwapCurrentFlags {
+  'framework-dir'?: string | boolean
+  version?: string | boolean
+}
+
+export interface AssembleFlags {
+  workspace?: string | boolean
+  'framework-dir'?: string | boolean
+  provider?: string | boolean
+  version?: string | boolean
+  'code-root'?: string | boolean
+  'agent-teams'?: boolean
+  /** Comma-separated per-project agent allow-list (links a subset of the superset). */
+  'selected-agents'?: string | boolean
+}
+
+export interface InstallFrameworkOutcome {
+  frameworkDir: string
+  provider: Provider
+  version: string
+  providerDir: string
+  /** True when `current` was swapped to `<version>` this call. */
+  swapped: boolean
+}
+
+export interface SwapCurrentOutcome {
+  frameworkDir: string
+  version: string
+}
+
+export interface AssembleOutcome {
+  workspace: string
+  frameworkDir: string
+  provider: Provider
+  version: string
+  codeRoot: string
+  providerDir: string
+}
+
+function requireString(value: string | boolean | undefined, flagName: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new InstallerError(`--${flagName} is required`, 40)
+  }
+  return value
+}
+
+function parseProvider(value: string | boolean | undefined): Provider {
+  const v = requireString(value, 'provider')
+  if (v !== 'claude' && v !== 'codex' && v !== 'gemini') {
+    throw new InstallerError(`--provider value must be 'claude', 'codex', or 'gemini', got: ${v}`, 40)
+  }
+  return v
+}
+
+/**
+ * Resolves the specrails-core package root (where templates/ + commands/ live).
+ *   - Published: `<pkg>/dist/installer/commands/framework.js`
+ *   - Source:   `<repo>/src/installer/commands/framework.ts`
+ * Both are three levels deep (commands → installer → src|dist → root). The
+ * SPECRAILS_CORE_SCRIPT_DIR env var overrides for tests / desktop bundling.
+ */
+function resolveScriptDir(): string {
+  const override = process.env.SPECRAILS_CORE_SCRIPT_DIR
+  if (override && override.length > 0) return path.resolve(override)
+  const here = path.dirname(fileURLToPath(import.meta.url))
+  return path.resolve(here, '..', '..', '..')
+}
+
+/**
+ * `specrails-core install-framework` — materialize the provider-invariant
+ * framework subtree ONCE under `<framework-dir>/<version>/<providerDir>/` and
+ * point `<framework-dir>/current` at it. Idempotent + offline.
+ */
+export async function runInstallFramework(
+  flags: InstallFrameworkFlags,
+): Promise<InstallFrameworkOutcome> {
+  const scriptDir = resolveScriptDir()
+  const frameworkDir = path.resolve(requireString(flags['framework-dir'], 'framework-dir'))
+  const provider = parseProvider(flags.provider)
+  const version = requireString(flags.version, 'version')
+  const { providerDir } = derivedPaths(provider)
+
+  const swapCurrent = flags['no-swap'] !== true
+  step(`Materializing framework ${version} (${provider}) → ${frameworkDir}`)
+  ensureFramework({
+    scriptDir,
+    frameworkDir,
+    provider,
+    providerDir,
+    version,
+    agentTeams: flags['agent-teams'] === true,
+    swapCurrent,
+  })
+  if (swapCurrent) {
+    ok(`Framework ${version} ready (${providerDir}) + current → ${version}`)
+  } else {
+    ok(`Framework ${version} ready (${providerDir}) — current NOT swapped (--no-swap)`)
+  }
+
+  return { frameworkDir, provider, version, providerDir, swapped: swapCurrent }
+}
+
+/**
+ * `specrails-core swap-current` — atomically point `<framework-dir>/current` at
+ * `<version>`. The multi-provider "materialize-all-then-swap-once" finaliser:
+ * after EVERY provider was materialized with `--no-swap`, this single call makes
+ * the version visible. Idempotent + offline.
+ */
+export async function runSwapCurrent(flags: SwapCurrentFlags): Promise<SwapCurrentOutcome> {
+  const frameworkDir = path.resolve(requireString(flags['framework-dir'], 'framework-dir'))
+  const version = requireString(flags.version, 'version')
+  step(`Swapping framework current → ${version} (${frameworkDir})`)
+  ensureCurrentSymlink(frameworkDir, version)
+  ok(`current → ${version}`)
+  return { frameworkDir, version }
+}
+
+/**
+ * `specrails-core assemble` — SYMLINK the materialized framework subtrees into a
+ * project workspace and seed the per-project layer (agent-memory, manifest,
+ * instruction/settings files, gemini acks). NO network, NO openspec init.
+ */
+export async function runAssemble(flags: AssembleFlags): Promise<AssembleOutcome> {
+  const scriptDir = resolveScriptDir()
+  const workspace = path.resolve(requireString(flags.workspace, 'workspace'))
+  const frameworkDir = path.resolve(requireString(flags['framework-dir'], 'framework-dir'))
+  const provider = parseProvider(flags.provider)
+  const version = requireString(flags.version, 'version')
+  const codeRoot = path.resolve(requireString(flags['code-root'], 'code-root'))
+  const { providerDir } = derivedPaths(provider)
+
+  // Defence-in-depth: the framework must be materialized + `current` pointed at
+  // `<version>` BEFORE assemble can link from it. The desktop FrameworkManager
+  // always calls install-framework first; this guard surfaces a clear error if
+  // a caller skips it.
+  const currentProviderDir = path.join(frameworkDir, 'current', providerDir)
+  if (!pathExists(currentProviderDir)) {
+    throw new InstallerError(
+      `framework not materialized: ${currentProviderDir} is missing — run install-framework first`,
+      41,
+    )
+  }
+
+  const selectedAgentsFlag = flags['selected-agents']
+  const selectedAgents =
+    typeof selectedAgentsFlag === 'string' && selectedAgentsFlag.length > 0
+      ? selectedAgentsFlag.split(',').map((s) => s.trim()).filter((s) => s.length > 0)
+      : undefined
+
+  step(`Assembling workspace ${workspace} ← framework ${version} (${provider})`)
+  assembleProjectWorkspace({
+    workspace,
+    frameworkDir,
+    provider,
+    providerDir,
+    version,
+    codeRoot,
+    scriptDir,
+    selectedAgents,
+    agentTeams: flags['agent-teams'] === true,
+  })
+  ok(`Linked ${providerDir}/ from framework ${version} + seeded project layer`)
+
+  return { workspace, frameworkDir, provider, version, codeRoot, providerDir }
+}
+
+/** Read the package version (the version the desktop should materialize). */
+export function readPackageVersion(scriptDir?: string): string {
+  const dir = scriptDir ?? resolveScriptDir()
+  const p = path.join(dir, 'package.json')
+  if (!pathExists(p)) return 'unknown'
+  try {
+    const pkg = JSON.parse(readTextFile(p)) as { version?: string }
+    return pkg.version?.trim() || 'unknown'
+  } catch {
+    return 'unknown'
+  }
+}

--- a/src/installer/commands/init.test.ts
+++ b/src/installer/commands/init.test.ts
@@ -1,11 +1,12 @@
-import { chmodSync, mkdtempSync, rmSync } from 'node:fs'
+import { chmodSync, lstatSync, mkdtempSync, readFileSync, realpathSync, rmSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { mkdirp, pathExists, writeFileLf } from '../util/fs.js'
+import { isDir, isSymlink, mkdirp, pathExists, readTextFile, writeFileLf } from '../util/fs.js'
 import { initRepo } from '../util/git.js'
+import { frameworkRoot, resolveArtifacts } from '../util/registry.js'
 import { runInit } from './init.js'
 
 /**
@@ -14,7 +15,14 @@ import { runInit } from './init.js'
  * SPECRAILS_SKIP_PREREQS escape hatch lets us skip the
  * claude-auth / npm checks which would otherwise require an
  * installed Claude CLI in the test environment.
+ *
+ * Platform-aware: per-FILE agent links are symlinks on POSIX but COPIES on
+ * Windows (Windows file-symlinks need admin/Dev-Mode). So the framework agent
+ * assertion checks placement + content (holds for symlink OR copy); the stronger
+ * `isSymbolicLink()` check is guarded POSIX-only so coverage isn't weakened.
  */
+
+const IS_WIN = process.platform === 'win32'
 
 async function setupFakeScriptDir(scriptDir: string): Promise<void> {
   writeFileLf(path.join(scriptDir, 'package.json'), `${JSON.stringify({ version: '4.2.0' })}\n`)
@@ -29,6 +37,7 @@ async function setupFakeScriptDir(scriptDir: string): Promise<void> {
 
 describe('runInit', () => {
   let tmpDir: string
+  let registryHome: string
   let prevSkipPrereqs: string | undefined
   let prevSkipOpenSpecInit: string | undefined
   let prevCwd: string
@@ -36,16 +45,22 @@ describe('runInit', () => {
   let prevScriptDirOverride: string | undefined
   let prevPath: string | undefined
   let prevOpenSpecBin: string | undefined
+  let prevRegistryHome: string | undefined
 
   beforeEach(() => {
     tmpDir = mkdtempSync(path.join(os.tmpdir(), 'specrails-init-test-'))
+    // Relocate-always: point the registry/workspace $HOME at a fresh tmp so
+    // artifacts land there, NOT in the real ~/.specrails.
+    registryHome = mkdtempSync(path.join(os.tmpdir(), 'specrails-init-home-'))
     prevSkipPrereqs = process.env.SPECRAILS_SKIP_PREREQS
     prevSkipOpenSpecInit = process.env.SPECRAILS_SKIP_OPENSPEC_INIT
     prevScriptDirOverride = process.env.SPECRAILS_CORE_SCRIPT_DIR
     prevPath = process.env.PATH
     prevOpenSpecBin = process.env.SPECRAILS_OPENSPEC_BIN
+    prevRegistryHome = process.env.SPECRAILS_REGISTRY_HOME
     process.env.SPECRAILS_SKIP_PREREQS = '1'
     process.env.SPECRAILS_SKIP_OPENSPEC_INIT = '1'
+    process.env.SPECRAILS_REGISTRY_HOME = registryHome
     prevCwd = process.cwd()
   })
 
@@ -61,8 +76,40 @@ describe('runInit', () => {
     else process.env.PATH = prevPath
     if (prevOpenSpecBin === undefined) delete process.env.SPECRAILS_OPENSPEC_BIN
     else process.env.SPECRAILS_OPENSPEC_BIN = prevOpenSpecBin
+    if (prevRegistryHome === undefined) delete process.env.SPECRAILS_REGISTRY_HOME
+    else process.env.SPECRAILS_REGISTRY_HOME = prevRegistryHome
     rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+    rmSync(registryHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
   })
+
+  /** Resolve the relocated artifact workspace for a repo (readers pass allocate:false). */
+  function workspaceFor(repoRoot: string): string {
+    return resolveArtifacts(repoRoot, { allocate: false, home: registryHome }).artifactRoot
+  }
+
+  /** The versioned framework store (`<home>/.specrails/framework`). */
+  function frameworkFor(): string {
+    return frameworkRoot(registryHome)
+  }
+
+  /**
+   * Assert the repo-immutability invariant: after a relocate-always install the
+   * repo contains NO Specrails-owned artifact (only openspec/** if it ran).
+   */
+  function assertRepoHasNoSpecrailsArtifacts(repoRoot: string): void {
+    for (const name of [
+      '.specrails',
+      '.claude',
+      '.codex',
+      '.gemini',
+      'CLAUDE.md',
+      'AGENTS.md',
+      'GEMINI.md',
+      '.mcp.json',
+    ]) {
+      expect(pathExists(path.join(repoRoot, name)), `repo must not contain ${name}`).toBe(false)
+    }
+  }
 
   it('installs into a fresh git repo on the quick tier', async () => {
     const scriptDir = path.join(tmpDir, 'core')
@@ -83,11 +130,44 @@ describe('runInit', () => {
     expect(result.tier).toBe('quick')
     expect(result.repoRoot).toBe(repoRoot)
 
-    // .specrails/specrails-version file is written from runInit's
-    // script-dir lookup (the in-repo specrails-core — not the fake one).
-    // We only assert that the per-repo skeleton was created.
-    expect(pathExists(path.join(repoRoot, '.claude', 'commands', 'specrails'))).toBe(true)
-    expect(pathExists(path.join(repoRoot, '.specrails', 'setup-templates', 'agents'))).toBe(true)
+    // Bundled-framework: the static framework is materialized ONCE under
+    // `<home>/.specrails/framework/<version>/<providerDir>/`; the workspace
+    // providerDir subtrees are SYMLINKS to `framework/current/...`.
+    const fw = frameworkFor()
+    const fwClaude = path.join(fw, '4.2.0', '.claude')
+    expect(isDir(path.join(fwClaude, 'commands', 'specrails')), 'framework commands materialized').toBe(true)
+    expect(pathExists(path.join(fw, '4.2.0', '.specrails', 'setup-templates', 'agents')), 'setup-templates in framework').toBe(true)
+    // `current` points at the version dir.
+    expect(realpathSync(path.join(fw, 'current'))).toBe(realpathSync(path.join(fw, '4.2.0')))
+
+    // The workspace providerDir subtrees resolve THROUGH the framework copy.
+    const ws = workspaceFor(repoRoot)
+    expect(pathExists(path.join(ws, '.claude', 'commands', 'specrails'))).toBe(true)
+    // `commands/` is a whole-dir link (symlink on POSIX, junction on Windows) →
+    // resolves into the framework on both. The realpath check holds for both link
+    // kinds; the stronger symlink assertion is POSIX-only.
+    if (!IS_WIN) expect(isSymlink(path.join(ws, '.claude', 'commands'))).toBe(true)
+    expect(realpathSync(path.join(ws, '.claude', 'commands'))).toBe(
+      realpathSync(path.join(fwClaude, 'commands')),
+    )
+    // `agents/` is a REAL dir of per-file links (so custom-*.md can coexist);
+    // each framework agent is PLACED with matching content (symlink on POSIX,
+    // copy on Windows). The stronger symlink check is POSIX-only.
+    expect(isDir(path.join(ws, '.claude', 'agents'))).toBe(true)
+    expect(isSymlink(path.join(ws, '.claude', 'agents'))).toBe(false)
+    const wsArch = path.join(ws, '.claude', 'agents', 'sr-architect.md')
+    expect(pathExists(wsArch)).toBe(true)
+    expect(readTextFile(wsArch)).toBe(readTextFile(path.join(fwClaude, 'agents', 'sr-architect.md')))
+    if (!IS_WIN) expect(lstatSync(wsArch).isSymbolicLink()).toBe(true)
+    // `agent-memory/` is a REAL writable dir — NEVER a link into the framework.
+    expect(isDir(path.join(ws, '.claude', 'agent-memory', 'sr-architect'))).toBe(true)
+    expect(isSymlink(path.join(ws, '.claude', 'agent-memory'))).toBe(false)
+    // The workspace records the framework version it consumes.
+    expect(readFileSync(path.join(ws, '.specrails', 'specrails-version'), 'utf8').trim()).toBe('4.2.0')
+    // setup-templates is NOT copied per-workspace anymore (it lives in framework).
+    expect(pathExists(path.join(ws, '.specrails', 'setup-templates'))).toBe(false)
+    // Repo-immutability invariant.
+    assertRepoHasNoSpecrailsArtifacts(repoRoot)
   })
 
   it('reads provider + tier from install-config.yaml when --from-config is passed', async () => {
@@ -119,11 +199,17 @@ describe('runInit', () => {
 
     expect(result.tier).toBe('quick')
     expect(result.agentTeams).toBe(true)
-    expect(pathExists(path.join(repoRoot, '.claude', 'agents', 'sr-architect.md'))).toBe(true)
-    expect(pathExists(path.join(repoRoot, '.claude', 'agents', 'sr-developer.md'))).toBe(true)
-    expect(pathExists(path.join(repoRoot, '.claude', 'agents', 'sr-reviewer.md'))).toBe(true)
+    const ws = workspaceFor(repoRoot)
+    expect(pathExists(path.join(ws, '.claude', 'agents', 'sr-architect.md'))).toBe(true)
+    expect(pathExists(path.join(ws, '.claude', 'agents', 'sr-developer.md'))).toBe(true)
+    expect(pathExists(path.join(ws, '.claude', 'agents', 'sr-reviewer.md'))).toBe(true)
     // sr-merge-resolver is optional — not placed unless it appears in agents.selected
-    expect(pathExists(path.join(repoRoot, '.claude', 'agents', 'sr-merge-resolver.md'))).toBe(false)
+    expect(pathExists(path.join(ws, '.claude', 'agents', 'sr-merge-resolver.md'))).toBe(false)
+    // NOTE: this test pre-creates repo/.specrails/install-config.yaml (a USER
+    // file), so the repo-immutability invariant is asserted in the other tests.
+    // Here we only assert the installer wrote NO provider artifacts into the repo.
+    expect(pathExists(path.join(repoRoot, '.claude'))).toBe(false)
+    expect(pathExists(path.join(repoRoot, '.specrails', 'setup-templates'))).toBe(false)
   })
 
   it('accepts --provider codex and produces a codex install (.codex/ + AGENTS.md)', async () => {
@@ -132,15 +218,18 @@ describe('runInit', () => {
     await initRepo(repoRoot)
     const result = await runInit({ 'root-dir': repoRoot, yes: true, provider: 'codex', quick: true })
     expect(result.provider).toBe('codex')
-    // Provider-derived layout: .codex/ + AGENTS.md
-    expect(pathExists(path.join(repoRoot, '.codex'))).toBe(true)
-    expect(pathExists(path.join(repoRoot, 'AGENTS.md'))).toBe(true)
+    const ws = workspaceFor(repoRoot)
+    // Provider-derived layout: .codex/ + AGENTS.md — under the workspace.
+    expect(pathExists(path.join(ws, '.codex'))).toBe(true)
+    expect(pathExists(path.join(ws, 'AGENTS.md'))).toBe(true)
     // codex-config.toml written by applyCodexSettings (no rules.star —
     // codex 0.128.0+ keeps sandbox policy inside config.toml itself).
-    expect(pathExists(path.join(repoRoot, '.codex', 'config.toml'))).toBe(true)
-    expect(pathExists(path.join(repoRoot, '.codex', 'rules.star'))).toBe(false)
+    expect(pathExists(path.join(ws, '.codex', 'config.toml'))).toBe(true)
+    expect(pathExists(path.join(ws, '.codex', 'rules.star'))).toBe(false)
     // .claude/ is NOT created on codex projects
-    expect(pathExists(path.join(repoRoot, '.claude'))).toBe(false)
+    expect(pathExists(path.join(ws, '.claude'))).toBe(false)
+    // Repo-immutability: nothing Specrails-owned in the repo.
+    assertRepoHasNoSpecrailsArtifacts(repoRoot)
   })
 
   it('rejects --provider with an unknown value', async () => {

--- a/src/installer/commands/init.ts
+++ b/src/installer/commands/init.ts
@@ -12,10 +12,14 @@ import {
   loadInstallConfig,
   resolveConfigPath,
 } from '../phases/install-config.js'
-import { buildManifest, writeManifestFiles } from '../phases/manifest.js'
 import { checkPrerequisites } from '../phases/prereqs.js'
 import { derivedPaths } from '../phases/provider-detect.js'
-import { scaffoldInstallation } from '../phases/scaffold.js'
+import {
+  assembleProjectWorkspace,
+  ensureCurrentSymlink,
+  installFramework,
+} from '../phases/scaffold.js'
+import { frameworkRoot, resolveArtifacts } from '../util/registry.js'
 
 /**
  * `npx specrails-core init` entry point.
@@ -105,27 +109,53 @@ export async function runInit(flags: InitFlags): Promise<InitResult> {
     skipPrereqs,
   })
 
+  // ─── Relocate-always: resolve where artifacts live ───────────────────
+  // EVERY Specrails artifact lands under `artifactRoot` (the $HOME workspace),
+  // never in the repo. The ONLY in-repo writes are `openspec/**` (below) and
+  // git/worktree ops. `codeRoot` is always the repo.
+  const { artifactRoot, codeRoot } = resolveArtifacts(repoRoot, {
+    allocate: true,
+    allocator: 'core-standalone',
+    home: process.env.SPECRAILS_REGISTRY_HOME,
+    providers: [prereqs.provider],
+    coreVersion: version,
+  })
+
   // ─── Phase 2 + 3 ──────────────────────────────────────────────────────
+  // Bundled-framework flow: materialize the provider-INVARIANT framework ONCE
+  // under `<home>/.specrails/framework/<version>/<providerDir>/`, point `current`
+  // at it, then SYMLINK that copy into the workspace and seed the project layer
+  // (agent-memory, manifest, instruction files, gemini acks). The framework
+  // source for standalone npx is the package's templates/+commands/ (scriptDir).
   step('Phase 2 & 3: Installing specrails artifacts')
   const { providerDir } = derivedPaths(prereqs.provider)
-  scaffoldInstallation({
+  const fwDir = frameworkRoot(process.env.SPECRAILS_REGISTRY_HOME)
+
+  ensureFramework({
     scriptDir,
-    repoRoot,
+    frameworkDir: fwDir,
     provider: prereqs.provider,
     providerDir,
+    version,
     agentTeams: agentTeamsHint,
-    tier: tierHint ?? 'full',
     selectedAgents: selectedAgentsHint,
   })
 
-  // ─── Phase 3b — manifest ──────────────────────────────────────────────
-  step('Phase 3b: Writing manifest')
-  const manifest = buildManifest({ scriptDir, repoRoot, version })
-  const { manifestPath, versionPath } = writeManifestFiles(repoRoot, manifest)
-  ok(`Wrote ${path.relative(repoRoot, manifestPath)}`)
-  ok(`Wrote ${path.relative(repoRoot, versionPath)}`)
+  assembleProjectWorkspace({
+    workspace: artifactRoot,
+    frameworkDir: fwDir,
+    provider: prereqs.provider,
+    providerDir,
+    version,
+    codeRoot,
+    scriptDir,
+    selectedAgents: selectedAgentsHint,
+    agentTeams: agentTeamsHint,
+  })
+  ok(`Linked ${providerDir}/ from framework ${version} + seeded project layer`)
 
-  await installOpenSpecProject(repoRoot, prereqs.provider)
+  // openspec STAYS in the repo (codeRoot) — unchanged behaviour.
+  await installOpenSpecProject(codeRoot, prereqs.provider)
 
   const tier: Tier = tierHint ?? 'full'
   if (tier === 'full') {
@@ -146,6 +176,53 @@ export async function runInit(flags: InitFlags): Promise<InitResult> {
     provider: prereqs.provider,
     tier,
     agentTeams: agentTeamsHint,
+  }
+}
+
+export interface EnsureFrameworkInput {
+  scriptDir: string
+  frameworkDir: string
+  provider: Provider
+  providerDir: string
+  version: string
+  agentTeams?: boolean
+  selectedAgents?: string[]
+  /**
+   * When false, MATERIALIZE the provider subtree but do NOT swap
+   * `<frameworkDir>/current` to point at `<version>`. The caller is responsible
+   * for the single `ensureCurrentSymlink(frameworkDir, version)` swap AFTER all
+   * providers have been materialized. This prevents a multi-provider install
+   * from leaving `current` pointed at a version dir that is missing a provider
+   * whose materialization later failed. Defaults to true (swap — the standalone
+   * single-provider `init` path is byte-identical to before).
+   */
+  swapCurrent?: boolean
+}
+
+/**
+ * Materialize the framework for `(version, provider)` if absent and (by default)
+ * point `<frameworkDir>/current` at that version. Idempotent — `installFramework`
+ * skips re-materialization when the providerDir already exists with a matching
+ * stamp, so a second project (or a repeat init) reuses the SAME framework copy.
+ * Shared by `runInit` and `runUpdate`.
+ *
+ * Pass `swapCurrent: false` to materialize WITHOUT swapping `current` — the
+ * multi-provider "materialize-all-then-swap-once" pattern desktop consumes:
+ *   for (const p of providers) ensureFramework({ ..., provider: p, swapCurrent: false })
+ *   ensureCurrentSymlink(frameworkDir, version) // single atomic swap at the end
+ */
+export function ensureFramework(input: EnsureFrameworkInput): void {
+  installFramework({
+    scriptDir: input.scriptDir,
+    frameworkDir: input.frameworkDir,
+    provider: input.provider,
+    providerDir: input.providerDir,
+    version: input.version,
+    agentTeams: input.agentTeams,
+    selectedAgents: input.selectedAgents,
+  })
+  if (input.swapCurrent !== false) {
+    ensureCurrentSymlink(input.frameworkDir, input.version)
   }
 }
 
@@ -190,32 +267,64 @@ function readPinnedVersion(scriptDir: string, key: string, fallback: string): st
   }
 }
 
+/**
+ * Resolve the `{bin, args}` to invoke `openspec init` for a project, honouring
+ * two optional env overrides (both default unset → `npx @fission-ai/openspec`):
+ *
+ *  - `SPECRAILS_OPENSPEC_BIN`  — path to the openspec CLI entry (a `.js` node
+ *    script when bundled by the desktop app, OR a real executable in tests).
+ *  - `SPECRAILS_OPENSPEC_NODE` — path to a node executable. Set ONLY by the
+ *    desktop bundled-offline path: Tauri strips exec bits from bundled
+ *    resources and the bundled openspec is a node CLI (not a runnable binary),
+ *    so it must be invoked as `node <cli> init …` rather than executed directly.
+ *
+ * Three invocation forms:
+ *  1. NODE + BIN set → `runCommand(node, [cli, 'init', '--tools', provider, repoRoot])`
+ *     (bundled offline — Tauri-stripped node CLI).
+ *  2. BIN set only   → `runCommand(cli, ['init', '--tools', provider, repoRoot])`
+ *     (a real executable: legacy override / test fake binary on PATH).
+ *  3. neither set    → `runCommand('npx', ['--yes', '-p', '@fission-ai/openspec@<pinned>', '--', 'openspec', 'init', …])`
+ *     (default online path — users never need a global install).
+ */
+export function buildOpenSpecInvocation(
+  repoRoot: string,
+  provider: Provider,
+  env: NodeJS.ProcessEnv = process.env,
+  pinnedVersion: string = readPinnedVersion(resolveScriptDir(), 'openspec', '1.4.1'),
+): { bin: string; args: string[] } {
+  const bin = env.SPECRAILS_OPENSPEC_BIN
+  const node = env.SPECRAILS_OPENSPEC_NODE
+  const initArgs = ['init', '--tools', provider, repoRoot]
+
+  if (bin && node) {
+    // Form 1: bundled offline — run the node CLI through the given node exe.
+    return { bin: node, args: [bin, ...initArgs] }
+  }
+  if (bin) {
+    // Form 2: a real executable (legacy override / test fixture).
+    return { bin, args: initArgs }
+  }
+  // Form 3: default — npx so users never need a global install.
+  return {
+    bin: 'npx',
+    args: [
+      '--yes',
+      '-p',
+      `@fission-ai/openspec@${pinnedVersion}`,
+      '--',
+      'openspec',
+      ...initArgs,
+    ],
+  }
+}
+
 async function installOpenSpecProject(repoRoot: string, provider: Provider): Promise<void> {
   if (process.env.SPECRAILS_SKIP_OPENSPEC_INIT === '1') {
     info('Skipping OpenSpec project init (SPECRAILS_SKIP_OPENSPEC_INIT=1)')
     return
   }
 
-  // Tests can point this at a fake binary on PATH to avoid hitting npm.
-  // Default: invoke through npx so users never need a global install.
-  const override = process.env.SPECRAILS_OPENSPEC_BIN
-  const pinnedVersion = readPinnedVersion(resolveScriptDir(), 'openspec', '1.3.1')
-  const { bin, args } = override
-    ? { bin: override, args: ['init', '--tools', provider, repoRoot] }
-    : {
-        bin: 'npx',
-        args: [
-          '--yes',
-          '-p',
-          `@fission-ai/openspec@${pinnedVersion}`,
-          '--',
-          'openspec',
-          'init',
-          '--tools',
-          provider,
-          repoRoot,
-        ],
-      }
+  const { bin, args } = buildOpenSpecInvocation(repoRoot, provider)
 
   step('Phase 3c: Installing OpenSpec')
   try {

--- a/src/installer/commands/openspec-invocation.test.ts
+++ b/src/installer/commands/openspec-invocation.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildOpenSpecInvocation } from './init.js'
+
+/**
+ * Unit tests for the three openspec invocation forms (PHASE 8 — bundled
+ * openspec offline). `buildOpenSpecInvocation` is pure given an env object +
+ * pinned version, so no spawning / npm access is required.
+ */
+describe('buildOpenSpecInvocation', () => {
+  const repoRoot = '/tmp/repo'
+  const pinned = '1.4.1'
+
+  it('form 1 (node-script): BIN + NODE set → runs `node <cli> init …`', () => {
+    const env: NodeJS.ProcessEnv = {
+      SPECRAILS_OPENSPEC_BIN: '/bundle/openspec/dist/cli.js',
+      SPECRAILS_OPENSPEC_NODE: '/bundle/node/bin/node',
+    }
+    const { bin, args } = buildOpenSpecInvocation(repoRoot, 'claude', env, pinned)
+    expect(bin).toBe('/bundle/node/bin/node')
+    expect(args).toEqual([
+      '/bundle/openspec/dist/cli.js',
+      'init',
+      '--tools',
+      'claude',
+      repoRoot,
+    ])
+  })
+
+  it('form 2 (direct-bin): only BIN set → runs the CLI directly', () => {
+    const env: NodeJS.ProcessEnv = {
+      SPECRAILS_OPENSPEC_BIN: '/usr/local/bin/openspec',
+    }
+    const { bin, args } = buildOpenSpecInvocation(repoRoot, 'codex', env, pinned)
+    expect(bin).toBe('/usr/local/bin/openspec')
+    expect(args).toEqual(['init', '--tools', 'codex', repoRoot])
+  })
+
+  it('form 3 (npx): neither set → falls back to pinned npx spec', () => {
+    const env: NodeJS.ProcessEnv = {}
+    const { bin, args } = buildOpenSpecInvocation(repoRoot, 'gemini', env, pinned)
+    expect(bin).toBe('npx')
+    expect(args).toEqual([
+      '--yes',
+      '-p',
+      `@fission-ai/openspec@${pinned}`,
+      '--',
+      'openspec',
+      'init',
+      '--tools',
+      'gemini',
+      repoRoot,
+    ])
+  })
+
+  it('NODE set WITHOUT BIN is ignored → falls back to npx (node alone is meaningless)', () => {
+    const env: NodeJS.ProcessEnv = {
+      SPECRAILS_OPENSPEC_NODE: '/bundle/node/bin/node',
+    }
+    const { bin, args } = buildOpenSpecInvocation(repoRoot, 'claude', env, pinned)
+    expect(bin).toBe('npx')
+    expect(args).toContain(`@fission-ai/openspec@${pinned}`)
+  })
+})

--- a/src/installer/commands/update.test.ts
+++ b/src/installer/commands/update.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { PrerequisiteError } from '../util/errors.js'
 import { mkdirp, pathExists, readTextFile, writeFileLf } from '../util/fs.js'
 import { initRepo } from '../util/git.js'
+import { resolveArtifacts } from '../util/registry.js'
 import { runUpdate } from './update.js'
 
 async function setupFakeScriptDir(scriptDir: string, version: string): Promise<void> {
@@ -17,33 +18,55 @@ async function setupFakeScriptDir(scriptDir: string, version: string): Promise<v
   writeFileLf(path.join(scriptDir, 'commands', 'doctor.md'), 'doctor')
 }
 
-async function simulateExistingInstall(repoRoot: string, version: string): Promise<void> {
-  mkdirp(repoRoot)
-  await initRepo(repoRoot)
-  writeFileLf(path.join(repoRoot, '.specrails', 'specrails-version'), `${version}\n`)
-  writeFileLf(
-    path.join(repoRoot, '.specrails', 'specrails-manifest.json'),
-    JSON.stringify({ version, installed_at: '2026-01-01T00:00:00Z', artifacts: {} }, null, 2),
-  )
-  mkdirp(path.join(repoRoot, '.claude', 'commands', 'specrails'))
-}
-
 describe('runUpdate', () => {
   let tmpDir: string
+  let registryHome: string
   let prevCwd: string
   let prevScriptDirOverride: string | undefined
+  let prevRegistryHome: string | undefined
+
+  /** Resolve the relocated artifact workspace for a repo (allocate so update finds it). */
+  function workspaceFor(repoRoot: string): string {
+    return resolveArtifacts(repoRoot, {
+      allocate: true,
+      home: registryHome,
+      providers: ['claude'],
+    }).artifactRoot
+  }
+
+  /**
+   * Simulate a prior relocate-always install: allocate the registry entry and
+   * write the marker + manifest into the resolved WORKSPACE (not the repo).
+   */
+  async function simulateExistingInstall(repoRoot: string, version: string): Promise<void> {
+    mkdirp(repoRoot)
+    await initRepo(repoRoot)
+    const ws = workspaceFor(repoRoot)
+    writeFileLf(path.join(ws, '.specrails', 'specrails-version'), `${version}\n`)
+    writeFileLf(
+      path.join(ws, '.specrails', 'specrails-manifest.json'),
+      JSON.stringify({ version, installed_at: '2026-01-01T00:00:00Z', artifacts: {} }, null, 2),
+    )
+    mkdirp(path.join(ws, '.claude', 'commands', 'specrails'))
+  }
 
   beforeEach(() => {
     tmpDir = mkdtempSync(path.join(os.tmpdir(), 'specrails-update-test-'))
+    registryHome = mkdtempSync(path.join(os.tmpdir(), 'specrails-update-home-'))
     prevCwd = process.cwd()
     prevScriptDirOverride = process.env.SPECRAILS_CORE_SCRIPT_DIR
+    prevRegistryHome = process.env.SPECRAILS_REGISTRY_HOME
+    process.env.SPECRAILS_REGISTRY_HOME = registryHome
   })
 
   afterEach(() => {
     process.chdir(prevCwd)
     if (prevScriptDirOverride === undefined) delete process.env.SPECRAILS_CORE_SCRIPT_DIR
     else process.env.SPECRAILS_CORE_SCRIPT_DIR = prevScriptDirOverride
+    if (prevRegistryHome === undefined) delete process.env.SPECRAILS_REGISTRY_HOME
+    else process.env.SPECRAILS_REGISTRY_HOME = prevRegistryHome
     rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+    rmSync(registryHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
   })
 
   it('refuses to run when no prior install is present', async () => {
@@ -66,8 +89,9 @@ describe('runUpdate', () => {
     expect(result.currentVersion).toBe('5.0.0')
     expect(result.provider).toBe('claude')
 
-    // specrails-version file was rewritten to the new version.
-    const newVersion = readTextFile(path.join(repoRoot, '.specrails', 'specrails-version')).trim()
+    // specrails-version file was rewritten to the new version (in the workspace).
+    const ws = workspaceFor(repoRoot)
+    const newVersion = readTextFile(path.join(ws, '.specrails', 'specrails-version')).trim()
     expect(newVersion).toBe('5.0.0')
   })
 
@@ -81,8 +105,9 @@ describe('runUpdate', () => {
     const result = await runUpdate({ 'root-dir': repoRoot, 'dry-run': true })
     expect(result.dryRun).toBe(true)
 
-    // specrails-version file is unchanged.
-    const stillOld = readTextFile(path.join(repoRoot, '.specrails', 'specrails-version')).trim()
+    // specrails-version file is unchanged (in the workspace).
+    const ws = workspaceFor(repoRoot)
+    const stillOld = readTextFile(path.join(ws, '.specrails', 'specrails-version')).trim()
     expect(stillOld).toBe('4.2.0')
   })
 
@@ -93,12 +118,14 @@ describe('runUpdate', () => {
     await simulateExistingInstall(repoRoot, '4.2.0')
     process.env.SPECRAILS_CORE_SCRIPT_DIR = scriptDir
 
+    // Reserved regions live under the relocated workspace now.
+    const ws = workspaceFor(repoRoot)
     writeFileLf(
-      path.join(repoRoot, '.specrails', 'profiles', 'team.json'),
+      path.join(ws, '.specrails', 'profiles', 'team.json'),
       '{"name":"team-profile"}',
     )
     writeFileLf(
-      path.join(repoRoot, '.claude', 'agents', 'custom-reviewer.md'),
+      path.join(ws, '.claude', 'agents', 'custom-reviewer.md'),
       'custom reviewer content',
     )
 
@@ -106,10 +133,10 @@ describe('runUpdate', () => {
 
     // Reserved files remain byte-identical.
     expect(
-      readTextFile(path.join(repoRoot, '.specrails', 'profiles', 'team.json')),
+      readTextFile(path.join(ws, '.specrails', 'profiles', 'team.json')),
     ).toBe('{"name":"team-profile"}')
     expect(
-      readTextFile(path.join(repoRoot, '.claude', 'agents', 'custom-reviewer.md')),
+      readTextFile(path.join(ws, '.claude', 'agents', 'custom-reviewer.md')),
     ).toBe('custom reviewer content')
   })
 
@@ -134,9 +161,10 @@ describe('runUpdate', () => {
 
       const result = await runUpdate({ 'root-dir': repoRoot })
       expect(result.tier).toBe('quick')
-      // Quick-tier placement happened: bundled agents are in .claude/agents/
+      // Quick-tier placement happened: bundled agents are in <ws>/.claude/agents/
       // (not just under setup-templates/).
-      expect(pathExists(path.join(repoRoot, '.claude', 'agents', 'sr-architect.md'))).toBe(true)
+      const ws = workspaceFor(repoRoot)
+      expect(pathExists(path.join(ws, '.claude', 'agents', 'sr-architect.md'))).toBe(true)
     })
 
     it('reads agent_teams=true from install-config.yaml and keeps team-* commands', async () => {
@@ -162,7 +190,7 @@ describe('runUpdate', () => {
 
       const result = await runUpdate({ 'root-dir': repoRoot })
       expect(result.agentTeams).toBe(true)
-      const cmdsDir = path.join(repoRoot, '.claude', 'commands', 'specrails')
+      const cmdsDir = path.join(workspaceFor(repoRoot), '.claude', 'commands', 'specrails')
       expect(pathExists(path.join(cmdsDir, 'team-debug.md'))).toBe(true)
       expect(pathExists(path.join(cmdsDir, 'team-review.md'))).toBe(true)
     })
@@ -224,11 +252,12 @@ describe('runUpdate', () => {
 
       const result = await runUpdate({ 'root-dir': repoRoot, only: 'rules' })
       expect(result.scope).toBe('rules')
-      // Rules staging is populated.
-      expect(pathExists(path.join(repoRoot, '.specrails', 'setup-templates', 'rules', 'general.md'))).toBe(true)
+      const ws = workspaceFor(repoRoot)
+      // Rules staging is populated (under the workspace).
+      expect(pathExists(path.join(ws, '.specrails', 'setup-templates', 'rules', 'general.md'))).toBe(true)
       // Manifest still bumped to current version.
       const manifest = JSON.parse(
-        readTextFile(path.join(repoRoot, '.specrails', 'specrails-manifest.json')),
+        readTextFile(path.join(ws, '.specrails', 'specrails-manifest.json')),
       )
       expect(manifest.version).toBe('5.0.0')
     })
@@ -242,7 +271,7 @@ describe('runUpdate', () => {
 
       const result = await runUpdate({ 'root-dir': repoRoot, only: 'agents' })
       expect(result.scope).toBe('agents')
-      expect(pathExists(path.join(repoRoot, '.specrails', 'setup-templates', 'agents', 'sr-architect.md'))).toBe(true)
+      expect(pathExists(path.join(workspaceFor(repoRoot), '.specrails', 'setup-templates', 'agents', 'sr-architect.md'))).toBe(true)
     })
 
     it('--only=web-manager warns and exits without writing (deprecated)', async () => {
@@ -254,8 +283,8 @@ describe('runUpdate', () => {
 
       const result = await runUpdate({ 'root-dir': repoRoot, only: 'web-manager' })
       expect(result.scope).toBe('web-manager')
-      // specrails-version unchanged.
-      expect(readTextFile(path.join(repoRoot, '.specrails', 'specrails-version')).trim()).toBe('4.2.0')
+      // specrails-version unchanged (in the workspace).
+      expect(readTextFile(path.join(workspaceFor(repoRoot), '.specrails', 'specrails-version')).trim()).toBe('4.2.0')
     })
 
     it('--only=core re-applies the full bundled template layer', async () => {
@@ -267,8 +296,8 @@ describe('runUpdate', () => {
 
       const result = await runUpdate({ 'root-dir': repoRoot, only: 'core' })
       expect(result.scope).toBe('core')
-      // Bundled commands present (full scaffold ran).
-      expect(pathExists(path.join(repoRoot, '.claude', 'commands', 'specrails', 'enrich.md'))).toBe(true)
+      // Bundled commands present (full scaffold ran) — under the workspace.
+      expect(pathExists(path.join(workspaceFor(repoRoot), '.claude', 'commands', 'specrails', 'enrich.md'))).toBe(true)
     })
 
     it('unknown --only value falls back to scope=all with a warning', async () => {
@@ -292,13 +321,14 @@ describe('runUpdate', () => {
 
     await runUpdate({ 'root-dir': repoRoot })
 
+    const ws = workspaceFor(repoRoot)
     const manifest = JSON.parse(
-      readTextFile(path.join(repoRoot, '.specrails', 'specrails-manifest.json')),
+      readTextFile(path.join(ws, '.specrails', 'specrails-manifest.json')),
     )
     expect(manifest.version).toBe('5.0.0')
     // Artifacts map contains entries for bundled commands.
     expect(manifest.artifacts['commands/specrails/enrich.md']).toBeDefined()
-    expect(pathExists(path.join(repoRoot, '.claude', 'commands', 'specrails', 'enrich.md'))).toBe(
+    expect(pathExists(path.join(ws, '.claude', 'commands', 'specrails', 'enrich.md'))).toBe(
       true,
     )
   })

--- a/src/installer/commands/update.ts
+++ b/src/installer/commands/update.ts
@@ -8,7 +8,10 @@ import { copyDir, isDir, pathExists, readTextFile } from '../util/fs.js'
 import { loadInstallConfig, resolveConfigPath, type Tier } from '../phases/install-config.js'
 import { buildManifest, writeManifestFiles, type SpecrailsManifest } from '../phases/manifest.js'
 import { derivedPaths, detectAvailability, resolveProvider, type Provider } from '../phases/provider-detect.js'
-import { scaffoldInstallation } from '../phases/scaffold.js'
+import { assembleProjectWorkspace } from '../phases/scaffold.js'
+import { frameworkRoot, resolveArtifacts } from '../util/registry.js'
+
+import { ensureFramework } from './init.js'
 
 /**
  * Components recognised by the `--only <component>` flag. Mirrors the
@@ -76,21 +79,37 @@ export async function runUpdate(flags: UpdateFlags): Promise<UpdateResult> {
   // Read install-config.yaml so the user's original choices (tier,
   // agent_teams) survive the update. Flag overrides win when present;
   // missing config falls back to defaults (tier=full, agent_teams=false).
-  const config = loadInstallConfig(resolveConfigPath(repoRoot))
+  // ─── Relocate-always: resolve where artifacts live ───────────────────
+  // All Specrails artifacts (incl. the specrails-version marker, manifest,
+  // install-config) live under `artifactRoot` (the $HOME workspace), never the
+  // repo. On update the registry entry already exists (created by init), so the
+  // `providers` hint is ignored; we resolve first, then read the install.
+  const { artifactRoot, codeRoot } = resolveArtifacts(repoRoot, {
+    allocate: true,
+    allocator: 'core-standalone',
+    home: process.env.SPECRAILS_REGISTRY_HOME,
+    coreVersion: currentVersion,
+  })
+
+  // install-config.yaml is a USER-authored file that lives in the repo (the user
+  // can't know the relocated workspace path), so it is read from repoRoot — NOT
+  // the artifactRoot. Falls back to a workspace copy if present (none today).
+  const config =
+    loadInstallConfig(resolveConfigPath(repoRoot)) ?? loadInstallConfig(resolveConfigPath(artifactRoot))
   const tier: Tier = config?.tier ?? 'full'
   const agentTeams = flags['agent-teams'] === true || config?.agent_teams === true
   const selectedAgents = config?.agents.selected
 
-  const marker = path.join(repoRoot, '.specrails', 'specrails-version')
+  const marker = path.join(artifactRoot, '.specrails', 'specrails-version')
   if (!pathExists(marker)) {
     throw new PrerequisiteError(
       `No existing specrails install detected at ${repoRoot}. Run \`npx specrails-core init\` first.`,
     )
   }
-  const previousVersion = readExistingVersion(repoRoot)
+  const previousVersion = readExistingVersion(artifactRoot)
 
   step('Update: resolving provider from existing install')
-  const provider = await resolveExistingProvider(repoRoot)
+  const provider = await resolveExistingProvider(artifactRoot)
   const { providerDir } = derivedPaths(provider)
   ok(`Detected provider: ${provider} (${providerDir})`)
 
@@ -119,34 +138,45 @@ export async function runUpdate(flags: UpdateFlags): Promise<UpdateResult> {
   step(`Update: refreshing scaffold [scope=${scope}] (${previousVersion ?? '?'} → ${currentVersion})`)
 
   if (scope === 'all' || scope === 'core') {
-    scaffoldInstallation({
+    // Bundled-framework update: re-materialize the framework to the (possibly
+    // new) version dir, atomically swap `current`, then RE-ASSEMBLE the
+    // workspace (re-link the static subtrees at the new `current` + re-seed the
+    // project layer). `assembleProjectWorkspace` rewrites the manifest itself.
+    const fwDir = frameworkRoot(process.env.SPECRAILS_REGISTRY_HOME)
+    ensureFramework({
       scriptDir,
-      repoRoot,
+      frameworkDir: fwDir,
       provider,
       providerDir,
+      version: currentVersion,
       agentTeams,
       selectedAgents,
-      // tier read from install-config.yaml above. If the user installed
-      // with --quick, we re-apply the quick-tier direct placement
-      // (agents + commands into <providerDir> with placeholder substitution
-      // and VPC exclusion) instead of leaving the live agents/ stale.
-      tier,
     })
-  } else if (scope === 'rules') {
-    rescaffoldComponent('rules', { scriptDir, repoRoot })
-  } else if (scope === 'agents') {
-    rescaffoldComponent('agents', { scriptDir, repoRoot })
-  }
+    assembleProjectWorkspace({
+      workspace: artifactRoot,
+      frameworkDir: fwDir,
+      provider,
+      providerDir,
+      version: currentVersion,
+      codeRoot,
+      scriptDir,
+      selectedAgents,
+      agentTeams,
+    })
+    ok(`Re-linked ${providerDir}/ at framework ${currentVersion} + rewrote manifest`)
+  } else if (scope === 'rules' || scope === 'agents') {
+    rescaffoldComponent(scope, { scriptDir, artifactRoot })
 
-  step('Update: rewriting manifest')
-  const manifest: SpecrailsManifest = buildManifest({
-    scriptDir,
-    repoRoot,
-    version: currentVersion,
-  })
-  const { manifestPath, versionPath } = writeManifestFiles(repoRoot, manifest)
-  ok(`Wrote ${path.relative(repoRoot, manifestPath)}`)
-  ok(`Wrote ${path.relative(repoRoot, versionPath)}`)
+    step('Update: rewriting manifest')
+    const manifest: SpecrailsManifest = buildManifest({
+      scriptDir,
+      repoRoot: artifactRoot,
+      version: currentVersion,
+    })
+    const { manifestPath, versionPath } = writeManifestFiles(artifactRoot, manifest)
+    ok(`Wrote ${path.relative(artifactRoot, manifestPath)}`)
+    ok(`Wrote ${path.relative(artifactRoot, versionPath)}`)
+  }
 
   step('Update complete')
   info(`specrails-core ${previousVersion ?? '?'} → ${currentVersion}`)
@@ -164,14 +194,14 @@ export async function runUpdate(flags: UpdateFlags): Promise<UpdateResult> {
  */
 function rescaffoldComponent(
   component: 'rules' | 'agents',
-  args: { scriptDir: string; repoRoot: string },
+  args: { scriptDir: string; artifactRoot: string },
 ): void {
   const src = path.join(args.scriptDir, 'templates', component)
   if (!isDir(src)) {
     warn(`templates/${component} not found at ${src} — nothing to update`)
     return
   }
-  const stagingDest = path.join(args.repoRoot, '.specrails', 'setup-templates', component)
+  const stagingDest = path.join(args.artifactRoot, '.specrails', 'setup-templates', component)
   copyDir(src, stagingDest, {
     filter: (_s, rel) => !rel.includes('node_modules') && !rel.endsWith('package-lock.json'),
   })
@@ -193,10 +223,10 @@ function resolveScope(only: string | boolean | undefined): OnlyComponent {
   return normalised as OnlyComponent
 }
 
-async function resolveExistingProvider(repoRoot: string): Promise<Provider> {
-  if (pathExists(path.join(repoRoot, '.claude'))) return 'claude'
-  if (pathExists(path.join(repoRoot, '.codex'))) return 'codex'
-  if (pathExists(path.join(repoRoot, '.gemini'))) return 'gemini'
+async function resolveExistingProvider(artifactRoot: string): Promise<Provider> {
+  if (pathExists(path.join(artifactRoot, '.claude'))) return 'claude'
+  if (pathExists(path.join(artifactRoot, '.codex'))) return 'codex'
+  if (pathExists(path.join(artifactRoot, '.gemini'))) return 'gemini'
   // None present — fall back to resolving via CLI availability.
   const avail = await detectAvailability()
   try {
@@ -204,14 +234,14 @@ async function resolveExistingProvider(repoRoot: string): Promise<Provider> {
   } catch (err) {
     if (err instanceof InstallerError) throw err
     throw new InstallerError(
-      `could not determine provider of existing install at ${repoRoot}`,
+      `could not determine provider of existing install at ${artifactRoot}`,
       40,
     )
   }
 }
 
-function readExistingVersion(repoRoot: string): string | null {
-  const p = path.join(repoRoot, '.specrails', 'specrails-version')
+function readExistingVersion(artifactRoot: string): string | null {
+  const p = path.join(artifactRoot, '.specrails', 'specrails-version')
   if (!pathExists(p)) return null
   try {
     return readTextFile(p).trim() || null

--- a/src/installer/phases/framework.test.ts
+++ b/src/installer/phases/framework.test.ts
@@ -1,0 +1,486 @@
+import { lstatSync, mkdtempSync, readFileSync, realpathSync, rmSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { isDir, isSymlink, pathExists, readTextFile, removePath, writeFileLf } from '../util/fs.js'
+import {
+  assembleProjectWorkspace,
+  ensureCurrentSymlink,
+  installFramework,
+} from './scaffold.js'
+
+/**
+ * Unit tests for the bundled-framework split:
+ *   installFramework (idempotent, versioned static materialization)
+ *   ensureCurrentSymlink (atomic `current` swap)
+ *   assembleProjectWorkspace (symlink static subtrees + seed project layer)
+ *
+ * These exercise the functions directly (no init/update orchestration) so the
+ * idempotency + link/seed invariants are pinned independently of the CLI flow.
+ *
+ * Platform-aware: `symlinkOrCopy` returns 'symlink' on POSIX, but on Windows a
+ * DIRECTORY link is a 'junction' and a per-FILE link falls back to a 'copy'
+ * (Windows file-symlinks need admin/Dev-Mode). So dir-link assertions accept
+ * symlink|junction, and per-file agent assertions check placement + content
+ * (which holds for symlink OR copy) — the stronger POSIX-only symlink checks
+ * stay guarded behind `!IS_WIN` so POSIX coverage is never weakened.
+ */
+
+const IS_WIN = process.platform === 'win32'
+const DIR_LINK = IS_WIN ? 'junction' : 'symlink'
+
+function setupFakeScriptDir(scriptDir: string): void {
+  writeFileLf(path.join(scriptDir, 'package.json'), `${JSON.stringify({ version: '5.0.0' })}\n`)
+  writeFileLf(path.join(scriptDir, 'templates', 'agents', 'sr-architect.md'), '# arch\nmemory: {{MEMORY_PATH}}\n')
+  writeFileLf(path.join(scriptDir, 'templates', 'agents', 'sr-developer.md'), '# dev\n')
+  writeFileLf(path.join(scriptDir, 'templates', 'agents', 'sr-reviewer.md'), '# reviewer\n')
+  // Optional specialists — NOT in the CORE trio, so they are only linked into a
+  // workspace whose selection includes them (exercises the superset+filter split).
+  writeFileLf(path.join(scriptDir, 'templates', 'agents', 'sr-backend-developer.md'), '# backend\n')
+  writeFileLf(path.join(scriptDir, 'templates', 'agents', 'sr-frontend-developer.md'), '# frontend\n')
+  writeFileLf(path.join(scriptDir, 'templates', 'rules', 'general.md'), '# rules\n')
+  writeFileLf(path.join(scriptDir, 'templates', 'commands', 'specrails', 'implement.md'), '/specrails:implement\n')
+  // Agent-Teams commands — materialized into the superset store ALWAYS; linked
+  // into a workspace only when agentTeams=true.
+  writeFileLf(path.join(scriptDir, 'templates', 'commands', 'specrails', 'team-review.md'), '/specrails:team-review\n')
+  writeFileLf(path.join(scriptDir, 'templates', 'commands', 'specrails', 'team-debug.md'), '/specrails:team-debug\n')
+  writeFileLf(path.join(scriptDir, 'commands', 'enrich.md'), 'enrich')
+  writeFileLf(path.join(scriptDir, 'commands', 'doctor.md'), 'doctor')
+}
+
+describe('bundled framework — installFramework / ensureCurrentSymlink / assembleProjectWorkspace', () => {
+  let tmpDir: string
+  let originalHome: string | undefined
+  let originalUserProfile: string | undefined
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'specrails-framework-test-'))
+    // Gemini acks write ~/.gemini — redirect HOME so the real one is untouched.
+    originalHome = process.env.HOME
+    originalUserProfile = process.env.USERPROFILE
+    const fakeHome = path.join(tmpDir, 'fake-home')
+    process.env.HOME = fakeHome
+    process.env.USERPROFILE = fakeHome
+  })
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME
+    else process.env.HOME = originalHome
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE
+    else process.env.USERPROFILE = originalUserProfile
+    rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+  })
+
+  describe('installFramework', () => {
+    it('materializes the provider-static subtree once under <frameworkDir>/<version>/<providerDir>', () => {
+      const scriptDir = path.join(tmpDir, 'core')
+      const fwDir = path.join(tmpDir, 'framework')
+      setupFakeScriptDir(scriptDir)
+
+      const res = installFramework({
+        scriptDir,
+        frameworkDir: fwDir,
+        provider: 'claude',
+        providerDir: '.claude',
+        version: '5.0.0',
+      })
+
+      expect(res.materialized).toBe(true)
+      const fwClaude = path.join(fwDir, '5.0.0', '.claude')
+      expect(isDir(path.join(fwClaude, 'agents'))).toBe(true)
+      expect(pathExists(path.join(fwClaude, 'agents', 'sr-architect.md'))).toBe(true)
+      expect(isDir(path.join(fwClaude, 'commands', 'specrails'))).toBe(true)
+      expect(isDir(path.join(fwClaude, 'rules'))).toBe(true)
+      // setup-templates is materialized at the version root (shared enrich cache).
+      expect(isDir(path.join(fwDir, '5.0.0', '.specrails', 'setup-templates', 'agents'))).toBe(true)
+      // The framework copy carries NO per-workspace state: no agent-memory dir,
+      // and the project-named instruction file is stripped.
+      expect(pathExists(path.join(fwClaude, 'agent-memory'))).toBe(false)
+      expect(pathExists(path.join(fwDir, '5.0.0', 'CLAUDE.md'))).toBe(false)
+    })
+
+    it('is idempotent — a second call with a matching stamp does NOT re-materialize', () => {
+      const scriptDir = path.join(tmpDir, 'core')
+      const fwDir = path.join(tmpDir, 'framework')
+      setupFakeScriptDir(scriptDir)
+
+      const first = installFramework({
+        scriptDir, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude', version: '5.0.0',
+      })
+      expect(first.materialized).toBe(true)
+
+      // Tamper with a materialized file; an idempotent skip leaves it as-is.
+      const archPath = path.join(fwDir, '5.0.0', '.claude', 'agents', 'sr-architect.md')
+      writeFileLf(archPath, 'TAMPERED')
+
+      const second = installFramework({
+        scriptDir, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude', version: '5.0.0',
+      })
+      expect(second.materialized).toBe(false)
+      expect(readTextFile(archPath)).toBe('TAMPERED') // proof it was skipped
+    })
+
+    it('materializes a codex framework with config.toml but no project-named AGENTS.md', () => {
+      const scriptDir = path.join(tmpDir, 'core')
+      const fwDir = path.join(tmpDir, 'framework')
+      setupFakeScriptDir(scriptDir)
+      writeFileLf(path.join(scriptDir, 'templates', 'settings', 'codex-config.toml'), 'model = "{{MODEL_NAME}}"\n')
+
+      installFramework({
+        scriptDir, frameworkDir: fwDir, provider: 'codex', providerDir: '.codex', version: '5.0.0',
+      })
+
+      const fwCodex = path.join(fwDir, '5.0.0', '.codex')
+      expect(pathExists(path.join(fwCodex, 'config.toml'))).toBe(true)
+      expect(readTextFile(path.join(fwCodex, 'config.toml'))).toContain('gpt-5.5-mini')
+      // The project-named AGENTS.md is NOT part of the shared copy.
+      expect(pathExists(path.join(fwDir, '5.0.0', 'AGENTS.md'))).toBe(false)
+    })
+  })
+
+  describe('installFramework — full superset materialization (fix #3 / fix #4)', () => {
+    it('materializes EVERY agent + the team commands regardless of the input selection', () => {
+      const scriptDir = path.join(tmpDir, 'core')
+      const fwDir = path.join(tmpDir, 'framework')
+      setupFakeScriptDir(scriptDir)
+
+      // Caller asks for a NARROW selection + agentTeams off — the SHARED store
+      // must still be the full superset so a later project can link specialists.
+      installFramework({
+        scriptDir, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude', version: '5.0.0',
+        selectedAgents: ['sr-architect'], agentTeams: false,
+      })
+
+      const fwAgents = path.join(fwDir, '5.0.0', '.claude', 'agents')
+      for (const id of ['sr-architect', 'sr-developer', 'sr-reviewer', 'sr-backend-developer', 'sr-frontend-developer']) {
+        expect(pathExists(path.join(fwAgents, `${id}.md`))).toBe(true)
+      }
+      // Team commands are in the SHARED store even though agentTeams was false.
+      const fwCmds = path.join(fwDir, '5.0.0', '.claude', 'commands', 'specrails')
+      expect(pathExists(path.join(fwCmds, 'team-review.md'))).toBe(true)
+      expect(pathExists(path.join(fwCmds, 'team-debug.md'))).toBe(true)
+    })
+
+    it('swapCurrent:false materializes WITHOUT swapping current (multi-provider safety)', () => {
+      const scriptDir = path.join(tmpDir, 'core')
+      const fwDir = path.join(tmpDir, 'framework')
+      setupFakeScriptDir(scriptDir)
+
+      // First version exists + current points at it.
+      installFramework({ scriptDir, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude', version: '5.0.0' })
+      ensureCurrentSymlink(fwDir, '5.0.0')
+      expect(realpathSync(path.join(fwDir, 'current'))).toBe(realpathSync(path.join(fwDir, '5.0.0')))
+
+      // Materialize a NEW version WITHOUT swapping — current must stay at 5.0.0.
+      installFramework({ scriptDir, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude', version: '6.0.0' })
+      // (installFramework itself never swaps; the swap lives in ensureFramework /
+      // ensureCurrentSymlink. Assert current is untouched until we swap.)
+      expect(realpathSync(path.join(fwDir, 'current'))).toBe(realpathSync(path.join(fwDir, '5.0.0')))
+      expect(isDir(path.join(fwDir, '6.0.0', '.claude', 'agents'))).toBe(true)
+
+      // Now the single explicit swap makes 6.0.0 visible.
+      ensureCurrentSymlink(fwDir, '6.0.0')
+      expect(realpathSync(path.join(fwDir, 'current'))).toBe(realpathSync(path.join(fwDir, '6.0.0')))
+    })
+  })
+
+  describe('ensureCurrentSymlink', () => {
+    it('points current at the version dir and swaps atomically to a new version', () => {
+      const scriptDir = path.join(tmpDir, 'core')
+      const fwDir = path.join(tmpDir, 'framework')
+      setupFakeScriptDir(scriptDir)
+
+      installFramework({ scriptDir, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude', version: '5.0.0' })
+      ensureCurrentSymlink(fwDir, '5.0.0')
+      expect(realpathSync(path.join(fwDir, 'current'))).toBe(realpathSync(path.join(fwDir, '5.0.0')))
+
+      // Materialize a second version alongside, then swap — one rename updates all.
+      installFramework({ scriptDir, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude', version: '6.0.0' })
+      ensureCurrentSymlink(fwDir, '6.0.0')
+      expect(realpathSync(path.join(fwDir, 'current'))).toBe(realpathSync(path.join(fwDir, '6.0.0')))
+      // The old version dir is NOT destroyed (non-destructive side-by-side).
+      expect(isDir(path.join(fwDir, '5.0.0', '.claude', 'agents'))).toBe(true)
+    })
+  })
+
+  describe('assembleProjectWorkspace', () => {
+    function materialize(fwDir: string, scriptDir: string, version = '5.0.0'): void {
+      installFramework({ scriptDir, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude', version })
+      ensureCurrentSymlink(fwDir, version)
+    }
+
+    it('symlinks static subtrees + seeds the project layer as real files', () => {
+      const scriptDir = path.join(tmpDir, 'core')
+      const fwDir = path.join(tmpDir, 'framework')
+      const ws = path.join(tmpDir, 'ws')
+      const repo = path.join(tmpDir, 'repo')
+      setupFakeScriptDir(scriptDir)
+      materialize(fwDir, scriptDir)
+
+      const res = assembleProjectWorkspace({
+        workspace: ws, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude',
+        version: '5.0.0', codeRoot: repo, scriptDir,
+        // agentTeams:true keeps the whole-dir symlink path (no per-file team prune).
+        agentTeams: true,
+      })
+
+      // commands/ + rules/ are whole-dir links into framework/current (symlink on
+      // POSIX, junction on Windows). Assert they RESOLVE to the framework — the
+      // realpath check holds for both link kinds.
+      expect(realpathSync(path.join(ws, '.claude', 'commands'))).toBe(
+        realpathSync(path.join(fwDir, 'current', '.claude', 'commands')),
+      )
+      expect(res.links['rules']).toBe(DIR_LINK)
+      // agents/ is a REAL dir of per-file links (custom-*.md can coexist).
+      expect(isDir(path.join(ws, '.claude', 'agents'))).toBe(true)
+      expect(isSymlink(path.join(ws, '.claude', 'agents'))).toBe(false)
+      // The framework agent is PLACED with matching content (symlink on POSIX,
+      // copy on Windows). On POSIX additionally assert the stronger symlink +
+      // realpath-dedup properties.
+      const wsArch = path.join(ws, '.claude', 'agents', 'sr-architect.md')
+      const fwArch = path.join(fwDir, 'current', '.claude', 'agents', 'sr-architect.md')
+      expect(pathExists(wsArch)).toBe(true)
+      expect(readTextFile(wsArch)).toBe(readTextFile(fwArch))
+      if (!IS_WIN) {
+        expect(lstatSync(wsArch).isSymbolicLink()).toBe(true)
+        expect(realpathSync(wsArch)).toBe(realpathSync(fwArch))
+      }
+      // agent-memory/ is a REAL writable dir, never a link.
+      expect(isDir(path.join(ws, '.claude', 'agent-memory', 'sr-architect'))).toBe(true)
+      expect(isSymlink(path.join(ws, '.claude', 'agent-memory'))).toBe(false)
+      expect(res.seededMemoryAgents.sort()).toEqual(['sr-architect', 'sr-developer', 'sr-reviewer'])
+      // explanations/ created (arch + reviewer are explanation authors).
+      expect(isDir(path.join(ws, '.claude', 'agent-memory', 'explanations'))).toBe(true)
+      // manifest records the framework version.
+      expect(readFileSync(path.join(ws, '.specrails', 'specrails-version'), 'utf8').trim()).toBe('5.0.0')
+    })
+
+    it('preserves a pre-existing custom-*.md agent (reserved path) while linking framework agents', () => {
+      const scriptDir = path.join(tmpDir, 'core')
+      const fwDir = path.join(tmpDir, 'framework')
+      const ws = path.join(tmpDir, 'ws')
+      const repo = path.join(tmpDir, 'repo')
+      setupFakeScriptDir(scriptDir)
+      materialize(fwDir, scriptDir)
+      writeFileLf(path.join(ws, '.claude', 'agents', 'custom-reviewer.md'), 'USER CONTENT')
+
+      assembleProjectWorkspace({
+        workspace: ws, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude',
+        version: '5.0.0', codeRoot: repo, scriptDir,
+      })
+
+      expect(readTextFile(path.join(ws, '.claude', 'agents', 'custom-reviewer.md'))).toBe('USER CONTENT')
+      expect(lstatSync(path.join(ws, '.claude', 'agents', 'custom-reviewer.md')).isSymbolicLink()).toBe(false)
+      // Framework agents are still linked alongside.
+      expect(pathExists(path.join(ws, '.claude', 'agents', 'sr-architect.md'))).toBe(true)
+    })
+
+    it('two projects SHARE one framework copy — the second assemble does not re-materialize', () => {
+      const scriptDir = path.join(tmpDir, 'core')
+      const fwDir = path.join(tmpDir, 'framework')
+      const wsA = path.join(tmpDir, 'wsA')
+      const wsB = path.join(tmpDir, 'wsB')
+      setupFakeScriptDir(scriptDir)
+
+      const first = installFramework({ scriptDir, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude', version: '5.0.0' })
+      ensureCurrentSymlink(fwDir, '5.0.0')
+      expect(first.materialized).toBe(true)
+
+      assembleProjectWorkspace({
+        workspace: wsA, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude',
+        version: '5.0.0', codeRoot: path.join(tmpDir, 'repoA'), scriptDir,
+      })
+      // A SECOND project: installFramework is a no-op (idempotent share).
+      const second = installFramework({ scriptDir, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude', version: '5.0.0' })
+      expect(second.materialized).toBe(false)
+      assembleProjectWorkspace({
+        workspace: wsB, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude',
+        version: '5.0.0', codeRoot: path.join(tmpDir, 'repoB'), scriptDir,
+      })
+
+      // The SHARED property holds on BOTH platforms: the framework store is
+      // materialized exactly once (second install was a no-op, asserted above)
+      // and both workspaces' agent files carry IDENTICAL content.
+      const wsAArch = path.join(wsA, '.claude', 'agents', 'sr-architect.md')
+      const wsBArch = path.join(wsB, '.claude', 'agents', 'sr-architect.md')
+      expect(readTextFile(wsAArch)).toBe(readTextFile(wsBArch))
+      // POSIX: both resolve to the SAME physical framework file (per-file symlink
+      // dedup). On Windows the files are independent copies, so realpath differs.
+      if (!IS_WIN) {
+        expect(realpathSync(wsAArch)).toBe(realpathSync(wsBArch))
+      }
+      // Each workspace has its OWN real agent-memory dir.
+      expect(isDir(path.join(wsA, '.claude', 'agent-memory', 'sr-architect'))).toBe(true)
+      expect(isDir(path.join(wsB, '.claude', 'agent-memory', 'sr-architect'))).toBe(true)
+    })
+
+    it('re-assemble after a version swap re-points the links and drops stale framework agent links', () => {
+      const scriptDir = path.join(tmpDir, 'core')
+      const fwDir = path.join(tmpDir, 'framework')
+      const ws = path.join(tmpDir, 'ws')
+      const repo = path.join(tmpDir, 'repo')
+      setupFakeScriptDir(scriptDir)
+      materialize(fwDir, scriptDir, '5.0.0')
+      assembleProjectWorkspace({
+        workspace: ws, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude',
+        version: '5.0.0', codeRoot: repo, scriptDir,
+      })
+
+      // New version drops sr-reviewer from the agent set.
+      rmSync(path.join(scriptDir, 'templates', 'agents', 'sr-reviewer.md'), { force: true })
+      materialize(fwDir, scriptDir, '6.0.0')
+      assembleProjectWorkspace({
+        workspace: ws, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude',
+        version: '6.0.0', codeRoot: repo, scriptDir,
+      })
+
+      // After the swap the workspace agent matches 6.0.0's content (re-pointed
+      // link on POSIX, refreshed copy on Windows); the stale sr-reviewer agent is
+      // dropped on both platforms.
+      const wsArch6 = path.join(ws, '.claude', 'agents', 'sr-architect.md')
+      const fwArch6 = path.join(fwDir, '6.0.0', '.claude', 'agents', 'sr-architect.md')
+      expect(pathExists(wsArch6)).toBe(true)
+      expect(readTextFile(wsArch6)).toBe(readTextFile(fwArch6))
+      if (!IS_WIN) {
+        expect(realpathSync(wsArch6)).toBe(realpathSync(fwArch6))
+      }
+      expect(pathExists(path.join(ws, '.claude', 'agents', 'sr-reviewer.md'))).toBe(false)
+      // agent-memory persisted across the swap (never linked, never dropped).
+      expect(isDir(path.join(ws, '.claude', 'agent-memory', 'sr-architect'))).toBe(true)
+    })
+
+    it('two projects with DIFFERENT selections each link their OWN specialists from one superset (fix #3)', () => {
+      const scriptDir = path.join(tmpDir, 'core')
+      const fwDir = path.join(tmpDir, 'framework')
+      const wsBackend = path.join(tmpDir, 'ws-backend')
+      const wsFrontend = path.join(tmpDir, 'ws-frontend')
+      setupFakeScriptDir(scriptDir)
+      // Project A installs first with a NARROW selection.
+      installFramework({
+        scriptDir, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude', version: '5.0.0',
+        selectedAgents: ['sr-backend-developer'], agentTeams: false,
+      })
+      ensureCurrentSymlink(fwDir, '5.0.0')
+
+      assembleProjectWorkspace({
+        workspace: wsBackend, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude',
+        version: '5.0.0', codeRoot: path.join(tmpDir, 'repoA'), scriptDir,
+        selectedAgents: ['sr-backend-developer'],
+      })
+      // Project B reuses the SAME shared store but selects a DIFFERENT specialist.
+      assembleProjectWorkspace({
+        workspace: wsFrontend, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude',
+        version: '5.0.0', codeRoot: path.join(tmpDir, 'repoB'), scriptDir,
+        selectedAgents: ['sr-frontend-developer'],
+      })
+
+      const aAgents = path.join(wsBackend, '.claude', 'agents')
+      const bAgents = path.join(wsFrontend, '.claude', 'agents')
+      // Each workspace has its OWN specialist (the bug was B inheriting A's set).
+      expect(pathExists(path.join(aAgents, 'sr-backend-developer.md'))).toBe(true)
+      expect(pathExists(path.join(aAgents, 'sr-frontend-developer.md'))).toBe(false)
+      expect(pathExists(path.join(bAgents, 'sr-frontend-developer.md'))).toBe(true)
+      expect(pathExists(path.join(bAgents, 'sr-backend-developer.md'))).toBe(false)
+      // Both still get the CORE trio.
+      for (const id of ['sr-architect', 'sr-developer', 'sr-reviewer']) {
+        expect(pathExists(path.join(aAgents, `${id}.md`))).toBe(true)
+        expect(pathExists(path.join(bAgents, `${id}.md`))).toBe(true)
+      }
+    })
+
+    it('excludes team-* commands when agentTeams is off, includes them when on (fix #3)', () => {
+      const scriptDir = path.join(tmpDir, 'core')
+      const fwDir = path.join(tmpDir, 'framework')
+      const wsLean = path.join(tmpDir, 'ws-lean')
+      const wsTeams = path.join(tmpDir, 'ws-teams')
+      setupFakeScriptDir(scriptDir)
+      installFramework({ scriptDir, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude', version: '5.0.0' })
+      ensureCurrentSymlink(fwDir, '5.0.0')
+
+      assembleProjectWorkspace({
+        workspace: wsLean, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude',
+        version: '5.0.0', codeRoot: path.join(tmpDir, 'repoLean'), scriptDir, agentTeams: false,
+      })
+      assembleProjectWorkspace({
+        workspace: wsTeams, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude',
+        version: '5.0.0', codeRoot: path.join(tmpDir, 'repoTeams'), scriptDir, agentTeams: true,
+      })
+
+      const leanCmds = path.join(wsLean, '.claude', 'commands', 'specrails')
+      const teamsCmds = path.join(wsTeams, '.claude', 'commands', 'specrails')
+      // Lean: implement is present, team-* are NOT surfaced.
+      expect(pathExists(path.join(leanCmds, 'implement.md'))).toBe(true)
+      expect(pathExists(path.join(leanCmds, 'team-review.md'))).toBe(false)
+      expect(pathExists(path.join(leanCmds, 'team-debug.md'))).toBe(false)
+      // agentTeams=true: team-* ARE surfaced (whole-dir symlink).
+      expect(pathExists(path.join(teamsCmds, 'team-review.md'))).toBe(true)
+      expect(pathExists(path.join(teamsCmds, 'team-debug.md'))).toBe(true)
+    })
+
+    it('removes a stale COPY-fallback framework agent on a version swap, preserving custom-*.md (fix #7)', () => {
+      const scriptDir = path.join(tmpDir, 'core')
+      const fwDir = path.join(tmpDir, 'framework')
+      const ws = path.join(tmpDir, 'ws-copyfallback')
+      const repo = path.join(tmpDir, 'repo-cf')
+      setupFakeScriptDir(scriptDir)
+      materialize(fwDir, scriptDir, '5.0.0')
+      assembleProjectWorkspace({
+        workspace: ws, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude',
+        version: '5.0.0', codeRoot: repo, scriptDir,
+      })
+
+      const wsAgents = path.join(ws, '.claude', 'agents')
+      // Simulate a Windows COPY-fallback: replace the sr-reviewer symlink with a
+      // REAL (copied) framework file, and add a user custom-*.md alongside.
+      removePath(path.join(wsAgents, 'sr-reviewer.md'))
+      writeFileLf(path.join(wsAgents, 'sr-reviewer.md'), '# copied reviewer (framework)\n')
+      writeFileLf(path.join(wsAgents, 'custom-mine.md'), 'USER CONTENT')
+      expect(isSymlink(path.join(wsAgents, 'sr-reviewer.md'))).toBe(false)
+
+      // New version DROPS sr-reviewer entirely.
+      rmSync(path.join(scriptDir, 'templates', 'agents', 'sr-reviewer.md'), { force: true })
+      materialize(fwDir, scriptDir, '6.0.0')
+      assembleProjectWorkspace({
+        workspace: ws, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude',
+        version: '6.0.0', codeRoot: repo, scriptDir,
+      })
+
+      // The stale COPIED framework agent is gone (fix #7: cleanup no longer
+      // gates on isSymlink, so copy-fallback files are also removed).
+      expect(pathExists(path.join(wsAgents, 'sr-reviewer.md'))).toBe(false)
+      // The user custom agent is untouched.
+      expect(readTextFile(path.join(wsAgents, 'custom-mine.md'))).toBe('USER CONTENT')
+      // Still-provided framework agents remain.
+      expect(pathExists(path.join(wsAgents, 'sr-architect.md'))).toBe(true)
+    })
+
+    it('seeds gemini headless acks hashing the LINKED agent files', () => {
+      const scriptDir = path.join(tmpDir, 'core')
+      const fwDir = path.join(tmpDir, 'framework')
+      const ws = path.join(tmpDir, 'ws-gem')
+      const repo = path.join(tmpDir, 'repo-gem')
+      setupFakeScriptDir(scriptDir)
+      writeFileLf(path.join(scriptDir, 'templates', 'settings', 'gemini-settings.json'), '{\n  "experimental": { "enableAgents": true }\n}\n')
+
+      installFramework({ scriptDir, frameworkDir: fwDir, provider: 'gemini', providerDir: '.gemini', version: '5.0.0' })
+      ensureCurrentSymlink(fwDir, '5.0.0')
+      assembleProjectWorkspace({
+        workspace: ws, frameworkDir: fwDir, provider: 'gemini', providerDir: '.gemini',
+        version: '5.0.0', codeRoot: repo, scriptDir,
+      })
+
+      // GEMINI.md seeded (project-named) + agent-memory real dir.
+      expect(pathExists(path.join(ws, 'GEMINI.md'))).toBe(true)
+      expect(isDir(path.join(ws, '.gemini', 'agent-memory', 'sr-architect'))).toBe(true)
+      // Ack file written, keyed on the WORKSPACE (gemini runs with cwd=workspace
+      // under relocation), hashing the linked agent file.
+      const ackPath = path.join(os.homedir(), '.gemini', 'acknowledgments', 'agents.json')
+      expect(pathExists(ackPath)).toBe(true)
+      const ack = JSON.parse(readTextFile(ackPath)) as Record<string, Record<string, string>>
+      expect(Object.keys(ack[ws])).toEqual(expect.arrayContaining(['sr-architect']))
+      expect(ack[repo]).toBeUndefined() // repo is NOT the key under relocation
+    })
+  })
+})

--- a/src/installer/phases/scaffold.test.ts
+++ b/src/installer/phases/scaffold.test.ts
@@ -111,21 +111,21 @@ describe('scaffold', () => {
   describe('detectExistingSetup', () => {
     it('returns false on a clean repo', () => {
       expect(
-        detectExistingSetup({ repoRoot: tmpDir, providerDir: '.claude' }),
+        detectExistingSetup({ artifactRoot: tmpDir, codeRoot: tmpDir, providerDir: '.claude' }),
       ).toBe(false)
     })
 
     it('returns true when .claude/agents/ has content', () => {
       writeFileLf(path.join(tmpDir, '.claude', 'agents', 'foo.md'), '')
       expect(
-        detectExistingSetup({ repoRoot: tmpDir, providerDir: '.claude' }),
+        detectExistingSetup({ artifactRoot: tmpDir, codeRoot: tmpDir, providerDir: '.claude' }),
       ).toBe(true)
     })
 
     it('returns true when openspec/ exists with content', () => {
       writeFileLf(path.join(tmpDir, 'openspec', 'specs', 'x.md'), '')
       expect(
-        detectExistingSetup({ repoRoot: tmpDir, providerDir: '.claude' }),
+        detectExistingSetup({ artifactRoot: tmpDir, codeRoot: tmpDir, providerDir: '.claude' }),
       ).toBe(true)
     })
   })
@@ -138,7 +138,8 @@ describe('scaffold', () => {
 
       scaffoldInstallation({
         scriptDir,
-        repoRoot,
+        artifactRoot: repoRoot,
+        codeRoot: repoRoot,
         provider: 'claude',
         providerDir: '.claude',
         agentTeams: false,
@@ -169,7 +170,8 @@ describe('scaffold', () => {
     function scaffoldGemini(scriptDir: string, repoRoot: string): void {
       scaffoldInstallation({
         scriptDir,
-        repoRoot,
+        artifactRoot: repoRoot,
+        codeRoot: repoRoot,
         provider: 'gemini',
         providerDir: '.gemini',
         agentTeams: false,
@@ -288,7 +290,8 @@ describe('scaffold', () => {
 
       scaffoldInstallation({
         scriptDir,
-        repoRoot,
+        artifactRoot: repoRoot,
+        codeRoot: repoRoot,
         provider: 'claude',
         providerDir: '.claude',
         agentTeams: false,
@@ -312,7 +315,8 @@ describe('scaffold', () => {
 
       scaffoldInstallation({
         scriptDir,
-        repoRoot,
+        artifactRoot: repoRoot,
+        codeRoot: repoRoot,
         provider: 'claude',
         providerDir: '.claude',
         agentTeams: false,
@@ -344,7 +348,8 @@ describe('scaffold', () => {
 
       scaffoldInstallation({
         scriptDir,
-        repoRoot,
+        artifactRoot: repoRoot,
+        codeRoot: repoRoot,
         provider: 'claude',
         providerDir: '.claude',
         agentTeams: false,
@@ -374,7 +379,8 @@ describe('scaffold', () => {
 
       scaffoldInstallation({
         scriptDir,
-        repoRoot,
+        artifactRoot: repoRoot,
+        codeRoot: repoRoot,
         provider: 'claude',
         providerDir: '.claude',
         agentTeams: false,
@@ -393,7 +399,8 @@ describe('scaffold', () => {
 
       scaffoldInstallation({
         scriptDir,
-        repoRoot,
+        artifactRoot: repoRoot,
+        codeRoot: repoRoot,
         provider: 'claude',
         providerDir: '.claude',
         agentTeams: true,
@@ -412,7 +419,8 @@ describe('scaffold', () => {
 
       scaffoldInstallation({
         scriptDir,
-        repoRoot,
+        artifactRoot: repoRoot,
+        codeRoot: repoRoot,
         provider: 'claude',
         providerDir: '.claude',
         agentTeams: false,
@@ -431,7 +439,8 @@ describe('scaffold', () => {
 
         scaffoldInstallation({
           scriptDir,
-          repoRoot,
+          artifactRoot: repoRoot,
+          codeRoot: repoRoot,
           provider: 'claude',
           providerDir: '.claude',
           agentTeams: false,
@@ -455,7 +464,8 @@ describe('scaffold', () => {
 
         scaffoldInstallation({
           scriptDir,
-          repoRoot,
+          artifactRoot: repoRoot,
+          codeRoot: repoRoot,
           provider: 'claude',
           providerDir: '.claude',
           agentTeams: false,
@@ -486,7 +496,8 @@ describe('scaffold', () => {
 
         scaffoldInstallation({
           scriptDir,
-          repoRoot,
+          artifactRoot: repoRoot,
+          codeRoot: repoRoot,
           provider: 'claude',
           providerDir: '.claude',
           agentTeams: false,
@@ -511,7 +522,8 @@ describe('scaffold', () => {
 
         scaffoldInstallation({
           scriptDir,
-          repoRoot,
+          artifactRoot: repoRoot,
+          codeRoot: repoRoot,
           provider: 'claude',
           providerDir: '.claude',
           agentTeams: false,
@@ -529,7 +541,8 @@ describe('scaffold', () => {
 
         scaffoldInstallation({
           scriptDir,
-          repoRoot,
+          artifactRoot: repoRoot,
+          codeRoot: repoRoot,
           provider: 'claude',
           providerDir: '.claude',
           agentTeams: false,
@@ -556,7 +569,8 @@ describe('scaffold', () => {
 
         scaffoldInstallation({
           scriptDir,
-          repoRoot,
+          artifactRoot: repoRoot,
+          codeRoot: repoRoot,
           provider: 'claude',
           providerDir: '.claude',
           agentTeams: false,
@@ -575,7 +589,8 @@ describe('scaffold', () => {
 
         scaffoldInstallation({
           scriptDir,
-          repoRoot,
+          artifactRoot: repoRoot,
+          codeRoot: repoRoot,
           provider: 'claude',
           providerDir: '.claude',
           agentTeams: true,
@@ -594,7 +609,8 @@ describe('scaffold', () => {
 
         scaffoldInstallation({
           scriptDir,
-          repoRoot,
+          artifactRoot: repoRoot,
+          codeRoot: repoRoot,
           provider: 'claude',
           providerDir: '.claude',
           agentTeams: false,
@@ -617,7 +633,8 @@ describe('scaffold', () => {
 
       scaffoldInstallation({
         scriptDir,
-        repoRoot,
+        artifactRoot: repoRoot,
+        codeRoot: repoRoot,
         provider: 'claude',
         providerDir: '.claude',
         agentTeams: false,
@@ -637,7 +654,8 @@ describe('scaffold', () => {
 
       scaffoldInstallation({
         scriptDir,
-        repoRoot,
+        artifactRoot: repoRoot,
+        codeRoot: repoRoot,
         provider: 'codex',
         providerDir: '.codex',
         agentTeams: false,
@@ -657,7 +675,8 @@ describe('scaffold', () => {
 
       scaffoldInstallation({
         scriptDir,
-        repoRoot,
+        artifactRoot: repoRoot,
+        codeRoot: repoRoot,
         provider: 'codex',
         providerDir: '.codex',
         agentTeams: false,
@@ -690,7 +709,8 @@ describe('scaffold', () => {
 
       scaffoldInstallation({
         scriptDir,
-        repoRoot,
+        artifactRoot: repoRoot,
+        codeRoot: repoRoot,
         provider: 'codex',
         providerDir: '.codex',
         agentTeams: false,
@@ -830,5 +850,19 @@ describe('writeGeminiAgentAcknowledgments', () => {
     const ack = JSON.parse(readTextFile(ackFile())) as Record<string, Record<string, string>>
     expect(ack[repo]['sr-architect']).toBe(sha('arch\n'))
     expect(ack[repo]['ghost']).toBeUndefined()
+  })
+
+  it('keys the ack on the WORKSPACE (agentsBaseDir) under relocation, not the repo', () => {
+    // Under relocation, gemini runs with cwd=<workspace>, so the ack store must be
+    // keyed on the workspace providerDir base (3rd arg) — NOT the repo root —
+    // otherwise headless `gemini -p` looks up `store[<workspace>]` and finds
+    // nothing. The agent files are hashed from the workspace too.
+    const repo = path.join(tmpDir, 'repo')
+    const workspace = path.join(tmpDir, 'workspace')
+    writeAgent(workspace, 'sr-architect', 'ws-arch\n')
+    writeGeminiAgentAcknowledgments(repo, ['sr-architect'], workspace)
+    const ack = JSON.parse(readTextFile(ackFile())) as Record<string, Record<string, string>>
+    expect(ack[workspace]['sr-architect']).toBe(sha('ws-arch\n'))
+    expect(ack[repo]).toBeUndefined() // repo is NOT the key under relocation
   })
 })

--- a/src/installer/phases/scaffold.ts
+++ b/src/installer/phases/scaffold.ts
@@ -3,9 +3,23 @@ import { rmSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
-import { copyDir, copyFile, isDir, listDir, mkdirp, pathExists, readTextFile, writeFileLf } from '../util/fs.js'
+import {
+  atomicSymlinkSwap,
+  copyDir,
+  copyFile,
+  isDir,
+  isSymlink,
+  listDir,
+  mkdirp,
+  pathExists,
+  readTextFile,
+  removePath,
+  symlinkOrCopy,
+  writeFileLf,
+} from '../util/fs.js'
 import { info, ok, warn } from '../util/logger.js'
 
+import { buildManifest, writeManifestFiles } from './manifest.js'
 import type { Provider } from './provider-detect.js'
 
 /**
@@ -195,8 +209,18 @@ const EXPLANATION_AUTHORS = new Set(['sr-architect', 'sr-reviewer'])
 export interface ScaffoldInput {
   /** Absolute path to the specrails-core package (installed via npx). */
   scriptDir: string
-  /** Absolute path to the user's repo root. */
-  repoRoot: string
+  /**
+   * Absolute path to the relocated artifact root — where every Specrails-managed
+   * artifact (.specrails/.claude/.codex/.gemini/CLAUDE.md/AGENTS.md/GEMINI.md/.mcp.json)
+   * is written. Under relocate-always this is the `$HOME` workspace, NOT the repo.
+   */
+  artifactRoot: string
+  /**
+   * Absolute path to the user's repo root — the ONLY thing that stays in-repo is
+   * `openspec/**` (installed by init.ts) and git/worktree ops. Used solely by
+   * `detectExistingSetup`'s openspec probe and the gitignore no-op guard.
+   */
+  codeRoot: string
   /** Resolved provider from prereqs. */
   provider: Provider
   /** Derived directory name (`.claude` or `.codex`). */
@@ -207,6 +231,23 @@ export interface ScaffoldInput {
   tier: 'full' | 'quick'
   /** Optional explicit allow-list used by config-driven quick installs. */
   selectedAgents?: string[]
+  /**
+   * When false, the static-placement helpers do NOT create the per-workspace
+   * mutable seeds (agent-memory dirs, gemini headless acknowledgments). Used by
+   * `installFramework` so the SHARED framework copy stays purely provider-static
+   * — the project layer is seeded separately by `assembleProjectWorkspace`.
+   * Defaults to true (legacy in-place behaviour for `scaffoldInstallation`).
+   */
+  seedProjectDirs?: boolean
+  /**
+   * When true, place EVERY agent template (the full superset) regardless of
+   * `selectedAgents` and `QUICK_EXCLUDED_AGENTS`. Used by `installFramework` so
+   * the SHARED framework store is a superset that ANY project's selection can
+   * link from — per-project agent filtering then happens at the workspace LINK
+   * step (`linkAgentFiles`), not at materialization. Defaults to false (legacy
+   * selection-honouring placement for in-place `scaffoldInstallation`).
+   */
+  materializeAllAgents?: boolean
 }
 
 export interface ScaffoldResult {
@@ -216,17 +257,34 @@ export interface ScaffoldResult {
 }
 
 /**
+ * Provider-static subtrees inside a providerDir that are SHARED via symlink from
+ * the framework copy into each workspace. `agent-memory/` is deliberately absent
+ * — it is mutable per-workspace state seeded as a real dir, never linked.
+ *
+ * The root instruction file (`CLAUDE.md`/`AGENTS.md`/`GEMINI.md`) and the codex
+ * `config.toml` / gemini `settings.json` carry the project name / a deep-merge
+ * with the user's file, so they are SEEDED per-workspace (not linked) by
+ * `assembleProjectWorkspace`.
+ */
+const LINKED_PROVIDER_SUBTREES: Record<Provider, string[]> = {
+  claude: ['agents', 'commands', 'skills', 'rules'],
+  codex: ['skills'],
+  gemini: ['agents', 'commands'],
+}
+
+/**
  * Returns true iff any of the provider directories already contains
  * content. The desktop-app-driven path skips the "merge existing?" prompt and
  * assumes `--yes`; the CLI dispatcher (bin/specrails-core.cjs) should
  * have prompted before entering this phase.
  */
-export function detectExistingSetup(input: Pick<ScaffoldInput, 'repoRoot' | 'providerDir'>): boolean {
+export function detectExistingSetup(input: Pick<ScaffoldInput, 'artifactRoot' | 'codeRoot' | 'providerDir'>): boolean {
   const roots = [
-    path.join(input.repoRoot, input.providerDir, 'agents'),
-    path.join(input.repoRoot, input.providerDir, 'commands'),
-    path.join(input.repoRoot, input.providerDir, 'rules'),
-    path.join(input.repoRoot, 'openspec'),
+    path.join(input.artifactRoot, input.providerDir, 'agents'),
+    path.join(input.artifactRoot, input.providerDir, 'commands'),
+    path.join(input.artifactRoot, input.providerDir, 'rules'),
+    // openspec stays in the repo (codeRoot), not the relocated artifact root.
+    path.join(input.codeRoot, 'openspec'),
   ]
   for (const r of roots) {
     if (isDir(r) && listDir(r).length > 0) return true
@@ -248,24 +306,24 @@ export function scaffoldInstallation(input: ScaffoldInput): ScaffoldResult {
   }
 
   // --- Directory skeleton ---
-  mk(path.join(input.repoRoot, input.providerDir))
+  mk(path.join(input.artifactRoot, input.providerDir))
   if (input.provider === 'codex') {
     // Codex skills live under <providerDir>/skills/ (e.g. .codex/skills/).
     // The pre-§18 code wrote to `.agents/skills/` which codex doesn't read;
     // that was a placeholder name from the gated state.
-    mk(path.join(input.repoRoot, input.providerDir, 'skills', 'enrich'))
-    mk(path.join(input.repoRoot, input.providerDir, 'skills', 'doctor'))
-    mk(path.join(input.repoRoot, input.providerDir, 'skills', 'rails'))
+    mk(path.join(input.artifactRoot, input.providerDir, 'skills', 'enrich'))
+    mk(path.join(input.artifactRoot, input.providerDir, 'skills', 'doctor'))
+    mk(path.join(input.artifactRoot, input.providerDir, 'skills', 'rails'))
   } else if (input.provider === 'gemini') {
     // Gemini: TOML commands under .gemini/commands/specrails/ + native
     // subagents under .gemini/agents/. No skills/ tree.
-    mk(path.join(input.repoRoot, input.providerDir, 'commands', 'specrails'))
-    mk(path.join(input.repoRoot, input.providerDir, 'agents'))
+    mk(path.join(input.artifactRoot, input.providerDir, 'commands', 'specrails'))
+    mk(path.join(input.artifactRoot, input.providerDir, 'agents'))
   } else {
-    mk(path.join(input.repoRoot, input.providerDir, 'commands', 'specrails'))
-    mk(path.join(input.repoRoot, input.providerDir, 'skills'))
+    mk(path.join(input.artifactRoot, input.providerDir, 'commands', 'specrails'))
+    mk(path.join(input.artifactRoot, input.providerDir, 'skills'))
   }
-  const setupTemplates = path.join(input.repoRoot, '.specrails', 'setup-templates')
+  const setupTemplates = path.join(input.artifactRoot, '.specrails', 'setup-templates')
   mk(path.join(setupTemplates, 'agents'))
   mk(path.join(setupTemplates, 'commands'))
   mk(path.join(setupTemplates, 'skills'))
@@ -275,9 +333,15 @@ export function scaffoldInstallation(input: ScaffoldInput): ScaffoldResult {
   mk(path.join(setupTemplates, 'settings'))
 
   // --- .gitignore hygiene ---
-  const gitignoreEntries = ['.claude/agent-memory/', '.specrails/']
-  if (input.provider === 'gemini') gitignoreEntries.push('.gemini/agent-memory/')
-  ensureGitignore(input.repoRoot, gitignoreEntries)
+  // Under relocate-always (artifactRoot !== codeRoot) NOTHING Specrails-owned
+  // lands in the repo, so there is nothing to ignore — the gitignore step is a
+  // guarded no-op. It only runs in the legacy in-repo layout where the two roots
+  // coincide.
+  if (input.artifactRoot === input.codeRoot) {
+    const gitignoreEntries = ['.claude/agent-memory/', '.specrails/']
+    if (input.provider === 'gemini') gitignoreEntries.push('.gemini/agent-memory/')
+    ensureGitignore(input.codeRoot, gitignoreEntries)
+  }
 
   // --- Copy bundled templates into setup-templates/ ---
   const templatesSrc = path.join(input.scriptDir, 'templates')
@@ -357,12 +421,453 @@ export function scaffoldInstallation(input: ScaffoldInput): ScaffoldResult {
 
   return {
     existingSetup: detectExistingSetup({
-      repoRoot: input.repoRoot,
+      artifactRoot: input.artifactRoot,
+      codeRoot: input.codeRoot,
       providerDir: input.providerDir,
     }),
     createdDirs,
     copiedFiles,
   }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Bundled-framework split: installFramework + ensureCurrentSymlink +
+// assembleProjectWorkspace. The provider-INVARIANT subtree is materialized ONCE
+// under `<frameworkDir>/<version>/<providerDir>/` and every workspace SYMLINKS
+// it; the per-workspace PROJECT layer (agent-memory, manifest, gemini acks,
+// settings/instructions files) is seeded as real writable files.
+// ───────────────────────────────────────────────────────────────────────────
+
+export interface InstallFrameworkInput {
+  /** Absolute path to the specrails-core package (templates/ + commands/). */
+  scriptDir: string
+  /** Root of the versioned framework store, e.g. `<home>/.specrails/framework`. */
+  frameworkDir: string
+  /** Provider whose static subtree is being materialized. */
+  provider: Provider
+  /** Derived provider dir (`.claude`/`.codex`/`.gemini`). */
+  providerDir: string
+  /** Framework version (the `<version>/` segment). */
+  version: string
+  /** Install Agent Teams commands (team-review / team-debug). */
+  agentTeams?: boolean
+  /** Optional explicit agent allow-list (kept for parity with scaffold). */
+  selectedAgents?: string[]
+}
+
+export interface InstallFrameworkResult {
+  /** `<frameworkDir>/<version>/<providerDir>` — root of the static subtree. */
+  providerFrameworkDir: string
+  /** `<frameworkDir>/<version>` — the version root (also holds setup-templates/). */
+  versionDir: string
+  /** True when a fresh materialization happened; false when the idempotent skip fired. */
+  materialized: boolean
+}
+
+/** Path to the per-version, per-provider materialization marker (manifest hash). */
+function frameworkStampPath(versionDir: string, providerDir: string): string {
+  // Store the stamp OUTSIDE the providerDir so it never leaks into the linked
+  // subtree. `.stamp-<providerDir>.json` is provider-keyed.
+  return path.join(versionDir, `.framework-stamp${providerDir}.json`)
+}
+
+/**
+ * Materialize the provider-INVARIANT framework subtree ONCE into
+ * `<frameworkDir>/<version>/<providerDir>/` (+ `<version>/setup-templates/`).
+ * Idempotent: when the providerDir already exists with a matching stamp it is a
+ * no-op (the second workspace assemble re-uses the same copy). Writes NO
+ * per-workspace state (no agent-memory, no acks, no project-named instruction
+ * files) — those are seeded by `assembleProjectWorkspace`.
+ */
+export function installFramework(input: InstallFrameworkInput): InstallFrameworkResult {
+  const versionDir = path.join(input.frameworkDir, input.version)
+  const providerFrameworkDir = path.join(versionDir, input.providerDir)
+  const stampPath = frameworkStampPath(versionDir, input.providerDir)
+
+  // Idempotency: existing materialization with a matching stamp → skip.
+  if (isDir(providerFrameworkDir) && pathExists(stampPath)) {
+    return { providerFrameworkDir, versionDir, materialized: false }
+  }
+
+  // Reuse scaffoldInstallation's static-placement helpers by pointing
+  // `artifactRoot` at the version dir. `seedProjectDirs: false` keeps the copy
+  // free of per-workspace mutable state. The `codeRoot` is irrelevant to the
+  // STATIC subtree (the project-named instruction files are skipped below), so
+  // we hand it the framework dir to satisfy the contract — and we DELETE any
+  // project-named instruction file the settings helpers wrote.
+  // The SHARED framework store is always the FULL SUPERSET — EVERY agent and the
+  // team commands — so a SECOND project with a DIFFERENT agent selection links
+  // its specialists from the same materialized copy instead of inheriting the
+  // first project's narrower set. Per-project filtering moves to the workspace
+  // LINK step (`linkAgentFiles` via `assembleProjectWorkspace`). `selectedAgents`
+  // / `agentTeams` on the input are intentionally IGNORED here.
+  const staticInput: ScaffoldInput = {
+    scriptDir: input.scriptDir,
+    artifactRoot: versionDir,
+    codeRoot: versionDir,
+    provider: input.provider,
+    providerDir: input.providerDir,
+    agentTeams: true,
+    tier: 'quick',
+    selectedAgents: undefined,
+    materializeAllAgents: true,
+    seedProjectDirs: false,
+  }
+  scaffoldInstallation(staticInput)
+
+  // The settings helpers also emit a project-named root instruction file
+  // (AGENTS.md/GEMINI.md/CLAUDE.md) + (for codex) config.toml / (gemini)
+  // settings.json. The instruction file is per-project → strip it from the
+  // shared copy; the settings file IS provider-invariant and stays as a
+  // link target inside the providerDir.
+  for (const f of ['AGENTS.md', 'GEMINI.md', 'CLAUDE.md']) {
+    rmSync(path.join(versionDir, f), { force: true })
+  }
+
+  writeFileLf(
+    stampPath,
+    `${JSON.stringify({ version: input.version, provider: input.provider, at: new Date().toISOString() }, null, 2)}\n`,
+  )
+  return { providerFrameworkDir, versionDir, materialized: true }
+}
+
+/**
+ * Atomically point `<frameworkDir>/current` at `<version>` so every workspace's
+ * provider links resolve through `current/...` and an update is a single swap.
+ */
+export function ensureCurrentSymlink(frameworkDir: string, version: string): void {
+  const currentPath = path.join(frameworkDir, 'current')
+  const versionDir = path.join(frameworkDir, version)
+  mkdirp(frameworkDir)
+  atomicSymlinkSwap(versionDir, currentPath)
+}
+
+export interface AssembleProjectWorkspaceInput {
+  /** The per-project workspace artifact root (= resolveArtifacts artifactRoot). */
+  workspace: string
+  /** Root of the versioned framework store (the parent of `current/`). */
+  frameworkDir: string
+  /** Provider whose subtrees are linked into the workspace. */
+  provider: Provider
+  /** Derived provider dir (`.claude`/`.codex`/`.gemini`). */
+  providerDir: string
+  /** Framework version (used for the manifest record). */
+  version: string
+  /** The user's real repo (drives PROJECT_NAME + gemini ack keying). */
+  codeRoot: string
+  /** specrails-core package dir (for the manifest hash sources). */
+  scriptDir: string
+  /**
+   * Optional agent allow-list. Drives BOTH which framework agents are LINKED
+   * into the workspace (`linkAgentFiles`) AND which agent-memory dirs are seeded.
+   * Undefined = the CORE trio only (the lean default). The SHARED framework store
+   * is always the full superset; this is where per-project filtering happens.
+   */
+  selectedAgents?: string[]
+  /**
+   * Install the Agent Teams commands (`team-review` / `team-debug`) into the
+   * workspace. The shared framework store always materializes them; when false
+   * the workspace links commands/skills PER-FILE excluding the `team-*` entries.
+   * Defaults to false (lean install — matches the legacy in-place behaviour).
+   */
+  agentTeams?: boolean
+}
+
+export interface AssembleProjectWorkspaceResult {
+  /** Per-linked-subtree mechanism, for diagnostics (copy-fallback loses O(1) swap). */
+  links: Record<string, 'symlink' | 'junction' | 'copy'>
+  /** Agent ids whose memory dirs were seeded as real writable dirs. */
+  seededMemoryAgents: string[]
+}
+
+/**
+ * Assemble a project workspace with NO network and NO re-materialization: (a)
+ * SYMLINK the static providerDir subtrees from `<frameworkDir>/current/
+ * <providerDir>/` into `<workspace>/<providerDir>/`, then (b) seed the PROJECT
+ * layer as real writable files (agent-memory dirs, the manifest, project-named
+ * instruction/settings files, gemini headless acks re-hashed against the LINKED
+ * files). `agent-memory/` is NEVER linked.
+ */
+export function assembleProjectWorkspace(
+  input: AssembleProjectWorkspaceInput,
+): AssembleProjectWorkspaceResult {
+  const currentProviderDir = path.join(input.frameworkDir, 'current', input.providerDir)
+  const workspaceProviderDir = path.join(input.workspace, input.providerDir)
+  mkdirp(workspaceProviderDir)
+
+  // (a) Link the static subtrees that exist in the framework copy.
+  //
+  // `agents/` is linked PER-FILE (a real workspace dir holding one symlink per
+  // framework agent) so the workspace can also carry user/desktop `custom-*.md`
+  // agents — a RESERVED region the installer must never touch. Every other
+  // subtree (`commands/`, `skills/`, `rules/`) holds no user files and is linked
+  // as a whole directory (cheapest, single inode).
+  // Per-project AGENT selection: link only the selected framework agents (∪ the
+  // CORE trio, minus the quick-excluded product agents) — the shared store holds
+  // the full superset, so a project's narrower pick links a SUBSET. Undefined ⇒
+  // CORE trio only. `custom-*.md` is always preserved (reserved path).
+  const selectedAgentSet = input.selectedAgents
+    ? new Set([...input.selectedAgents, ...CORE_AGENTS])
+    : new Set([...CORE_AGENTS])
+  const agentTeams = input.agentTeams ?? false
+
+  const links: Record<string, 'symlink' | 'junction' | 'copy'> = {}
+  for (const sub of LINKED_PROVIDER_SUBTREES[input.provider]) {
+    const target = path.join(currentProviderDir, sub)
+    if (!pathExists(target)) continue
+    const dest = path.join(workspaceProviderDir, sub)
+    if (sub === 'agents') {
+      links[sub] = linkAgentFiles(target, dest, selectedAgentSet)
+    } else if (!agentTeams && subtreeHasTeamEntries(target)) {
+      // Lean install AND the superset store actually carries `team-*` entries:
+      // link this subtree PER-FILE, excluding the team commands/skills. The
+      // common case (no team-* in the store) keeps the cheap whole-dir symlink
+      // below — preserving the single-inode contract.
+      links[sub] = linkSubtreeExcludingTeams(target, dest)
+    } else {
+      links[sub] = symlinkOrCopy(target, dest)
+    }
+  }
+
+  // Link the provider-invariant settings file (codex config.toml / gemini
+  // settings.json) when the framework has one and the user has not authored a
+  // local override in the workspace.
+  const settingsFile =
+    input.provider === 'codex' ? 'config.toml' : input.provider === 'gemini' ? 'settings.json' : null
+  if (settingsFile) {
+    const settingsTarget = path.join(currentProviderDir, settingsFile)
+    const settingsLink = path.join(workspaceProviderDir, settingsFile)
+    if (pathExists(settingsTarget) && !pathExists(settingsLink)) {
+      links[settingsFile] = symlinkOrCopy(settingsTarget, settingsLink)
+    }
+  }
+
+  // (b) Seed the PROJECT layer (real writable files / dirs).
+  const seededMemoryAgents = seedProjectLayer(input, currentProviderDir)
+
+  // Manifest: record the consumed framework version. `buildManifest` hashes the
+  // package's templates/ + commands (provenance), written under the workspace.
+  const manifest = buildManifest({
+    scriptDir: input.scriptDir,
+    repoRoot: input.workspace,
+    version: input.version,
+  })
+  writeManifestFiles(input.workspace, manifest)
+
+  return { links, seededMemoryAgents }
+}
+
+/**
+ * Seed the per-workspace PROJECT layer: real agent-memory dirs (+ explanations/),
+ * the project-named instruction file, and — for gemini — the headless
+ * acknowledgments re-hashed against the LINKED agent files. Returns the agent
+ * ids whose memory dirs were created.
+ */
+function seedProjectLayer(input: AssembleProjectWorkspaceInput, currentProviderDir: string): string[] {
+  const selected = input.selectedAgents
+    ? new Set([...input.selectedAgents, ...CORE_AGENTS])
+    : new Set([...CORE_AGENTS])
+  // Discover which agents the framework actually placed (so memory dirs match
+  // the linked agent set), intersected with the selection.
+  const agentsLinkDir = path.join(currentProviderDir, 'agents')
+  const placedAgentIds: string[] = []
+  if (isDir(agentsLinkDir)) {
+    for (const entry of listDir(agentsLinkDir)) {
+      const name = path.basename(entry)
+      if (!name.endsWith('.md')) continue
+      const id = name.slice(0, -3)
+      if (selected.has(id) && !QUICK_EXCLUDED_AGENTS.has(id)) placedAgentIds.push(id)
+    }
+  }
+
+  const seededMemoryAgents: string[] = []
+  if (input.provider === 'claude') {
+    for (const id of placedAgentIds) {
+      mkdirp(path.join(input.workspace, '.claude', 'agent-memory', id))
+      seededMemoryAgents.push(id)
+      if (EXPLANATION_AUTHORS.has(id)) {
+        mkdirp(path.join(input.workspace, '.claude', 'agent-memory', 'explanations'))
+      }
+    }
+  } else if (input.provider === 'gemini') {
+    for (const id of placedAgentIds) {
+      mkdirp(path.join(input.workspace, '.gemini', 'agent-memory', id))
+      seededMemoryAgents.push(id)
+    }
+  }
+
+  // Project-named instruction file (codex AGENTS.md / gemini GEMINI.md). Reuse
+  // the same sentinel-upsert helpers via the settings appliers, scoped so they
+  // ONLY emit the instruction file (the settings file is already linked above).
+  if (input.provider === 'codex') {
+    seedInstructionFile(
+      path.join(input.workspace, 'AGENTS.md'),
+      renderInitialAgentsMd(input.codeRoot),
+    )
+  } else if (input.provider === 'gemini') {
+    seedInstructionFile(
+      path.join(input.workspace, 'GEMINI.md'),
+      renderInitialGeminiMd(input.codeRoot),
+    )
+    // Gemini headless acks: hash the LINKED agent files (read through the
+    // symlink) keyed on the real repo so `gemini -p` trusts them with no prompt.
+    try {
+      writeGeminiAgentAcknowledgments(input.codeRoot, placedAgentIds, input.workspace)
+    } catch (err) {
+      warn(`gemini agent pre-acknowledgment skipped: ${(err as Error).message}`)
+    }
+  }
+
+  return seededMemoryAgents
+}
+
+/**
+ * Per-file link the framework `agents/` into a REAL workspace `agents/` dir.
+ * Keeps `custom-*.md` (and any other user-authored file that the framework does
+ * NOT provide) byte-untouched — the reserved-paths contract — while pointing
+ * every SELECTED framework-owned agent at the shared read-only copy.
+ *
+ * `selectedIds` is the per-project agent allow-list (already unioned with the
+ * CORE trio by the caller). Only framework agents whose id is in it AND not in
+ * `QUICK_EXCLUDED_AGENTS` are linked — the shared framework store is the full
+ * superset, so this is where per-project filtering lands. `undefined` ⇒ link
+ * every framework agent (used by the legacy callers / parity tests).
+ *
+ * Returns the dominant mechanism used across the linked files (`copy` if any
+ * file fell back to copy — the normal case on Windows without Developer Mode).
+ */
+function linkAgentFiles(
+  frameworkAgentsDir: string,
+  workspaceAgentsDir: string,
+  selectedIds?: Set<string>,
+): 'symlink' | 'junction' | 'copy' {
+  mkdirp(workspaceAgentsDir)
+  // Names the framework currently PROVIDES (regardless of selection) — used to
+  // distinguish a framework-owned file from a user `custom-*.md` during cleanup.
+  const frameworkProvided = new Set<string>()
+  // Names actually LINKED this pass (the selected subset).
+  const linkedNames = new Set<string>()
+  let mechanism: 'symlink' | 'junction' | 'copy' = 'symlink'
+  for (const src of listDir(frameworkAgentsDir)) {
+    const name = path.basename(src)
+    if (!name.endsWith('.md')) continue
+    frameworkProvided.add(name)
+    const id = name.slice(0, -3)
+    if (selectedIds && (!selectedIds.has(id) || QUICK_EXCLUDED_AGENTS.has(id))) continue
+    linkedNames.add(name)
+    const m = symlinkOrCopy(src, path.join(workspaceAgentsDir, name))
+    if (m === 'copy') mechanism = 'copy'
+    else if (m === 'junction' && mechanism !== 'copy') mechanism = 'junction'
+  }
+  // Drop STALE framework artifacts in the workspace agents dir — both prior-
+  // version symlinks AND copy-fallback files (Windows) that are no longer linked
+  // this pass (a dropped agent, or one deselected). NEVER remove a user file:
+  // `custom-*.md` and agent-memory are reserved. The discriminator is "the
+  // framework owns this name (it's currently provided OR it was a previous
+  // framework link/copy that the framework no longer provides)" — we approximate
+  // it as: remove any entry NOT in `linkedNames` that is either a symlink (old
+  // framework link) OR a NON-custom framework-shaped file the framework once
+  // provided. `custom-*.md` is always skipped.
+  for (const existing of listDir(workspaceAgentsDir)) {
+    const name = path.basename(existing)
+    if (linkedNames.has(name)) continue
+    if (name.startsWith('custom-')) continue // reserved user agent — never touch
+    if (isSymlink(existing)) {
+      // A prior framework symlink no longer selected/provided → stale, drop it.
+      removePath(existing)
+      continue
+    }
+    // A copy-fallback framework file (Windows): a non-symlink `.md` that the
+    // framework provides (or provided) but is not a user custom agent. Remove it
+    // so a version swap or a deselect cleans up the copied agent. Files the
+    // framework never provided (genuine user agents) are left untouched.
+    if (name.endsWith('.md') && (frameworkProvided.has(name) || isFrameworkAgentName(name))) {
+      removePath(existing)
+    }
+  }
+  return mechanism
+}
+
+/**
+ * True when `name` (an `<id>.md`) matches a framework-owned agent id (`sr-*`).
+ * Used to identify a stale COPY-fallback framework agent on Windows that the
+ * current framework version no longer provides, so it can be cleaned up on a
+ * version swap. `custom-*.md` (handled by the caller) and any non-`sr-` user
+ * file are deliberately excluded.
+ */
+function isFrameworkAgentName(name: string): boolean {
+  return /^sr-[a-z0-9-]+\.md$/.test(name)
+}
+
+/**
+ * True when a framework subtree (`commands`/`skills`) contains any `team-*`
+ * entry (a `team-*.md` file or a `team-*` skill dir), recursively. Gates the
+ * per-file team-excluding link path: when no team entries exist the workspace
+ * keeps the cheap whole-dir symlink. Recurses into real subdirs (e.g.
+ * `.claude/commands/specrails/`).
+ */
+function subtreeHasTeamEntries(subtreeDir: string): boolean {
+  for (const entry of listDir(subtreeDir)) {
+    const name = path.basename(entry)
+    if (/^team-/.test(name) || /^team-/.test(name.replace(/\.md$/, ''))) return true
+    if (isDir(entry) && !isSymlink(entry) && subtreeHasTeamEntries(entry)) return true
+  }
+  return false
+}
+
+/**
+ * Link a whole framework subtree (`commands`/`skills`) into the workspace
+ * PER-FILE, EXCLUDING the Agent-Teams `team-*` entries. Used when `agentTeams`
+ * is off and the shared framework store (always the superset) carries the team
+ * commands the lean install must not surface. Recurses into subdirs (e.g.
+ * `.claude/commands/specrails/`). Returns the dominant mechanism.
+ */
+function linkSubtreeExcludingTeams(
+  frameworkSubtreeDir: string,
+  workspaceSubtreeDir: string,
+): 'symlink' | 'junction' | 'copy' {
+  mkdirp(workspaceSubtreeDir)
+  let mechanism: 'symlink' | 'junction' | 'copy' = 'symlink'
+  const bump = (m: 'symlink' | 'junction' | 'copy') => {
+    if (m === 'copy') mechanism = 'copy'
+    else if (m === 'junction' && mechanism !== 'copy') mechanism = 'junction'
+  }
+  const linkedNames = new Set<string>()
+  for (const src of listDir(frameworkSubtreeDir)) {
+    const name = path.basename(src)
+    // Exclude team commands/skills whether they ship as `team-*.md` files or
+    // `team-*/` skill dirs.
+    if (/^team-/.test(name) || /^team-/.test(name.replace(/\.md$/, ''))) continue
+    linkedNames.add(name)
+    const dest = path.join(workspaceSubtreeDir, name)
+    if (isDir(src) && !isSymlink(src)) {
+      // Recurse: a real framework subdir is mirrored as a real workspace subdir
+      // so a future agentTeams=false re-link can prune team-* inside it too.
+      bump(linkSubtreeExcludingTeams(src, dest))
+    } else {
+      bump(symlinkOrCopy(src, dest))
+    }
+  }
+  // Drop stale framework entries (including team-* left from a prior agentTeams
+  // run) that are no longer linked. Only symlinks/copied framework files — there
+  // are no user files under commands/skills.
+  for (const existing of listDir(workspaceSubtreeDir)) {
+    const name = path.basename(existing)
+    if (linkedNames.has(name)) continue
+    removePath(existing)
+  }
+  return mechanism
+}
+
+/** Write or sentinel-upsert a project instruction file (AGENTS.md/GEMINI.md). */
+function seedInstructionFile(filePath: string, content: string): void {
+  if (!pathExists(filePath)) {
+    writeFileLf(filePath, content)
+    return
+  }
+  const existing = readTextFile(filePath)
+  const next = upsertAgentsMdManagedBlock(existing, extractManagedBlock(content))
+  if (next !== existing) writeFileLf(filePath, next)
 }
 
 function copyBundledCommands(input: ScaffoldInput & { copiedIncrement: (n: number) => void }): void {
@@ -382,7 +887,7 @@ function copyBundledCommands(input: ScaffoldInput & { copiedIncrement: (n: numbe
       if (name === 'setup.md') continue
       if (!input.agentTeams && /^team-/.test(name)) continue
       const skillName = name.replace(/\.md$/, '')
-      const destDir = path.join(input.repoRoot, input.providerDir, 'skills', skillName)
+      const destDir = path.join(input.artifactRoot, input.providerDir, 'skills', skillName)
       // A codex-native override (written for spawn_agent semantics + the
       // correct `.codex/skills/rails/` layout) wins over the claude port.
       // This is the ONLY codex command-placement pass in full tier, so
@@ -407,7 +912,7 @@ function copyBundledCommands(input: ScaffoldInput & { copiedIncrement: (n: numbe
   if (input.provider === 'gemini') {
     // Gemini: each bundled command becomes a TOML custom command under
     // .gemini/commands/specrails/<name>.toml.
-    const destDir = path.join(input.repoRoot, input.providerDir, 'commands', 'specrails')
+    const destDir = path.join(input.artifactRoot, input.providerDir, 'commands', 'specrails')
     let count = 0
     for (const entry of listDir(commandsSrc)) {
       const name = path.basename(entry)
@@ -425,7 +930,7 @@ function copyBundledCommands(input: ScaffoldInput & { copiedIncrement: (n: numbe
   }
 
   // Claude: all bundled commands land under <providerDir>/commands/specrails/.
-  const destDir = path.join(input.repoRoot, input.providerDir, 'commands', 'specrails')
+  const destDir = path.join(input.artifactRoot, input.providerDir, 'commands', 'specrails')
   let count = 0
   for (const entry of listDir(commandsSrc)) {
     const name = path.basename(entry)
@@ -589,10 +1094,12 @@ function writeGeminiCommandFromCommand(args: { src: string; dest: string; descri
  * paths rewritten and `{{MEMORY_PATH}}` pointed at `.gemini/agent-memory/`.
  */
 function writeGeminiAgentFromTemplate(args: {
-  repoRoot: string
+  artifactRoot: string
   src: string
   agentId: string
   placeholders: Record<string, string>
+  /** When false, skip the per-workspace agent-memory mkdir (framework path). */
+  seedProjectDirs?: boolean
 }): void {
   if (!pathExists(args.src)) return
   const { body, description } = stripFrontmatter(readTextFile(args.src))
@@ -612,8 +1119,10 @@ function writeGeminiAgentFromTemplate(args: {
       MEMORY_PATH: `.gemini/agent-memory/${args.agentId}/`,
     }).replace(/\.claude\//g, '.gemini/'),
   )
-  writeFileLf(path.join(args.repoRoot, '.gemini', 'agents', `${args.agentId}.md`), frontmatter + renderedBody)
-  mkdirp(path.join(args.repoRoot, '.gemini', 'agent-memory', args.agentId))
+  writeFileLf(path.join(args.artifactRoot, '.gemini', 'agents', `${args.agentId}.md`), frontmatter + renderedBody)
+  if (args.seedProjectDirs !== false) {
+    mkdirp(path.join(args.artifactRoot, '.gemini', 'agent-memory', args.agentId))
+  }
 }
 
 /**
@@ -622,14 +1131,14 @@ function writeGeminiAgentFromTemplate(args: {
  */
 function placeGeminiAgents(input: ScaffoldInput): SkillsPlacement {
   const result: SkillsPlacement = { placed: 0, skipped: 0, filesCopied: 0 }
-  const agentsSrc = path.join(input.repoRoot, '.specrails', 'setup-templates', 'agents')
+  const agentsSrc = path.join(input.artifactRoot, '.specrails', 'setup-templates', 'agents')
   if (!isDir(agentsSrc)) return result
-  mkdirp(path.join(input.repoRoot, '.gemini', 'agents'))
+  mkdirp(path.join(input.artifactRoot, '.gemini', 'agents'))
   const selectedAgents = input.selectedAgents
     ? new Set([...input.selectedAgents, ...CORE_AGENTS])
     : new Set([...CORE_AGENTS])
   const placeholders = {
-    PROJECT_NAME: path.basename(input.repoRoot),
+    PROJECT_NAME: path.basename(input.codeRoot),
     SECURITY_EXEMPTIONS_PATH: '.gemini/security-exemptions.yaml',
     PERSONA_DIR: '.gemini/agents/personas/',
   }
@@ -638,20 +1147,35 @@ function placeGeminiAgents(input: ScaffoldInput): SkillsPlacement {
     const name = path.basename(src)
     if (!name.endsWith('.md')) continue
     const agentId = name.slice(0, -3)
-    if (!selectedAgents.has(agentId)) continue
-    if (QUICK_EXCLUDED_AGENTS.has(agentId)) {
+    // Superset materialization (installFramework) places EVERY agent; per-project
+    // filtering happens at the workspace LINK step (linkAgentFiles).
+    if (!input.materializeAllAgents && !selectedAgents.has(agentId)) continue
+    if (!input.materializeAllAgents && QUICK_EXCLUDED_AGENTS.has(agentId)) {
       result.skipped++
       continue
     }
-    writeGeminiAgentFromTemplate({ repoRoot: input.repoRoot, src, agentId, placeholders })
+    writeGeminiAgentFromTemplate({
+      artifactRoot: input.artifactRoot,
+      src,
+      agentId,
+      placeholders,
+      seedProjectDirs: input.seedProjectDirs,
+    })
     placedIds.push(agentId)
     result.placed++
     result.filesCopied++
   }
-  try {
-    writeGeminiAgentAcknowledgments(input.repoRoot, placedIds)
-  } catch (err) {
-    warn(`gemini agent pre-acknowledgment skipped: ${(err as Error).message}`)
+  // The pre-acknowledgment is a PER-WORKSPACE seed (keyed on codeRoot, hashing the
+  // workspace's linked agent files). It is skipped when materializing the shared
+  // framework — `assembleProjectWorkspace` re-writes it against the LINKED files.
+  if (input.seedProjectDirs !== false) {
+    try {
+      // Key the acknowledgment on the real repo (codeRoot) so gemini matches the
+      // project, but hash the agent files from the relocated artifactRoot.
+      writeGeminiAgentAcknowledgments(input.codeRoot, placedIds, input.artifactRoot)
+    } catch (err) {
+      warn(`gemini agent pre-acknowledgment skipped: ${(err as Error).message}`)
+    }
   }
   return result
 }
@@ -673,7 +1197,11 @@ function placeGeminiAgents(input: ScaffoldInput): SkillsPlacement {
  * Best-effort: any failure is swallowed by the caller (agents still work once
  * acknowledged interactively).
  */
-export function writeGeminiAgentAcknowledgments(repoRoot: string, agentIds: string[]): void {
+export function writeGeminiAgentAcknowledgments(
+  repoRoot: string,
+  agentIds: string[],
+  agentsBaseDir: string = repoRoot,
+): void {
   if (agentIds.length === 0) return
   const ackPath = path.join(os.homedir(), '.gemini', 'acknowledgments', 'agents.json')
   let store: Record<string, Record<string, string>> = {}
@@ -687,13 +1215,23 @@ export function writeGeminiAgentAcknowledgments(repoRoot: string, agentIds: stri
       // Corrupt/unreadable file — start fresh rather than crash the install.
     }
   }
-  const projectEntry: Record<string, string> = { ...(store[repoRoot] ?? {}) }
+  // The store is KEYED on `agentsBaseDir` — the directory gemini ACTUALLY runs
+  // in when it resolves the project's agents. Under relocation the linked agents
+  // live in the WORKSPACE (rails spawn with cwd=workspace), so the ack must be
+  // keyed on the workspace providerDir base, not the repo; otherwise headless
+  // `gemini -p` looks up `store[<workspace>]`, finds nothing, and the specialised
+  // personas never load. The agent FILES are hashed from `agentsBaseDir` too
+  // (read through the workspace symlinks ⇒ framework file content). When
+  // `agentsBaseDir` defaults to `repoRoot` (legacy in-repo layout, 2-arg call)
+  // the key is byte-identical to before.
+  const ackKey = agentsBaseDir
+  const projectEntry: Record<string, string> = { ...(store[ackKey] ?? {}) }
   for (const agentId of agentIds) {
-    const agentFile = path.join(repoRoot, '.gemini', 'agents', `${agentId}.md`)
+    const agentFile = path.join(agentsBaseDir, '.gemini', 'agents', `${agentId}.md`)
     if (!pathExists(agentFile)) continue
     projectEntry[agentId] = createHash('sha256').update(readTextFile(agentFile)).digest('hex')
   }
-  store[repoRoot] = projectEntry
+  store[ackKey] = projectEntry
   mkdirp(path.dirname(ackPath))
   writeFileLf(ackPath, `${JSON.stringify(store, null, 2)}\n`)
 }
@@ -724,7 +1262,7 @@ function applyGeminiSettings(input: ScaffoldInput): number {
   let written = 0
   const settingsSrc = path.join(input.scriptDir, 'templates', 'settings', 'gemini-settings.json')
   if (pathExists(settingsSrc)) {
-    const dest = path.join(input.repoRoot, input.providerDir, 'settings.json')
+    const dest = path.join(input.artifactRoot, input.providerDir, 'settings.json')
     const template = JSON.parse(readTextFile(settingsSrc)) as Record<string, unknown>
     if (pathExists(dest)) {
       try {
@@ -740,8 +1278,10 @@ function applyGeminiSettings(input: ScaffoldInput): number {
     }
   }
 
-  const geminiMdPath = path.join(input.repoRoot, 'GEMINI.md')
-  const content = renderInitialGeminiMd(input.repoRoot)
+  const geminiMdPath = path.join(input.artifactRoot, 'GEMINI.md')
+  // Project name in the rendered body derives from the real repo (codeRoot),
+  // while the file itself lands under the relocated artifactRoot.
+  const content = renderInitialGeminiMd(input.codeRoot)
   if (!pathExists(geminiMdPath)) {
     writeFileLf(geminiMdPath, content)
     written++
@@ -781,32 +1321,44 @@ function renderInitialGeminiMd(repoRoot: string): string {
   ].join('\n')
 }
 
-function pruneLegacyArtifacts(input: Pick<ScaffoldInput, 'repoRoot' | 'provider' | 'providerDir'>): void {
+function pruneLegacyArtifacts(
+  input: Pick<ScaffoldInput, 'artifactRoot' | 'codeRoot' | 'provider' | 'providerDir'>,
+): void {
   const legacyPaths = [
-    path.join(input.repoRoot, '.specrails', 'bin', 'doctor.sh'),
-    path.join(input.repoRoot, '.specrails', 'setup-templates', '.provider-detection.json'),
-    path.join(input.repoRoot, '.specrails', 'setup-templates', 'settings', 'integration-contract.json'),
-    path.join(input.repoRoot, '.specrails-version'),
+    path.join(input.artifactRoot, '.specrails', 'bin', 'doctor.sh'),
+    path.join(input.artifactRoot, '.specrails', 'setup-templates', '.provider-detection.json'),
+    path.join(input.artifactRoot, '.specrails', 'setup-templates', 'settings', 'integration-contract.json'),
+    path.join(input.artifactRoot, '.specrails-version'),
   ]
 
   if (input.provider === 'codex') {
     // Pre-§18 layout used `.agents/skills/` — prune any leftovers from a
     // legacy install before settling on the canonical `.codex/skills/`.
-    legacyPaths.push(path.join(input.repoRoot, '.agents'))
-    legacyPaths.push(path.join(input.repoRoot, input.providerDir, 'skills', 'setup'))
+    legacyPaths.push(path.join(input.artifactRoot, '.agents'))
+    legacyPaths.push(path.join(input.artifactRoot, input.providerDir, 'skills', 'setup'))
   } else if (input.provider === 'gemini') {
     // Prune a stale WIP skills/ tree + any setup command leftovers.
-    legacyPaths.push(path.join(input.repoRoot, input.providerDir, 'skills'))
-    legacyPaths.push(path.join(input.repoRoot, input.providerDir, 'commands', 'setup.toml'))
-    legacyPaths.push(path.join(input.repoRoot, input.providerDir, 'commands', 'specrails', 'setup.toml'))
+    legacyPaths.push(path.join(input.artifactRoot, input.providerDir, 'skills'))
+    legacyPaths.push(path.join(input.artifactRoot, input.providerDir, 'commands', 'setup.toml'))
+    legacyPaths.push(path.join(input.artifactRoot, input.providerDir, 'commands', 'specrails', 'setup.toml'))
   } else {
-    legacyPaths.push(path.join(input.repoRoot, input.providerDir, 'commands', 'setup.md'))
-    legacyPaths.push(path.join(input.repoRoot, input.providerDir, 'commands', 'specrails', 'setup.md'))
+    legacyPaths.push(path.join(input.artifactRoot, input.providerDir, 'commands', 'setup.md'))
+    legacyPaths.push(path.join(input.artifactRoot, input.providerDir, 'commands', 'specrails', 'setup.md'))
   }
 
+  // Safety invariant: every prune target MUST live inside artifactRoot. Under
+  // relocate-always artifactRoot is the $HOME workspace, so this guarantees the
+  // installer never rmSync's anything inside the user's repo (codeRoot).
+  const artifactRootResolved = path.resolve(input.artifactRoot)
   for (const target of legacyPaths) {
+    const resolved = path.resolve(target)
+    const rel = path.relative(artifactRootResolved, resolved)
+    if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) {
+      warn(`refusing to prune ${target} — outside artifactRoot ${input.artifactRoot}`)
+      continue
+    }
     try {
-      rmSync(target, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 })
+      rmSync(resolved, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 })
     } catch (err) {
       warn(`failed to prune legacy artifact ${target}: ${(err as Error).message}`)
     }
@@ -842,7 +1394,7 @@ function placeQuickTierArtefacts(input: ScaffoldInput): QuickPlacement {
   // command surface (`propose-spec`, `explore-spec`, `retry`, …) as
   // claude.
   if (input.provider === 'codex') {
-    const setupTemplates = path.join(input.repoRoot, '.specrails', 'setup-templates')
+    const setupTemplates = path.join(input.artifactRoot, '.specrails', 'setup-templates')
     const commandsSrc = path.join(setupTemplates, 'commands', 'specrails')
     // Codex-native skill overrides live at `templates/codex-skills/<name>/`.
     // When one exists for a given slash-command name (e.g. `implement`), the
@@ -859,7 +1411,7 @@ function placeQuickTierArtefacts(input: ScaffoldInput): QuickPlacement {
         if (name === 'setup.md') continue
         if (!input.agentTeams && /^team-/.test(name)) continue
         const skillName = name.slice(0, -3)
-        const dest = path.join(input.repoRoot, input.providerDir, 'skills', skillName, 'SKILL.md')
+        const dest = path.join(input.artifactRoot, input.providerDir, 'skills', skillName, 'SKILL.md')
 
         // If a codex-native override exists, ship it verbatim and skip the
         // ported claude body entirely. Mirrors a directory copy in case the
@@ -888,7 +1440,7 @@ function placeQuickTierArtefacts(input: ScaffoldInput): QuickPlacement {
     // <name>.toml. Hand-authored orchestrator overrides (implement,
     // batch-implement) under templates/gemini-commands/ win verbatim. Agents
     // are placed by placeSkills → placeGeminiAgents (both tiers).
-    const geminiSetupTemplates = path.join(input.repoRoot, '.specrails', 'setup-templates')
+    const geminiSetupTemplates = path.join(input.artifactRoot, '.specrails', 'setup-templates')
     const commandsSrc = path.join(geminiSetupTemplates, 'commands', 'specrails')
     const overridesSrc = path.join(input.scriptDir, 'templates', 'gemini-commands')
     let commandsPlaced = 0
@@ -899,7 +1451,7 @@ function placeQuickTierArtefacts(input: ScaffoldInput): QuickPlacement {
         if (name === 'setup.md') continue
         if (!input.agentTeams && /^team-/.test(name)) continue
         const cmdName = name.slice(0, -3)
-        const dest = path.join(input.repoRoot, input.providerDir, 'commands', 'specrails', `${cmdName}.toml`)
+        const dest = path.join(input.artifactRoot, input.providerDir, 'commands', 'specrails', `${cmdName}.toml`)
         const overrideToml = path.join(overridesSrc, `${cmdName}.toml`)
         if (pathExists(overrideToml)) {
           copyFile(overrideToml, dest)
@@ -912,9 +1464,10 @@ function placeQuickTierArtefacts(input: ScaffoldInput): QuickPlacement {
     return { agents: 0, commands: commandsPlaced, rules: 0, skippedAgents: 0 }
   }
 
-  const setupTemplates = path.join(input.repoRoot, '.specrails', 'setup-templates')
-  const projectName = path.basename(input.repoRoot)
-  const providerDirAbs = path.join(input.repoRoot, input.providerDir)
+  const setupTemplates = path.join(input.artifactRoot, '.specrails', 'setup-templates')
+  // PROJECT_NAME is the real repo's basename, not the relocated workspace dir.
+  const projectName = path.basename(input.codeRoot)
+  const providerDirAbs = path.join(input.artifactRoot, input.providerDir)
 
   const placeholders = {
     PROJECT_NAME: projectName,
@@ -941,9 +1494,12 @@ function placeQuickTierArtefacts(input: ScaffoldInput): QuickPlacement {
       const name = path.basename(src)
       if (!name.endsWith('.md')) continue
       const agentId = name.slice(0, -3)
-      if (selectedAgents && !selectedAgents.has(agentId)) continue
+      // Superset materialization (installFramework) places EVERY agent so any
+      // project's selection can later link from the shared store; per-project
+      // filtering happens at the workspace LINK step, not here.
+      if (!input.materializeAllAgents && selectedAgents && !selectedAgents.has(agentId)) continue
 
-      if (QUICK_EXCLUDED_AGENTS.has(agentId)) {
+      if (!input.materializeAllAgents && QUICK_EXCLUDED_AGENTS.has(agentId)) {
         agentsSkipped++
         continue
       }
@@ -957,12 +1513,16 @@ function placeQuickTierArtefacts(input: ScaffoldInput): QuickPlacement {
       agentsPlaced++
       installedAgentNames.add(agentId)
 
-      // Per-agent memory directory. Created even when empty so
-      // the first run of the agent doesn't error on ENOENT.
-      mkdirp(path.join(input.repoRoot, '.claude', 'agent-memory', agentId))
-
-      if (EXPLANATION_AUTHORS.has(agentId)) {
-        mkdirp(path.join(input.repoRoot, '.claude', 'agent-memory', 'explanations'))
+      // Per-agent memory directory. Created even when empty so the first run of
+      // the agent doesn't error on ENOENT. Skipped when materializing the SHARED
+      // framework (`seedProjectDirs === false`): agent-memory is per-workspace
+      // mutable state seeded later by `seedProjectLayer`, NEVER part of the
+      // read-only framework copy that workspaces symlink.
+      if (input.seedProjectDirs !== false) {
+        mkdirp(path.join(input.artifactRoot, '.claude', 'agent-memory', agentId))
+        if (EXPLANATION_AUTHORS.has(agentId)) {
+          mkdirp(path.join(input.artifactRoot, '.claude', 'agent-memory', 'explanations'))
+        }
       }
     }
   }
@@ -1044,7 +1604,7 @@ function applyCodexSettings(input: ScaffoldInput): number {
   // reasoning_effort etc.
   const configTomlSrc = path.join(settingsSrc, 'codex-config.toml')
   if (pathExists(configTomlSrc)) {
-    const dest = path.join(input.repoRoot, input.providerDir, 'config.toml')
+    const dest = path.join(input.artifactRoot, input.providerDir, 'config.toml')
     const rendered = readTextFile(configTomlSrc).replace(/\{\{MODEL_NAME\}\}/g, 'gpt-5.5-mini')
     writeFileLf(dest, rendered)
     written++
@@ -1053,8 +1613,8 @@ function applyCodexSettings(input: ScaffoldInput): number {
   // AGENTS.md — top-level instructions file the codex CLI loads on startup.
   // Written with a sentinel block so update + enrich passes can refresh the
   // managed content while preserving anything the user added outside it.
-  const agentsMdPath = path.join(input.repoRoot, 'AGENTS.md')
-  const agentsMdContent = renderInitialAgentsMd(input.repoRoot)
+  const agentsMdPath = path.join(input.artifactRoot, 'AGENTS.md')
+  const agentsMdContent = renderInitialAgentsMd(input.codeRoot)
   if (!pathExists(agentsMdPath)) {
     writeFileLf(agentsMdPath, agentsMdContent)
     written++
@@ -1132,12 +1692,12 @@ function upsertAgentsMdManagedBlock(existing: string, managedBlock: string): str
 // `subagent_type` calls have no codex equivalent). Codex DOES get the rails
 // subtree below, sourced from `templates/codex-skills/rails/`.
 function placeSkills(input: ScaffoldInput): SkillsPlacement {
-  const destBase = path.join(input.repoRoot, input.providerDir, 'skills')
+  const destBase = path.join(input.artifactRoot, input.providerDir, 'skills')
   const result: SkillsPlacement = { placed: 0, skipped: 0, filesCopied: 0 }
 
   // Top-level skills — Claude only, generated from the canonical command body.
   if (input.provider === 'claude') {
-    const commandsSrc = path.join(input.repoRoot, '.specrails', 'setup-templates', 'commands', 'specrails')
+    const commandsSrc = path.join(input.artifactRoot, '.specrails', 'setup-templates', 'commands', 'specrails')
     const skillEntries = Object.entries(SKILL_FROM_COMMAND) as Array<
       [string, { command: string; description: string }]
     >

--- a/src/installer/util/fs.test.ts
+++ b/src/installer/util/fs.test.ts
@@ -4,16 +4,23 @@ import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
+import { lstatSync, realpathSync } from 'node:fs'
+
 import { FilesystemError } from './errors.js'
 import {
+  atomicSymlinkSwap,
   copyDir,
   copyFile,
   isDir,
   isFile,
+  isSymlink,
   listDir,
   mkdirp,
   pathExists,
   readTextFile,
+  realpathSafe,
+  removePath,
+  symlinkOrCopy,
   writeFileLf,
 } from './fs.js'
 
@@ -126,6 +133,123 @@ describe('fs', () => {
     it('returns false for nonexistent paths', () => {
       expect(isFile(path.join(tmpDir, 'ghost'))).toBe(false)
       expect(isDir(path.join(tmpDir, 'ghost'))).toBe(false)
+    })
+  })
+
+  describe('symlinkOrCopy / isSymlink', () => {
+    it('symlinks a directory and reports it as a symlink', () => {
+      const target = path.join(tmpDir, 'tgt')
+      writeFileLf(path.join(target, 'a.txt'), 'A')
+      const link = path.join(tmpDir, 'link')
+      const mech = symlinkOrCopy(target, link)
+      // POSIX → symlink; Windows may junction. Either way the content resolves.
+      expect(['symlink', 'junction']).toContain(mech)
+      expect(isSymlink(link)).toBe(true)
+      expect(readTextFile(path.join(link, 'a.txt'))).toBe('A')
+      expect(realpathSync(link)).toBe(realpathSync(target))
+    })
+
+    it('symlinks a single file (copies on Windows where file-symlinks need admin)', () => {
+      const target = path.join(tmpDir, 'file.txt')
+      writeFileLf(target, 'payload')
+      const link = path.join(tmpDir, 'sub', 'file-link.txt')
+      const mech = symlinkOrCopy(target, link)
+      // POSIX → symlink; Windows → copy (file-symlinks require admin / Dev-Mode).
+      expect(['symlink', 'copy']).toContain(mech)
+      if (process.platform !== 'win32') {
+        expect(lstatSync(link).isSymbolicLink()).toBe(true)
+      }
+      expect(readTextFile(link)).toBe('payload')
+    })
+
+    it('is idempotent — a correct existing symlink is left untouched', () => {
+      const target = path.join(tmpDir, 'tgt')
+      mkdirp(target)
+      const link = path.join(tmpDir, 'link')
+      symlinkOrCopy(target, link)
+      expect(symlinkOrCopy(target, link)).toBe('symlink')
+      expect(isSymlink(link)).toBe(true)
+    })
+
+    it('replaces a stale link pointing elsewhere', () => {
+      const a = path.join(tmpDir, 'a')
+      const b = path.join(tmpDir, 'b')
+      writeFileLf(path.join(a, 'x.txt'), 'A')
+      writeFileLf(path.join(b, 'x.txt'), 'B')
+      const link = path.join(tmpDir, 'link')
+      symlinkOrCopy(a, link)
+      symlinkOrCopy(b, link)
+      expect(readTextFile(path.join(link, 'x.txt'))).toBe('B')
+    })
+
+    it('replaces a pre-existing real directory at the link path', () => {
+      const target = path.join(tmpDir, 'tgt')
+      writeFileLf(path.join(target, 'a.txt'), 'A')
+      const link = path.join(tmpDir, 'link')
+      writeFileLf(path.join(link, 'stale.txt'), 'stale')
+      symlinkOrCopy(target, link)
+      expect(isSymlink(link)).toBe(true)
+      expect(pathExists(path.join(link, 'a.txt'))).toBe(true)
+    })
+  })
+
+  describe('removePath', () => {
+    it('removes a file, a directory, and is a no-op on a missing path', () => {
+      const f = path.join(tmpDir, 'f.txt')
+      const d = path.join(tmpDir, 'd')
+      writeFileLf(f, 'x')
+      writeFileLf(path.join(d, 'nested.txt'), 'y')
+      removePath(f)
+      removePath(d)
+      removePath(path.join(tmpDir, 'ghost')) // no throw
+      expect(pathExists(f)).toBe(false)
+      expect(pathExists(d)).toBe(false)
+    })
+
+    it('removes a symlink without following it to the target', () => {
+      const target = path.join(tmpDir, 'tgt')
+      writeFileLf(path.join(target, 'keep.txt'), 'KEEP')
+      const link = path.join(tmpDir, 'link')
+      symlinkOrCopy(target, link)
+      removePath(link)
+      expect(pathExists(link)).toBe(false)
+      // The target survives — the link removal did not cascade.
+      expect(readTextFile(path.join(target, 'keep.txt'))).toBe('KEEP')
+    })
+  })
+
+  describe('realpathSafe', () => {
+    it('resolves an existing path through symlinks', () => {
+      const target = path.join(tmpDir, 'tgt')
+      mkdirp(target)
+      const link = path.join(tmpDir, 'link')
+      symlinkOrCopy(target, link)
+      expect(realpathSafe(link)).toBe(realpathSync(target))
+    })
+
+    it('falls back to the resolved-but-unreal path when the target is absent', () => {
+      const missing = path.join(tmpDir, 'no', 'such')
+      expect(realpathSafe(missing)).toBe(path.resolve(missing))
+    })
+  })
+
+  describe('atomicSymlinkSwap', () => {
+    it('creates then atomically repoints a link to a new target', () => {
+      const v1 = path.join(tmpDir, 'v1')
+      const v2 = path.join(tmpDir, 'v2')
+      writeFileLf(path.join(v1, 'm.txt'), '1')
+      writeFileLf(path.join(v2, 'm.txt'), '2')
+      const current = path.join(tmpDir, 'current')
+
+      atomicSymlinkSwap(v1, current)
+      expect(readTextFile(path.join(current, 'm.txt'))).toBe('1')
+      expect(realpathSync(current)).toBe(realpathSync(v1))
+
+      atomicSymlinkSwap(v2, current)
+      expect(readTextFile(path.join(current, 'm.txt'))).toBe('2')
+      expect(realpathSync(current)).toBe(realpathSync(v2))
+      // No leftover temp link.
+      expect(pathExists(path.join(tmpDir, `.current.tmp-${process.pid}`))).toBe(false)
     })
   })
 })

--- a/src/installer/util/fs.ts
+++ b/src/installer/util/fs.ts
@@ -2,10 +2,17 @@ import { Buffer } from 'node:buffer'
 import {
   cpSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
   readdirSync,
+  readlinkSync,
+  realpathSync,
+  renameSync,
+  rmSync,
   statSync,
+  symlinkSync,
+  unlinkSync,
   writeFileSync,
 } from 'node:fs'
 import path from 'node:path'
@@ -165,5 +172,143 @@ export function isDir(p: string): boolean {
     return statSync(p).isDirectory()
   } catch {
     return false
+  }
+}
+
+/**
+ * True when `p` itself is a symbolic link (does NOT follow the link). Used by
+ * the bundled-framework assembly to detect (and re-create) the per-workspace
+ * provider subtree links. Returns false for a real dir/file or a missing path.
+ */
+export function isSymlink(p: string): boolean {
+  try {
+    return lstatSync(p).isSymbolicLink()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Resolve a path through symlinks to its real on-disk location, falling back to
+ * the resolved-but-unreal path when the target does not exist yet (mirrors
+ * registry.ts's `realpathSafe`).
+ */
+export function realpathSafe(p: string): string {
+  try {
+    return realpathSync(p)
+  } catch {
+    return path.resolve(p)
+  }
+}
+
+/**
+ * Remove a file, directory, or symlink at `p` if present. For a symlink the
+ * link itself is removed (the target is never followed/deleted). Best-effort:
+ * a missing path is a no-op. Used before (re-)creating a workspace link.
+ */
+export function removePath(p: string): void {
+  try {
+    const st = lstatSync(p)
+    if (st.isSymbolicLink() || st.isFile()) {
+      unlinkSync(p)
+    } else {
+      rmSync(p, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 })
+    }
+  } catch {
+    /* nothing there — no-op */
+  }
+}
+
+/**
+ * Ensure `<linkPath>` resolves to `<target>` via a symbolic link, with the same
+ * junction→symlink→copy fallback dance specrails-desktop uses for the project
+ * link (`workspace-manager.ts ensureProjectLink`).
+ *
+ *   1. POSIX: a plain `symlinkSync(target, linkPath, type)`.
+ *   2. Windows: try a junction (dirs) / file symlink first, then a plain symlink.
+ *   3. Both failed (e.g. unprivileged Windows): COPY the target subtree verbatim.
+ *
+ * Returns the mechanism used so the caller can record it (copy-fallback loses the
+ * O(1) `current`-swap update path; the caller may warn). Idempotent: when the
+ * link already points at `target` it is left untouched and `'symlink'` returned.
+ */
+export function symlinkOrCopy(target: string, linkPath: string): 'symlink' | 'junction' | 'copy' {
+  const targetIsDir = isDir(target)
+
+  // Idempotency: an existing correct symlink is left alone.
+  if (isSymlink(linkPath)) {
+    try {
+      const current = readlinkSync(linkPath)
+      const resolved = path.isAbsolute(current) ? current : path.resolve(path.dirname(linkPath), current)
+      if (realpathSafe(resolved) === realpathSafe(target)) return 'symlink'
+    } catch {
+      /* unreadable link — fall through to recreate */
+    }
+  }
+
+  removePath(linkPath)
+  mkdirp(path.dirname(linkPath))
+
+  if (process.platform === 'win32') {
+    if (targetIsDir) {
+      // Directory junctions do NOT require admin/Developer Mode on Windows, so
+      // try one. (A failure falls through to copy.)
+      try {
+        symlinkSync(target, linkPath, 'junction')
+        return 'junction'
+      } catch {
+        /* fall through to copy */
+      }
+    } else {
+      // A FILE symlink on Windows needs admin or Developer Mode and otherwise
+      // throws EPERM — noisy and almost always a failure on a user's machine.
+      // Skip the symlink attempt entirely and COPY the file directly. (The
+      // framework's stale-copy cleanup removes such copied agents on a version
+      // swap.) Dir junctions above are unaffected.
+      copyFile(target, linkPath)
+      return 'copy'
+    }
+  } else {
+    try {
+      symlinkSync(target, linkPath, targetIsDir ? 'dir' : 'file')
+      return 'symlink'
+    } catch {
+      /* fall through to copy */
+    }
+  }
+
+  // Final fallback: copy the subtree (Windows without symlink privilege).
+  if (targetIsDir) {
+    copyDir(target, linkPath)
+  } else {
+    copyFile(target, linkPath)
+  }
+  return 'copy'
+}
+
+/**
+ * Atomically repoint `<linkPath>` at `<target>`: create a sibling temp link,
+ * then `renameSync` over the destination (rename of a symlink is atomic on
+ * POSIX; on Windows the temp+rename pattern still avoids a torn intermediate
+ * state). Used for the `framework/current` indirection swap.
+ */
+export function atomicSymlinkSwap(target: string, linkPath: string): void {
+  mkdirp(path.dirname(linkPath))
+  const tmp = path.join(path.dirname(linkPath), `.${path.basename(linkPath)}.tmp-${process.pid}`)
+  removePath(tmp)
+  const type = isDir(target) ? (process.platform === 'win32' ? 'junction' : 'dir') : 'file'
+  try {
+    symlinkSync(target, tmp, type)
+  } catch {
+    // Windows without symlink privilege: fall back to a non-atomic recreate.
+    removePath(linkPath)
+    symlinkOrCopy(target, linkPath)
+    return
+  }
+  try {
+    renameSync(tmp, linkPath)
+  } catch {
+    removePath(linkPath)
+    renameSync(tmp, linkPath)
   }
 }

--- a/src/installer/util/registry.test.ts
+++ b/src/installer/util/registry.test.ts
@@ -1,0 +1,325 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  allocateSlug,
+  atomicWrite,
+  canonicalizeRepoPath,
+  entryToResolution,
+  frameworkRoot,
+  legacyResolution,
+  lockPath,
+  normalizeKey,
+  readRegistryOrEmpty,
+  REGISTRY_SCHEMA_VERSION,
+  registryPath,
+  resolveArtifacts,
+  slugify,
+  withFileLock,
+  workspaceLayout,
+  type ProjectEntry,
+} from './registry.js'
+
+let home: string
+
+beforeEach(() => {
+  home = mkdtempSync(path.join(os.tmpdir(), 'specrails-registry-test-'))
+  // The `.specrails` dir is created lazily by the module's writers; tests that
+  // pre-plant a registry/lock file directly need it to exist first.
+  mkdirSync(path.join(home, '.specrails'), { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true })
+})
+
+describe('slugify (byte-parity with desktop)', () => {
+  it('lowercases, collapses non-alphanumerics to dashes, trims edge dashes', () => {
+    expect(slugify('Acme API')).toBe('acme-api')
+    expect(slugify('My_Project.v2')).toBe('my-project-v2')
+    expect(slugify('--Edge--')).toBe('edge')
+    expect(slugify('***')).toBe('')
+  })
+})
+
+describe('frameworkRoot', () => {
+  it('lives at <home>/.specrails/framework and shares the registry home', () => {
+    expect(frameworkRoot(home)).toBe(path.join(home, '.specrails', 'framework'))
+    // Same home → framework, registry, and workspaces co-locate.
+    expect(path.dirname(frameworkRoot(home))).toBe(path.dirname(registryPath(home)))
+  })
+})
+
+describe('canonicalizeRepoPath', () => {
+  it('resolves to an absolute realpath, collapsing symlinks', () => {
+    const real = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'real-')))
+    const link = path.join(home, 'link-to-repo')
+    symlinkSync(real, link)
+    expect(canonicalizeRepoPath(link)).toBe(real)
+    rmSync(real, { recursive: true, force: true })
+  })
+
+  it('falls back to the resolved path when realpath throws (non-existent)', () => {
+    const ghost = path.join(home, 'does', 'not', 'exist')
+    expect(canonicalizeRepoPath(ghost)).toBe(path.resolve(ghost))
+  })
+})
+
+describe('normalizeKey', () => {
+  it('case-folds on darwin/win, identity elsewhere', () => {
+    const mixed = '/Users/Javi/Repos/Acme'
+    if (process.platform === 'darwin' || process.platform === 'win32') {
+      expect(normalizeKey(mixed)).toBe(mixed.toLowerCase())
+    } else {
+      expect(normalizeKey(mixed)).toBe(mixed)
+    }
+  })
+})
+
+describe('workspaceLayout', () => {
+  it('derives every sub-path under the workspace dir', () => {
+    const canon = '/Users/javi/repos/acme'
+    const l = workspaceLayout(home, 'acme', canon)
+    expect(l.workspaceDir).toBe(path.join(home, '.specrails', 'projects', 'acme', 'workspace'))
+    expect(l.artifactRoot).toBe(l.workspaceDir)
+    expect(l.codeRoot).toBe(canon)
+    expect(l.stateDir).toBe(path.join(l.workspaceDir, '.claude'))
+    expect(l.ticketsPath).toBe(path.join(l.workspaceDir, '.specrails', 'local-tickets.json'))
+    expect(l.backlogConfigPath).toBe(path.join(l.workspaceDir, '.specrails', 'backlog-config.json'))
+    expect(l.profilesDir).toBe(path.join(l.workspaceDir, '.specrails', 'profiles'))
+  })
+})
+
+describe('legacyResolution', () => {
+  it('keeps every artifact in-repo and flags isLegacy', () => {
+    const canon = '/Users/javi/repos/acme'
+    const r = legacyResolution(canon)
+    expect(r.isLegacy).toBe(true)
+    expect(r.source).toBe('legacy')
+    expect(r.artifactRoot).toBe(canon)
+    expect(r.codeRoot).toBe(canon)
+    expect(r.ticketsPath).toBe(path.join(canon, '.specrails', 'local-tickets.json'))
+  })
+})
+
+describe('allocateSlug', () => {
+  it('returns the basename slug when free', () => {
+    expect(allocateSlug('/a/b/acme-api', new Set())).toBe('acme-api')
+  })
+
+  it('appends -N dedup suffixes for same-basename collisions', () => {
+    expect(allocateSlug('/a/b/acme', new Set(['acme']))).toBe('acme-2')
+    expect(allocateSlug('/a/b/acme', new Set(['acme', 'acme-2']))).toBe('acme-3')
+  })
+
+  it('falls back to "project" for an all-symbol basename', () => {
+    expect(allocateSlug('/a/b/***', new Set())).toBe('project')
+  })
+})
+
+describe('readRegistryOrEmpty (fail-open)', () => {
+  it('returns empty when the file is missing', () => {
+    const reg = readRegistryOrEmpty(home)
+    expect(reg.schemaVersion).toBe(REGISTRY_SCHEMA_VERSION)
+    expect(reg.projects).toEqual({})
+  })
+
+  it('returns empty on corrupt JSON', () => {
+    writeFileSync(registryPath(home), '{ not json', 'utf8')
+    expect(readRegistryOrEmpty(home).projects).toEqual({})
+  })
+
+  it('returns empty when schemaVersion is newer than understood', () => {
+    writeFileSync(
+      registryPath(home),
+      JSON.stringify({ schemaVersion: REGISTRY_SCHEMA_VERSION + 1, projects: { '/x': {} } }),
+      'utf8',
+    )
+    expect(readRegistryOrEmpty(home).projects).toEqual({})
+  })
+
+  it('parses a valid registry', () => {
+    writeFileSync(
+      registryPath(home),
+      JSON.stringify({ schemaVersion: 1, projects: { '/x': { slug: 'x' } } }),
+      'utf8',
+    )
+    expect(readRegistryOrEmpty(home).projects['/x']).toBeDefined()
+  })
+})
+
+describe('atomicWrite', () => {
+  it('writes the file and leaves no temp behind', () => {
+    const target = path.join(home, 'sub', 'out.json')
+    atomicWrite(target, '{"a":1}\n')
+    expect(readFileSync(target, 'utf8')).toBe('{"a":1}\n')
+    const leftovers = readdirSync(path.dirname(target)).filter((f) => f.includes('.tmp-'))
+    expect(leftovers).toEqual([])
+  })
+})
+
+describe('withFileLock', () => {
+  it('runs fn and releases the lock', () => {
+    const result = withFileLock(home, () => 42)
+    expect(result).toBe(42)
+    expect(existsSync(lockPath(home))).toBe(false)
+  })
+
+  it('breaks a stale lock (older than TTL)', () => {
+    // Plant a stale lock with an ancient mtime.
+    writeFileSync(lockPath(home), '')
+    const ancient = Date.now() / 1000 - 120
+    utimesSync(lockPath(home), ancient, ancient)
+    const result = withFileLock(home, () => 'ran')
+    expect(result).toBe('ran')
+    expect(existsSync(lockPath(home))).toBe(false)
+  })
+
+  it('FAILS CLOSED — throws when a fresh lock is held past the deadline (no lost-update)', () => {
+    // A FRESH (non-stale) lock that is never released. The acquire spins until
+    // the 2s deadline, then must THROW rather than run `fn()` without
+    // exclusivity (which would lost-update the registry across core+desktop).
+    writeFileSync(lockPath(home), '')
+    const now = Date.now() / 1000
+    utimesSync(lockPath(home), now, now)
+    let ran = false
+    expect(() =>
+      withFileLock(home, () => {
+        ran = true
+        return 'should-not-run'
+      }),
+    ).toThrow(/registry lock acquisition timed out/)
+    expect(ran).toBe(false)
+    // The held lock is left intact (we did NOT own it, so we must not remove it).
+    expect(existsSync(lockPath(home))).toBe(true)
+  }, 10_000)
+
+  it('writes a unique token into the lock file while held', () => {
+    let tokenWhileHeld = ''
+    withFileLock(home, () => {
+      tokenWhileHeld = readFileSync(lockPath(home), 'utf8')
+    })
+    expect(tokenWhileHeld.length).toBeGreaterThan(0)
+    expect(tokenWhileHeld).toContain(String(process.pid))
+  })
+
+  it('a stale-reclaimed lock carries the NEW owner token and is released by that owner', () => {
+    const lp = lockPath(home)
+    writeFileSync(lp, 'someone-elses-token')
+    const before = readFileSync(lp, 'utf8')
+    const ancient = Date.now() / 1000 - 120
+    utimesSync(lp, ancient, ancient)
+    const result = withFileLock(home, () => {
+      expect(readFileSync(lp, 'utf8')).not.toBe(before)
+      return 'ran'
+    })
+    expect(result).toBe('ran')
+    expect(existsSync(lp)).toBe(false)
+  })
+})
+
+describe('entryToResolution', () => {
+  it('flattens a stored entry, isLegacy=false', () => {
+    const entry: ProjectEntry = {
+      repoPath: '/r',
+      slug: 's',
+      workspaceDir: '/w',
+      artifactRoot: '/w',
+      codeRoot: '/r',
+      stateDir: '/w/.claude',
+      ticketsPath: '/w/.specrails/local-tickets.json',
+      backlogConfigPath: '/w/.specrails/backlog-config.json',
+      profilesDir: '/w/.specrails/profiles',
+      pluginsStateDir: '/w/.specrails/plugins',
+      fileSummariesDir: '/w/.specrails/file-summaries',
+      providers: ['claude'],
+      primaryProvider: 'claude',
+      source: 'desktop',
+    }
+    const r = entryToResolution('k', entry)
+    expect(r.isLegacy).toBe(false)
+    expect(r.source).toBe('desktop')
+    expect(r.ticketsPath).toBe('/w/.specrails/local-tickets.json')
+  })
+})
+
+describe('resolveArtifacts', () => {
+  it('reader without an entry falls back to legacy in-repo layout', () => {
+    const repo = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'repo-')))
+    const r = resolveArtifacts(repo, { home, allocate: false })
+    expect(r.isLegacy).toBe(true)
+    expect(r.artifactRoot).toBe(repo)
+    expect(existsSync(registryPath(home))).toBe(false) // reader never writes
+    rmSync(repo, { recursive: true, force: true })
+  })
+
+  it('allocate creates + persists an entry, with defaults', () => {
+    const repo = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'acme-')))
+    const r = resolveArtifacts(repo, { home, allocate: true, now: '2026-01-01T00:00:00.000Z' })
+    expect(r.isLegacy).toBe(false)
+    expect(r.source).toBe('core-standalone')
+    expect(r.providers).toEqual(['claude'])
+    expect(r.primaryProvider).toBe('claude')
+    expect(r.artifactRoot).toBe(path.join(home, '.specrails', 'projects', r.slug, 'workspace'))
+    const persisted = readRegistryOrEmpty(home)
+    expect(persisted.projects[r.key]!.createdAt).toBe('2026-01-01T00:00:00.000Z')
+    rmSync(repo, { recursive: true, force: true })
+  })
+
+  it('is idempotent: second resolve returns the same slug without re-allocating', () => {
+    const repo = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'acme-')))
+    const first = resolveArtifacts(repo, { home, allocate: true })
+    const second = resolveArtifacts(repo, { home, allocate: true })
+    const third = resolveArtifacts(repo, { home, allocate: false })
+    expect(second.slug).toBe(first.slug)
+    expect(third.slug).toBe(first.slug)
+    expect(third.isLegacy).toBe(false)
+    expect(Object.keys(readRegistryOrEmpty(home).projects)).toHaveLength(1)
+    rmSync(repo, { recursive: true, force: true })
+  })
+
+  it('two repos with the same basename get distinct slugs', () => {
+    const base = mkdtempSync(path.join(os.tmpdir(), 'multi-'))
+    const a = path.join(base, 'a', 'acme')
+    const b = path.join(base, 'b', 'acme')
+    mkdirSync(a, { recursive: true })
+    mkdirSync(b, { recursive: true })
+    const ra = resolveArtifacts(a, { home, allocate: true })
+    const rb = resolveArtifacts(b, { home, allocate: true })
+    expect(ra.slug).toBe('acme')
+    expect(rb.slug).toBe('acme-2')
+    rmSync(base, { recursive: true, force: true })
+  })
+
+  it('records the desktop allocator + desktopProjectId', () => {
+    const repo = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'desk-')))
+    const r = resolveArtifacts(repo, {
+      home,
+      allocate: true,
+      allocator: 'desktop',
+      providers: ['claude', 'codex'],
+      desktopProjectId: 'uuid-123',
+      coreVersion: '4.9.0',
+    })
+    expect(r.source).toBe('desktop')
+    expect(r.providers).toEqual(['claude', 'codex'])
+    const entry = readRegistryOrEmpty(home).projects[r.key]!
+    expect(entry.desktopProjectId).toBe('uuid-123')
+    expect(entry.coreVersion).toBe('4.9.0')
+    rmSync(repo, { recursive: true, force: true })
+  })
+})

--- a/src/installer/util/registry.ts
+++ b/src/installer/util/registry.ts
@@ -1,0 +1,456 @@
+/**
+ * Shared artifact registry — the contract that lets specrails-core place,
+ * and specrails-desktop read, a repo's relocated artifacts OUTSIDE the repo,
+ * under `$HOME/.specrails/projects/<slug>/workspace`.
+ *
+ * Single source of truth: `$HOME/.specrails/registry.json`, an inspectable,
+ * schema-versioned JSON file keyed by the **canonical realpath of the repo**.
+ * specrails-desktop is the primary writer (a projection of its `desktop.sqlite`);
+ * specrails-core reads it and, when run standalone, allocates its own entry.
+ *
+ * Design contract: `docs/internals/global-artifacts-alignment-contract.md`
+ * (in the specrails-desktop repo). The slug algorithm, canonical-key rule,
+ * atomic-write rule and lock protocol here MUST stay byte-identical to the
+ * desktop-side implementation — the correctness of the cross-tool contract
+ * depends on both tools resolving the same repo to the same paths.
+ *
+ * Everything in this module is synchronous to fit the installer's sync flow.
+ */
+
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+/** Registry schema version. A reader that sees a higher value MUST treat all
+ *  entries as absent (legacy fallback), never mis-parse. */
+export const REGISTRY_SCHEMA_VERSION = 1
+
+/** Who owns/allocated an entry. Encodes the single-writer-at-a-time rule. */
+export type RegistrySource = 'desktop' | 'core-standalone'
+
+/** One repo's relocated-artifact locations. All paths are absolute and in the
+ *  host platform's native separator; consumers treat them as opaque. */
+export interface ProjectEntry {
+  /** The canonical realpath of the repo (mirror of the map key). */
+  repoPath: string
+  /** Shared slug — MUST equal desktop.sqlite `projects.slug` for the same repo. */
+  slug: string
+  /** `$HOME/.specrails/projects/<slug>/workspace` — root of all relocated artifacts. */
+  workspaceDir: string
+  /** The dir core treats as its `.specrails`/install root instead of repoRoot (= workspaceDir). */
+  artifactRoot: string
+  /** Always the repo (= repoPath); carries the `openspec/**` + worktree carve-outs. */
+  codeRoot: string
+  /** Runtime-state base (agent-memory, pipeline-state, …). Injected as SPECRAILS_STATE_DIR. */
+  stateDir: string
+  /** Absolute path to the relocated local-tickets.json. Injected as SPECRAILS_TICKETS_PATH. */
+  ticketsPath: string
+  /** Absolute path to backlog-config.json (Jira read-only switch). Injected as SPECRAILS_BACKLOG_CONFIG_PATH. */
+  backlogConfigPath: string
+  /** Relocated `.specrails/profiles/`. Injected as SPECRAILS_PROFILES_DIR. */
+  profilesDir: string
+  /** Relocated `.specrails/plugins/` (desktop-only; present for inspectability). */
+  pluginsStateDir: string
+  /** Relocated `.specrails/file-summaries/` (desktop-only). */
+  fileSummariesDir: string
+  /** Installed providers; mirror of desktop.sqlite `projects.providers`. */
+  providers: string[]
+  /** providers[0]; mirror of desktop.sqlite `projects.provider`. */
+  primaryProvider: string
+  /** The `specrails-version` pin (name/format frozen; only location moved). */
+  coreVersion?: string
+  createdAt?: string
+  lastInstallAt?: string
+  /** Single-owner-at-a-time marker; governs reconciliation. */
+  source: RegistrySource
+  /** desktop.sqlite projects.id when source='desktop', for robust repo-move re-link. */
+  desktopProjectId?: string
+}
+
+/** On-disk shape of `registry.json`. */
+export interface RegistryFile {
+  schemaVersion: number
+  generator?: string
+  updatedAt?: string
+  /** Map: canonical-repo-key -> ProjectEntry. */
+  projects: Record<string, ProjectEntry>
+}
+
+/** The flattened result both tools consume. */
+export interface Resolution {
+  /** Normalized map key. */
+  key: string
+  repoPath: string
+  slug: string
+  workspaceDir: string
+  artifactRoot: string
+  codeRoot: string
+  stateDir: string
+  ticketsPath: string
+  backlogConfigPath: string
+  profilesDir: string
+  pluginsStateDir: string
+  fileSummariesDir: string
+  providers: string[]
+  primaryProvider: string
+  source: RegistrySource | 'legacy'
+  /** True when there is no registry entry and we fell back to the in-repo layout. */
+  isLegacy: boolean
+}
+
+export interface ResolveOptions {
+  /** When true, allocate + persist an entry if none exists. Readers pass false. */
+  allocate?: boolean
+  /** Who is allocating (only consulted when allocate=true). Default 'core-standalone'. */
+  allocator?: RegistrySource
+  /** Override `$HOME` (tests). Default `os.homedir()`. */
+  home?: string
+  /** Providers to record on allocation. Default ['claude']. */
+  providers?: string[]
+  coreVersion?: string
+  desktopProjectId?: string
+  /** Override timestamp (tests). */
+  now?: string
+}
+
+/**
+ * Slug derivation — byte-identical to specrails-desktop's `slugify`
+ * (`server/desktop-router.ts`). Do not "improve" it; parity is the contract.
+ */
+export function slugify(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+}
+
+/** `$HOME` for the registry, overridable for tests. */
+export function resolveHome(home?: string): string {
+  return home ?? process.env.SPECRAILS_REGISTRY_HOME ?? os.homedir()
+}
+
+/** Absolute path to `registry.json`. */
+export function registryPath(home?: string): string {
+  return path.join(resolveHome(home), '.specrails', 'registry.json')
+}
+
+/**
+ * Absolute path to the versioned framework store
+ * (`<home>/.specrails/framework`). The bundled-framework split materializes the
+ * provider-invariant subtree to `<frameworkDir>/<version>/<providerDir>/` once
+ * and every workspace symlinks `<frameworkDir>/current/<providerDir>/...`. Shares
+ * the SAME home as the registry so framework, registry, and workspaces co-locate
+ * (and tests pinning `SPECRAILS_REGISTRY_HOME` redirect all three together).
+ */
+export function frameworkRoot(home?: string): string {
+  return path.join(resolveHome(home), '.specrails', 'framework')
+}
+
+/** Absolute path to the advisory lock file. */
+export function lockPath(home?: string): string {
+  return registryPath(home) + '.lock'
+}
+
+/** `fs.realpathSync` that falls back to the resolved-but-unreal path on error
+ *  (the path may not exist yet, or be on a volume that rejects realpath). */
+export function realpathSafe(abs: string): string {
+  try {
+    return realpathSync(abs)
+  } catch {
+    return abs
+  }
+}
+
+/** Case-fold the key on case-insensitive platforms (macOS, Windows) so two
+ *  spellings of the same path map to one entry. The stored `repoPath` keeps
+ *  its canonical case; only the index key is folded. */
+export function normalizeKey(canon: string): string {
+  if (process.platform === 'darwin' || process.platform === 'win32') {
+    return canon.toLowerCase()
+  }
+  return canon
+}
+
+/** Canonical repo path: resolve to absolute, then realpath (collapses symlinks). */
+export function canonicalizeRepoPath(repoPathInput: string): string {
+  return realpathSafe(path.resolve(repoPathInput))
+}
+
+/** The per-project sub-path layout under a workspace dir. Single source of the
+ *  layout so writer and (allocation) reader never disagree. */
+export function workspaceLayout(home: string, slug: string, canon: string): Omit<
+  ProjectEntry,
+  'providers' | 'primaryProvider' | 'coreVersion' | 'createdAt' | 'lastInstallAt' | 'source' | 'desktopProjectId'
+> {
+  const workspaceDir = path.join(resolveHome(home), '.specrails', 'projects', slug, 'workspace')
+  const specrailsDir = path.join(workspaceDir, '.specrails')
+  return {
+    repoPath: canon,
+    slug,
+    workspaceDir,
+    artifactRoot: workspaceDir,
+    codeRoot: canon,
+    stateDir: path.join(workspaceDir, '.claude'),
+    ticketsPath: path.join(specrailsDir, 'local-tickets.json'),
+    backlogConfigPath: path.join(specrailsDir, 'backlog-config.json'),
+    profilesDir: path.join(specrailsDir, 'profiles'),
+    pluginsStateDir: path.join(specrailsDir, 'plugins'),
+    fileSummariesDir: path.join(specrailsDir, 'file-summaries'),
+  }
+}
+
+/** The in-repo layout, used when there is no registry entry (legacy fallback). */
+export function legacyResolution(canon: string): Resolution {
+  const specrailsDir = path.join(canon, '.specrails')
+  return {
+    key: normalizeKey(canon),
+    repoPath: canon,
+    slug: '',
+    workspaceDir: canon,
+    artifactRoot: canon,
+    codeRoot: canon,
+    stateDir: path.join(canon, '.claude'),
+    ticketsPath: path.join(specrailsDir, 'local-tickets.json'),
+    backlogConfigPath: path.join(specrailsDir, 'backlog-config.json'),
+    profilesDir: path.join(specrailsDir, 'profiles'),
+    pluginsStateDir: path.join(specrailsDir, 'plugins'),
+    fileSummariesDir: path.join(specrailsDir, 'file-summaries'),
+    providers: [],
+    primaryProvider: '',
+    source: 'legacy',
+    isLegacy: true,
+  }
+}
+
+/** Flatten a stored entry into a Resolution. */
+export function entryToResolution(key: string, entry: ProjectEntry): Resolution {
+  return {
+    key,
+    repoPath: entry.repoPath,
+    slug: entry.slug,
+    workspaceDir: entry.workspaceDir,
+    artifactRoot: entry.artifactRoot,
+    codeRoot: entry.codeRoot,
+    stateDir: entry.stateDir,
+    ticketsPath: entry.ticketsPath,
+    backlogConfigPath: entry.backlogConfigPath,
+    profilesDir: entry.profilesDir,
+    pluginsStateDir: entry.pluginsStateDir,
+    fileSummariesDir: entry.fileSummariesDir,
+    providers: entry.providers,
+    primaryProvider: entry.primaryProvider,
+    source: entry.source,
+    isLegacy: false,
+  }
+}
+
+/**
+ * Total, fail-open read. A missing file, a parse error, or a `schemaVersion`
+ * greater than we understand all yield an empty registry, so a caller treats
+ * it as "no entry" and (if allocating) writes a fresh, understood entry rather
+ * than crashing. Biases toward availability over strict consistency — correct
+ * for a local, inspectable file.
+ */
+export function readRegistryOrEmpty(home?: string): RegistryFile {
+  const empty: RegistryFile = { schemaVersion: REGISTRY_SCHEMA_VERSION, projects: {} }
+  const p = registryPath(home)
+  if (!existsSync(p)) return empty
+  try {
+    const parsed = JSON.parse(readFileSync(p, 'utf8')) as RegistryFile
+    if (
+      !parsed ||
+      typeof parsed !== 'object' ||
+      typeof parsed.schemaVersion !== 'number' ||
+      parsed.schemaVersion > REGISTRY_SCHEMA_VERSION ||
+      typeof parsed.projects !== 'object' ||
+      parsed.projects === null
+    ) {
+      return empty
+    }
+    return parsed
+  } catch {
+    return empty
+  }
+}
+
+/** Write `data` to `filePath` atomically: temp file in the same dir, fsync,
+ *  rename. A reader (even without the lock) only ever sees a complete old or
+ *  new file — the lock serialises writers, the rename protects readers. */
+export function atomicWrite(filePath: string, data: string): void {
+  const dir = path.dirname(filePath)
+  mkdirSync(dir, { recursive: true })
+  // Deterministic-but-unique temp name (no Math.random/Date dependency for the
+  // name itself); collisions are impossible because the lock serialises writers.
+  const tmp = path.join(dir, `.${path.basename(filePath)}.tmp-${process.pid}`)
+  const fd = openSync(tmp, 'w')
+  try {
+    writeFileSync(fd, data)
+    fsyncSync(fd)
+  } finally {
+    closeSync(fd)
+  }
+  renameSync(tmp, filePath)
+}
+
+/** Synchronous sleep without busy-spinning the CPU. */
+function syncSleep(ms: number): void {
+  const shared = new Int32Array(new SharedArrayBuffer(4))
+  Atomics.wait(shared, 0, 0, ms)
+}
+
+const LOCK_STALE_MS = 30_000
+const LOCK_SPIN_MS = 50
+const LOCK_MAX_WAIT_MS = 2_000
+
+/**
+ * Run `fn` while holding an advisory lock over the registry. Mutual exclusion
+ * is an exclusive-create lock file (`open(..., 'wx')`) with bounded spin-retry
+ * and stale-lock breaking (a lock whose mtime exceeds the TTL is reclaimed —
+ * covers a crashed writer). Read-only callers never take the lock.
+ */
+export function withFileLock<T>(home: string | undefined, fn: () => T): T {
+  const lp = lockPath(home)
+  mkdirSync(path.dirname(lp), { recursive: true })
+  let fd: number | undefined
+  // Unique per-acquisition token written INTO the lock file. On release we only
+  // unlink the file when the token still matches OURS — so a writer whose lock
+  // was stale-broken (TTL-reclaimed) by another writer never deletes the NEW
+  // owner's lock out from under it (which would let a third writer acquire
+  // concurrently and race the read-modify-write).
+  const ourToken = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  const deadline = Date.now() + LOCK_MAX_WAIT_MS
+  for (;;) {
+    try {
+      fd = openSync(lp, 'wx')
+      try {
+        writeFileSync(fd, ourToken)
+        fsyncSync(fd)
+      } catch {
+        /* best-effort — the lock still serialises via exclusive-create */
+      }
+      break
+    } catch {
+      // Lock held — break it if stale, otherwise spin until the deadline.
+      try {
+        const age = Date.now() - statSync(lp).mtimeMs
+        if (age > LOCK_STALE_MS) {
+          unlinkSync(lp)
+          continue
+        }
+      } catch {
+        // lock vanished between open and stat — retry immediately
+        continue
+      }
+      if (Date.now() >= deadline) {
+        // FAIL CLOSED: proceeding without the lock would run `fn()` (a
+        // read-modify-write of the registry) with NO exclusivity, so a
+        // concurrent core+desktop writer can lost-update the registry. Throw
+        // instead of silently dropping mutual exclusivity — callers wrap this as
+        // non-fatal (the registry update is retried / skipped).
+        throw new Error('registry lock acquisition timed out')
+      }
+      syncSleep(LOCK_SPIN_MS)
+    }
+  }
+  try {
+    return fn()
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd)
+      } catch {
+        /* already closed */
+      }
+      // Only unlink the lock when it still carries OUR token. If we were
+      // stale-broken and another writer now owns the file, its token differs and
+      // we leave it alone (a missing/unreadable file ⇒ already gone ⇒ no-op).
+      try {
+        const onDisk = readFileSync(lp, 'utf8')
+        if (onDisk === ourToken) {
+          unlinkSync(lp)
+        }
+      } catch {
+        /* already removed / unreadable — nothing to clean up */
+      }
+    }
+  }
+}
+
+/** Deterministic slug allocation: basename-derived, `-N` dedup suffix. Both
+ *  tools implement this identically so they only ever diverge on the suffix,
+ *  which read-before-allocate resolves. */
+export function allocateSlug(canon: string, existing: ReadonlySet<string>): string {
+  let base = slugify(path.basename(canon))
+  if (base === '') base = 'project'
+  if (!existing.has(base)) return base
+  let n = 2
+  while (existing.has(`${base}-${n}`)) n += 1
+  return `${base}-${n}`
+}
+
+function buildEntry(
+  home: string,
+  canon: string,
+  slug: string,
+  opts: ResolveOptions,
+): ProjectEntry {
+  const providers = opts.providers && opts.providers.length > 0 ? opts.providers : ['claude']
+  const now = opts.now ?? new Date().toISOString()
+  const layout = workspaceLayout(home, slug, canon)
+  const entry: ProjectEntry = {
+    ...layout,
+    providers,
+    primaryProvider: providers[0]!,
+    coreVersion: opts.coreVersion,
+    createdAt: now,
+    lastInstallAt: now,
+    source: opts.allocator ?? 'core-standalone',
+  }
+  if (opts.desktopProjectId) entry.desktopProjectId = opts.desktopProjectId
+  return entry
+}
+
+/**
+ * The shared resolver both tools run. Given a repo path, returns where that
+ * repo's artifacts live. With `allocate:true`, creates + persists an entry when
+ * none exists (under the lock, with a re-read double-check); readers pass
+ * `allocate:false` and fall back to the in-repo legacy layout when absent.
+ */
+export function resolveArtifacts(repoPathInput: string, opts: ResolveOptions = {}): Resolution {
+  const home = opts.home
+  const canon = canonicalizeRepoPath(repoPathInput)
+  const key = normalizeKey(canon)
+
+  // Fast path: lock-free read for a pure lookup.
+  const reg = readRegistryOrEmpty(home)
+  const existing = reg.projects[key]
+  if (existing) return entryToResolution(key, existing)
+
+  if (!opts.allocate) return legacyResolution(canon)
+
+  // Allocation path: lock, re-read, double-check, atomic write.
+  return withFileLock(home, () => {
+    const fresh = readRegistryOrEmpty(home)
+    const raced = fresh.projects[key]
+    if (raced) return entryToResolution(key, raced)
+
+    const existingSlugs = new Set<string>(Object.values(fresh.projects).map((e) => e.slug))
+    const slug = allocateSlug(canon, existingSlugs)
+    const entry = buildEntry(resolveHome(home), canon, slug, opts)
+    fresh.projects[key] = entry
+    fresh.schemaVersion = REGISTRY_SCHEMA_VERSION
+    fresh.generator = 'specrails-core'
+    fresh.updatedAt = opts.now ?? new Date().toISOString()
+    atomicWrite(registryPath(home), JSON.stringify(fresh, null, 2) + '\n')
+    return entryToResolution(key, entry)
+  })
+}

--- a/templates/agents/sr-architect.md
+++ b/templates/agents/sr-architect.md
@@ -47,6 +47,10 @@ You are the kind of architect who can sit in a room with a product owner, fully 
 
 Do not proceed with any design work, file reading, or artifact creation until specName is confirmed.
 
+## Repository location (read first)
+
+Your working directory may NOT be the user's source repository. The user's source code, `openspec/**`, `.claude/rules/`, and `.git` all live under **`${SPECRAILS_REPO_DIR:-.}`** (the spawner sets the env var to the repo path; unset defaults to `.`, i.e. byte-identical to a classic in-repo run). Read specs from `${SPECRAILS_REPO_DIR:-.}/openspec/...`, scan conventions under `${SPECRAILS_REPO_DIR:-.}/.claude/rules/`, and resolve every compatibility-surface read (CLI/commands/agents/config) relative to `${SPECRAILS_REPO_DIR:-.}`.
+
 ## Core Responsibilities
 
 When invoked by the orchestrator with a specName argument, you must execute the following steps in order:
@@ -71,7 +75,7 @@ This must be a real Skill tool invocation that appears in your transcript — no
 - "Change already exists" → REUSE it and continue (the step is idempotent). Do NOT call `opsx:new` first.
 
 **3 — PROOF-OF-EXECUTION gate.** After `opsx:ff` returns, verify it really ran by reading the authoritative status — not a hardcoded file list:
-- Run `openspec status --change "<specName>" --json`. The gate PASSES when **every artifact id in `applyRequires` has `status: "done"`** (the canonical apply-readiness signal). `tasks.md` is always among them — confirm `openspec/changes/<specName>/tasks.md` exists and is non-empty. The other artifacts the schema generates (typically `proposal.md`, `design.md`, `specs/`) are `applyRequires` dependencies; their absence is a failure ONLY if the schema actually lists them in `applyRequires`.
+- Run `(cd "${SPECRAILS_REPO_DIR:-.}" && openspec status --change "<specName>" --json)` (the OpenSpec project root is `${SPECRAILS_REPO_DIR:-.}`, not the workspace cwd). The gate PASSES when **every artifact id in `applyRequires` has `status: "done"`** (the canonical apply-readiness signal). `tasks.md` is always among them — confirm `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<specName>/tasks.md` exists and is non-empty. The other artifacts the schema generates (typically `proposal.md`, `design.md`, `specs/`) are `applyRequires` dependencies; their absence is a failure ONLY if the schema actually lists them in `applyRequires`.
 
 If the gate does NOT pass, the scaffold was simulated or incomplete — **do NOT hand-author the artifacts to cover it.** Recover skill-only, in order: (a) if `opsx:ff` reported the change already exists and some artifacts are still pending, finish the remaining ones with `Skill("opsx:continue", "<specName>")`; (b) otherwise re-invoke `Skill("opsx:ff", "<specName>")` once; (c) if `applyRequires` is still not all `done`, HALT and report `[error] opsx:ff did not produce canonical artifacts` to the orchestrator.
 
@@ -82,8 +86,8 @@ If the gate does NOT pass, the scaffold was simulated or incomplete — **do NOT
 Only after Step 0's proof gate passes do you proceed to Steps 1–6.
 
 ### 1. Analyze Spec Changes
-- Read all relevant specs from `openspec/specs/` — this is the **source of truth**
-- Read pending changes from `openspec/changes/<name>/`
+- Read all relevant specs from `${SPECRAILS_REPO_DIR:-.}/openspec/specs/` — this is the **source of truth**
+- Read pending changes from `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<name>/`
 - Understand the full context: what changed, why it changed, and what it impacts
 - Cross-reference with existing specs
 
@@ -114,7 +118,7 @@ This project follows this architecture:
 {{LAYER_CONVENTIONS}}
 
 - Always check scoped context: {{LAYER_CLAUDE_MD_PATHS}}
-- Always check `.claude/rules/` for conditional conventions per layer
+- Always check `${SPECRAILS_REPO_DIR:-.}/.claude/rules/` for conditional conventions per layer
 
 ### 5. Key Warnings to Always Consider
 {{WARNINGS}}
@@ -125,12 +129,12 @@ After producing the task breakdown and before finalizing output:
 
 1. **Extract the proposed surface changes** from your implementation design: which commands, agents, placeholders, flags, or config keys are being added, removed, renamed, or modified?
 
-2. **Compare against the current surface** by reading:
-   - `bin/specrails-core.mjs` for CLI flags
-   - `templates/commands/*.md` for command names and argument flags
-   - `templates/agents/*.md` for agent names
-   - `templates/**/*.md` for `{{PLACEHOLDER}}` keys
-   - `openspec/config.yaml` for config keys
+2. **Compare against the current surface** by reading (all paths are repo-resident — resolve them under `${SPECRAILS_REPO_DIR:-.}`):
+   - `${SPECRAILS_REPO_DIR:-.}/bin/specrails-core.mjs` for CLI flags
+   - `${SPECRAILS_REPO_DIR:-.}/templates/commands/*.md` for command names and argument flags
+   - `${SPECRAILS_REPO_DIR:-.}/templates/agents/*.md` for agent names
+   - `${SPECRAILS_REPO_DIR:-.}/templates/**/*.md` for `{{PLACEHOLDER}}` keys
+   - `${SPECRAILS_REPO_DIR:-.}/openspec/config.yaml` for config keys
 
 3. **Classify each change** using the four categories:
    - Category 1: Removal (BREAKING — the element no longer exists; example: a CLI flag is deleted)

--- a/templates/agents/sr-backend-developer.md
+++ b/templates/agents/sr-backend-developer.md
@@ -8,6 +8,8 @@ memory: project
 
 You are a backend specialist — expert in {{BACKEND_TECH_LIST}}. You implement backend and core logic tasks with surgical precision.
 
+**Repository location.** Your working directory may NOT be the source repo. `openspec/**` and the source files named in `tasks.md` (repo-relative paths) live under `${SPECRAILS_REPO_DIR:-.}` (unset ⇒ `.` ⇒ classic in-repo run). Read openspec from `${SPECRAILS_REPO_DIR:-.}/openspec/...` and edit every source file as `${SPECRAILS_REPO_DIR:-.}/<path>`; run CI/build/test from `cd "${SPECRAILS_REPO_DIR:-.}"`.
+
 ## Your Expertise
 
 {{BACKEND_EXPERTISE}}
@@ -38,7 +40,7 @@ A real Skill invocation in your transcript, not a description. `opsx:apply` walk
 
 **2 — UNATTENDED pre-authorization.** Never emit `AskUserQuestion`; never wait for input. Change selection → `<specName>`. Ambiguous task → choose the most reasonable implementation and continue. Design issue surfaced → note it, resolve reasonably, continue. Error or blocker → do NOT wait; attempt the conservative fix and continue, or if unrecoverable, leave the task `- [ ]`, HALT, and report the blocker — never stall, never fake completion.
 
-**3 — PROOF-OF-EXECUTION gate.** Before you finish, every task you own in `openspec/changes/<specName>/tasks.md` must be `- [x]` AND backed by real changes. If `- [ ]` items remain, re-enter the apply loop — do NOT hand-flip checkboxes.
+**3 — PROOF-OF-EXECUTION gate.** Before you finish, every task you own in `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<specName>/tasks.md` must be `- [x]` AND backed by real changes. If `- [ ]` items remain, re-enter the apply loop — do NOT hand-flip checkboxes.
 
 **4 — Execution receipt.** End with an `## OpenSpec Skill Execution Receipt` section: the exact `Skill("opsx:apply", …)` call and the task progress it produced.
 
@@ -50,7 +52,7 @@ A real Skill invocation in your transcript, not a description. `opsx:apply` walk
    ```bash
    {{CI_COMMANDS_BACKEND}}
    ```
-4. **Commit**: `git add -A && git commit -m "feat: <change-name>"`
+4. **Commit** (against the repo): `git -C "${SPECRAILS_REPO_DIR:-.}" add -A && git -C "${SPECRAILS_REPO_DIR:-.}" commit -m "feat: <change-name>"`
 
 ## Critical Rules
 

--- a/templates/agents/sr-developer.md
+++ b/templates/agents/sr-developer.md
@@ -50,18 +50,30 @@ You are a polyglot engineer with extraordinary depth in:
 
 You don't just write code that works — you write code that is elegant, maintainable, testable, and performant.
 
+## Repository location (read first)
+
+Your working directory may NOT be the user's source repository. The user's source code, `openspec/**`, the project `CLAUDE.md`, `.claude/rules/`, and `.git` all live under **`${SPECRAILS_REPO_DIR:-.}`** (the env var is set by the spawner to the repo path; when it is unset it defaults to `.`, i.e. the current directory — byte-identical to a classic in-repo run).
+
+Concretely:
+- **Every openspec read/write** targets `${SPECRAILS_REPO_DIR:-.}/openspec/...`.
+- **Every source-file edit** named in `tasks.md` uses repo-relative paths (e.g. `src/foo.ts`); resolve and edit them as `${SPECRAILS_REPO_DIR:-.}/<path>` so the change lands in the real repo, not the working directory.
+- **CI / build / test commands** run from inside the repo — `cd "${SPECRAILS_REPO_DIR:-.}"` (or run them with that as the working directory) before invoking them.
+- **Convention scans** of the project `CLAUDE.md` and `.claude/rules/` read from `${SPECRAILS_REPO_DIR:-.}`.
+
+Run-state directories you write to during a run — `.claude/agent-memory/`, `.claude/pipeline-state/` — are NOT repo-resident; leave them relative to the working directory.
+
 ## Your Mission
 
 When an OpenSpec change is being applied, you:
-1. **Read and deeply understand the change specification** in `openspec/changes/<name>/`
-2. **Read the relevant base specs** in `openspec/specs/` to understand the full context
-3. **Consult existing codebase conventions** from CLAUDE.md files, `.claude/rules/`, and existing code patterns
+1. **Read and deeply understand the change specification** in `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<name>/`
+2. **Read the relevant base specs** in `${SPECRAILS_REPO_DIR:-.}/openspec/specs/` to understand the full context
+3. **Consult existing codebase conventions** from `${SPECRAILS_REPO_DIR:-.}/CLAUDE.md` files, `${SPECRAILS_REPO_DIR:-.}/.claude/rules/`, and existing code patterns
 4. **Implement the changes** with surgical precision across all affected layers
 5. **Ensure consistency** with the existing codebase style, patterns, and architecture
 
 ## Tool Selection — MCP-First for Codebase Tasks
 
-**Mandatory step BEFORE any code-navigation tool call**: scan the project's `CLAUDE.md` for MCP tool blocks (typically headed `## Plugin: <name>` and listing `mcp__*` tool names with declared use-cases).
+**Mandatory step BEFORE any code-navigation tool call**: scan the project's `${SPECRAILS_REPO_DIR:-.}/CLAUDE.md` for MCP tool blocks (typically headed `## Plugin: <name>` and listing `mcp__*` tool names with declared use-cases).
 
 If a project-documented MCP tool's "When to use" matches your current need, you **MUST** call it instead of the built-in equivalent (`Read`, `Grep`, `WebFetch`, etc.). Built-in fallbacks are reserved for cases the documented tools explicitly exclude (binary files, free-form prose, unstructured logs) or for non-codebase concerns (project-state files, config inspection, system commands).
 
@@ -77,7 +89,7 @@ This is non-negotiable for code-navigation work: plugin authors choose tools bec
 You MUST follow Test-Driven Development. This is non-negotiable. The cycle is: **Red → Green → Refactor**. Never write production code without a failing test first.
 
 ### Phase 1: Understand
-- **First, scan the project's `CLAUDE.md` for MCP tool blocks** (headed `## Plugin: <name>`) — these define the code-navigation primitives you must reach for in this and every later phase. See "Tool Selection — MCP-First" above. Internalise the available tools BEFORE you start reading files.
+- **First, scan the project's `${SPECRAILS_REPO_DIR:-.}/CLAUDE.md` for MCP tool blocks** (headed `## Plugin: <name>`) — these define the code-navigation primitives you must reach for in this and every later phase. See "Tool Selection — MCP-First" above. Internalise the available tools BEFORE you start reading files.
 - Read the OpenSpec change spec thoroughly
 - Read referenced base specs
 - Read layer-specific CLAUDE.md files ({{LAYER_CLAUDE_MD_PATHS}})
@@ -113,13 +125,13 @@ This must be a real Skill tool invocation in your transcript. `opsx:apply` reads
 - "Implementation reveals a design issue?" → note it in your output, implement the most reasonable resolution, and continue — do NOT stall.
 - "Error or blocker encountered — pause and wait for guidance?" → do NOT wait. Capture the error, attempt the conservative fix, and continue; if it is truly unrecoverable, leave the affected tasks `- [ ]`, then HALT and report the blocker to the orchestrator (never silently stall, never fake completion).
 
-**3 — PROOF-OF-EXECUTION gate.** Enforced by the Checkbox Verification Gate below (a necessary proxy, not proof on its own): every task in `tasks.md` must be `- [x]` AND backed by real code/test changes, AND `openspec instructions apply --change "<specName>" --json` must report `state: "all_done"` (the apply skill's own completion signal). If `opsx:apply` exits with `- [ ]` items still present, re-enter the apply loop — do NOT hand-flip checkboxes to pass the gate.
+**3 — PROOF-OF-EXECUTION gate.** Enforced by the Checkbox Verification Gate below (a necessary proxy, not proof on its own): every task in `tasks.md` must be `- [x]` AND backed by real code/test changes, AND `(cd "${SPECRAILS_REPO_DIR:-.}" && openspec instructions apply --change "<specName>" --json)` must report `state: "all_done"` (the apply skill's own completion signal; the OpenSpec project root is `${SPECRAILS_REPO_DIR:-.}`, not the workspace cwd). If `opsx:apply` exits with `- [ ]` items still present, re-enter the apply loop — do NOT hand-flip checkboxes to pass the gate.
 
 **4 — Execution receipt.** Finish with an `## OpenSpec Skill Execution Receipt` section stating the exact `Skill("opsx:apply", …)` call you made and the task progress it produced (N/N tasks `- [x]`). No receipt with a real Skill call = contract failed.
 
 **After `opsx:apply` exits — Checkbox Verification Gate:**
 
-1. Read `openspec/changes/<specName>/tasks.md`
+1. Read `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<specName>/tasks.md`
 2. Search for any lines matching the pattern `- [ ]` (hyphen, space, open-bracket, space, close-bracket)
 3. **If any `- [ ]` lines are found**: HALT. List every incomplete task title. Do NOT proceed to Phase 4. Report the incomplete tasks to the orchestrator.
 4. **If no `- [ ]` lines remain** (all tasks are `- [x]`): the gate passes — proceed to Phase 4.
@@ -156,7 +168,7 @@ Follow the project architecture strictly:
 
 ### Phase 4: Verify
 
-**Prerequisite: Phase 4 is only reachable if the Phase 3 checkbox verification gate passed** — meaning every task in `openspec/changes/<specName>/tasks.md` is marked `- [x]`. If any `- [ ]` items remain, return to Phase 3.
+**Prerequisite: Phase 4 is only reachable if the Phase 3 checkbox verification gate passed** — meaning every task in `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<specName>/tasks.md` is marked `- [x]`. If any `- [ ]` items remain, return to Phase 3.
 
 **All tests MUST pass before you hand off to the reviewer. This is a hard gate — do not proceed if any test fails.**
 

--- a/templates/agents/sr-frontend-developer.md
+++ b/templates/agents/sr-frontend-developer.md
@@ -8,6 +8,8 @@ memory: project
 
 You are a frontend specialist — expert in {{FRONTEND_TECH_LIST}}. You implement frontend tasks with pixel-perfect precision.
 
+**Repository location.** Your working directory may NOT be the source repo. `openspec/**` and the source files named in `tasks.md` (repo-relative paths) live under `${SPECRAILS_REPO_DIR:-.}` (unset ⇒ `.` ⇒ classic in-repo run). Read openspec from `${SPECRAILS_REPO_DIR:-.}/openspec/...` and edit every source file as `${SPECRAILS_REPO_DIR:-.}/<path>`; run CI/build/test from `cd "${SPECRAILS_REPO_DIR:-.}"`.
+
 ## Your Expertise
 
 {{FRONTEND_EXPERTISE}}
@@ -38,7 +40,7 @@ A real Skill invocation in your transcript, not a description. `opsx:apply` walk
 
 **2 — UNATTENDED pre-authorization.** Never emit `AskUserQuestion`; never wait for input. Change selection → `<specName>`. Ambiguous task → choose the most reasonable implementation and continue. Design issue surfaced → note it, resolve reasonably, continue. Error or blocker → do NOT wait; attempt the conservative fix and continue, or if unrecoverable, leave the task `- [ ]`, HALT, and report the blocker — never stall, never fake completion.
 
-**3 — PROOF-OF-EXECUTION gate.** Before you finish, every task you own in `openspec/changes/<specName>/tasks.md` must be `- [x]` AND backed by real changes. If `- [ ]` items remain, re-enter the apply loop — do NOT hand-flip checkboxes.
+**3 — PROOF-OF-EXECUTION gate.** Before you finish, every task you own in `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<specName>/tasks.md` must be `- [x]` AND backed by real changes. If `- [ ]` items remain, re-enter the apply loop — do NOT hand-flip checkboxes.
 
 **4 — Execution receipt.** End with an `## OpenSpec Skill Execution Receipt` section: the exact `Skill("opsx:apply", …)` call and the task progress it produced.
 
@@ -50,7 +52,7 @@ A real Skill invocation in your transcript, not a description. `opsx:apply` walk
    ```bash
    {{CI_COMMANDS_FRONTEND}}
    ```
-4. **Commit**: `git add -A && git commit -m "feat: <change-name>"`
+4. **Commit** (against the repo): `git -C "${SPECRAILS_REPO_DIR:-.}" add -A && git -C "${SPECRAILS_REPO_DIR:-.}" commit -m "feat: <change-name>"`
 
 ## Critical Rules
 

--- a/templates/agents/sr-reviewer.md
+++ b/templates/agents/sr-reviewer.md
@@ -43,6 +43,10 @@ Leave empty to review all areas with equal weight.
 
 Do not proceed with any review work until specName is confirmed.
 
+## Repository location (read first)
+
+Your working directory may NOT be the user's source repository. The user's source code, `openspec/**`, and `.git` all live under **`${SPECRAILS_REPO_DIR:-.}`** (the spawner sets the env var to the repo path; unset defaults to `.`, i.e. byte-identical to a classic in-repo run). Read the change spec from `${SPECRAILS_REPO_DIR:-.}/openspec/...`, and run every CI / build / test / `git` command from inside the repo — `cd "${SPECRAILS_REPO_DIR:-.}"` (or use it as the working directory) before invoking them. (The archive Skill resolves `openspec/**` itself; only your own on-disk verification reads need the prefix.)
+
 ## Your Mission
 
 You are the last line of defense between developer output and a PR. You:
@@ -94,7 +98,7 @@ After running CI checks, also review for:
 - Check test quality: tests should assert on behavior, not implementation details
 
 ### Spec Completeness (mandatory)
-- Read the OpenSpec change spec in `openspec/changes/<name>/`
+- Read the OpenSpec change spec in `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<name>/`
 - **Every requirement listed in the spec must have a corresponding implementation** — cross-reference each spec item against the code changes
 - If any spec requirement is missing or only partially implemented, **this is a blocking issue** — flag exactly which requirements are not fulfilled
 - If the developer made assumptions about ambiguous spec items, verify they are reasonable
@@ -117,7 +121,7 @@ After running CI checks, also review for:
 3. **Repeat** up to 3 fix-and-verify cycles
 4. **Report** a summary of what passed, what failed, and what you fixed
 5. **Task Completion Gate** — Before archiving, verify all tasks are complete:
-   - Read `openspec/changes/<specName>/tasks.md`
+   - Read `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<specName>/tasks.md`
    - Search for any lines matching `- [ ]` (hyphen, space, open-bracket, space, close-bracket)
    - **If any `- [ ]` lines are found**: BLOCK archive. List every incomplete task title. Report to orchestrator that archive is blocked — do NOT invoke `/opsx:archive`.
    - **If no `- [ ]` lines remain** (all tasks are `- [x]`): gate passes — proceed to Step 6.
@@ -140,8 +144,8 @@ After running CI checks, also review for:
    - "Delta specs: Sync now vs Archive without syncing?" → ALWAYS choose **Sync now** (canonical). NEVER skip the sync.
 
    **3 — PROOF-OF-EXECUTION gate.** After the skill returns, verify on disk:
-   - `openspec/changes/<specName>/` no longer exists (the change was moved), AND
-   - the delta-spec changes are now present under `openspec/specs/` — open the affected `openspec/specs/<capability>/spec.md` and confirm the change's added/modified requirements are there.
+   - `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<specName>/` no longer exists (the change was moved), AND
+   - the delta-spec changes are now present under `${SPECRAILS_REPO_DIR:-.}/openspec/specs/` — open the affected `${SPECRAILS_REPO_DIR:-.}/openspec/specs/<capability>/spec.md` and confirm the change's added/modified requirements are there.
 
    If the move happened but the specs were NOT synced (the classic *simulated-archive* symptom), recover canonically — **never hand-copy**:
    - a. Invoke `Skill("opsx:sync", "<specName>")` (the official sync skill) and re-verify.
@@ -278,7 +282,7 @@ Score semantics:
 
 ### How to derive the change name
 
-The change name is the kebab-case directory under `openspec/changes/` that was active during this review. It is typically provided in your invocation prompt by the orchestrator. If not provided explicitly, find it by listing `openspec/changes/` and identifying the directory most recently modified.
+The change name is the kebab-case directory under `${SPECRAILS_REPO_DIR:-.}/openspec/changes/` that was active during this review. It is typically provided in your invocation prompt by the orchestrator. If not provided explicitly, find it by listing `${SPECRAILS_REPO_DIR:-.}/openspec/changes/` and identifying the directory most recently modified.
 
 If the change name cannot be determined: write the score with `"change": "unknown"` and `"overall": 0`, and populate every `notes` field with an explanation of why the name could not be determined.
 
@@ -286,7 +290,7 @@ If the change name cannot be determined: write the score with `"change": "unknow
 
 Write to:
 ```
-openspec/changes/<name>/confidence-score.json
+${SPECRAILS_REPO_DIR:-.}/openspec/changes/<name>/confidence-score.json
 ```
 
 ### Required fields

--- a/templates/codex-skills/implement/SKILL.md
+++ b/templates/codex-skills/implement/SKILL.md
@@ -12,6 +12,14 @@ verdicts, and close the ticket. The role instructions live in
 their own skills — your message to each spawn invokes the right
 role via `$skill_name`.
 
+**Repository location.** Your working directory may NOT be the source repo.
+`openspec/**`, `.git`, and the source live under `${SPECRAILS_REPO_DIR:-.}`
+(unset ⇒ `.` ⇒ classic in-repo run). Run every `openspec`/`git` CLI command
+from the repo — `(cd "${SPECRAILS_REPO_DIR:-.}" && …)` — and read change
+artefacts under `${SPECRAILS_REPO_DIR:-.}/openspec/...`. The ticket store
+`.specrails/local-tickets.json` is run-state and stays relative to the working
+directory.
+
 **This is explicit permission to use `spawn_agent`.** The user
 wants the multi-agent split. Do not collapse the work into a
 single turn.
@@ -94,9 +102,10 @@ the combo and you'll burn a turn on the retry.
 
 ### 0. Bootstrap + agent discovery
 
-1. Confirm `pwd` matches `git rev-parse --show-toplevel`. If not,
-   `cd` to the root.
-2. Load the ticket (skip for free-form invocations):
+1. Confirm the repo root with `git -C "${SPECRAILS_REPO_DIR:-.}" rev-parse --show-toplevel`
+   (the source repo is `${SPECRAILS_REPO_DIR:-.}`; unset ⇒ `.`).
+2. Load the ticket (skip for free-form invocations) — the ticket store is
+   run-state, relative to the working directory:
    `jq '.tickets["<ID>"]' .specrails/local-tickets.json`
 3. **List the installed rail skills**:
    `ls .codex/skills/rails/`
@@ -318,15 +327,15 @@ performs the lifecycle close:
 
 The reviewer rail's archive-only mode must run these checks:
 
-1. Re-confirm every task box in `openspec/changes/<slug>/tasks.md`
+1. Re-confirm every task box in `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<slug>/tasks.md`
    is ticked (`- [x]`) and the change validates:
-   `openspec validate "<slug>" --strict`.
-2. Archive it: `openspec archive "<slug>" -y` — this updates the
-   main specs and moves the change to `openspec/changes/archive/`.
+   `(cd "${SPECRAILS_REPO_DIR:-.}" && openspec validate "<slug>" --strict)`.
+2. Archive it: `(cd "${SPECRAILS_REPO_DIR:-.}" && openspec archive "<slug>" -y)` — this updates the
+   main specs and moves the change to `${SPECRAILS_REPO_DIR:-.}/openspec/changes/archive/`.
 3. **Verify the archive landed — do NOT assume success.** Confirm
-   `openspec/changes/archive/` now contains the slug
-   (`ls -d openspec/changes/archive/*<slug>* 2>/dev/null`) AND that
-   `openspec/changes/<slug>/` is gone. If the archive directory is
+   `${SPECRAILS_REPO_DIR:-.}/openspec/changes/archive/` now contains the slug
+   (`ls -d "${SPECRAILS_REPO_DIR:-.}"/openspec/changes/archive/*<slug>* 2>/dev/null`) AND that
+   `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<slug>/` is gone. If the archive directory is
    absent, archiving FAILED.
 4. If `openspec validate`, `openspec archive`, or the step-3
    verification fails: do NOT mark the ticket `done`. Treat the run

--- a/templates/codex-skills/rails/sr-architect/SKILL.md
+++ b/templates/codex-skills/rails/sr-architect/SKILL.md
@@ -10,10 +10,17 @@ orchestrator already loaded the ticket and surveyed the repo before
 spawning you. Your turn is short, focused, and ends with TWO
 written artefacts: an OpenSpec change package and a plan artefact.
 
+**Repository location.** `openspec/**`, `.git`, and the source live under
+`${SPECRAILS_REPO_DIR:-.}` (unset ⇒ `.` ⇒ classic in-repo run). Run every
+`openspec` CLI command from the repo — `(cd "${SPECRAILS_REPO_DIR:-.}" && openspec …)`
+— and read/write change artefacts under `${SPECRAILS_REPO_DIR:-.}/openspec/...`.
+Your plan artefact under `.specrails/agent-memory/` is run-state and stays
+relative to the working directory.
+
 ## Your scope
 
 You **plan**. You do not write production code. You do not edit
-source files outside `openspec/` and `.specrails/agent-memory/`.
+source files outside `${SPECRAILS_REPO_DIR:-.}/openspec/` and `.specrails/agent-memory/`.
 
 ## What you produce
 
@@ -25,15 +32,15 @@ scaffolding so the change is registered with a workflow schema and
 stays trackable by `openspec status`. Run:
 
 ```
-openspec new change "<slug>" --schema spec-driven
+(cd "${SPECRAILS_REPO_DIR:-.}" && openspec new change "<slug>" --schema spec-driven)
 ```
 
 where `<slug>` is a kebab-case derivation of the ticket title
 (e.g. ticket "Build a Playable Tetris Game" → `add-tetris-game`).
-This creates `openspec/changes/<slug>/.openspec.yaml`.
+This creates `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<slug>/.openspec.yaml`.
 
 - If the command fails because OpenSpec isn't initialised in this
-  repo, run `openspec init . --tools codex --force` once, then
+  repo, run `(cd "${SPECRAILS_REPO_DIR:-.}" && openspec init . --tools codex --force)` once, then
   re-run `openspec new change …`.
 - If the change directory already exists from a prior run,
   **reuse** it (idempotent) — skip the `new change` call.
@@ -44,10 +51,10 @@ tasks). Check the order and what's still outstanding at any time
 with:
 
 ```
-openspec status --change "<slug>" --json
+(cd "${SPECRAILS_REPO_DIR:-.}" && openspec status --change "<slug>" --json)
 ```
 
-Write these four artefacts into `openspec/changes/<slug>/`:
+Write these four artefacts into `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<slug>/`:
 
 **`proposal.md`** — the change's executive summary:
 
@@ -256,9 +263,11 @@ on the touched files as a fallback.>
 When BOTH the OpenSpec change package and the plan artefact are
 written:
 
-1. **Validate the change with the OpenSpec CLI** (mandatory):
+1. **Validate the change with the OpenSpec CLI** (mandatory). The
+   OpenSpec project root is `${SPECRAILS_REPO_DIR:-.}` (the repo),
+   NOT the workspace cwd — so run it scoped to the repo:
    ```
-   openspec validate "<slug>"
+   (cd "${SPECRAILS_REPO_DIR:-.}" && openspec validate "<slug>")
    ```
    If validation reports structural errors, fix the offending
    artefact and re-run until it passes. Do not hand off a change

--- a/templates/codex-skills/rails/sr-backend-developer/SKILL.md
+++ b/templates/codex-skills/rails/sr-backend-developer/SKILL.md
@@ -15,8 +15,11 @@ for changes that are neither, `$sr-developer`.
 ## Your scope
 
 Same TDD contract as `$sr-developer` — read the architect's
-plan, walk `openspec/changes/<slug>/tasks.md` in order, write
+plan, walk `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<slug>/tasks.md` in order, write
 the failing test first, then production code, re-run, tick.
+(openspec + the source files named in `tasks.md` live under
+`${SPECRAILS_REPO_DIR:-.}` — unset ⇒ `.` ⇒ classic in-repo run; edit each
+source file as `${SPECRAILS_REPO_DIR:-.}/<path>`.)
 
 What's different: you bias the test surface toward integration
 and contract correctness, not isolated unit happy paths.

--- a/templates/codex-skills/rails/sr-developer/SKILL.md
+++ b/templates/codex-skills/rails/sr-developer/SKILL.md
@@ -5,6 +5,15 @@ license: MIT
 compatibility: "Codex-native. Designed to run as a full-history sub-agent fork of the implement orchestrator."
 ---
 
+**Repository location.** Your working directory may NOT be the source
+repo. `openspec/**` and the source files named in `tasks.md` (repo-relative
+paths like `src/foo.ts`) live under `${SPECRAILS_REPO_DIR:-.}` — unset ⇒ `.`
+⇒ byte-identical to a classic in-repo run. Read openspec from
+`${SPECRAILS_REPO_DIR:-.}/openspec/...` and edit every source file as
+`${SPECRAILS_REPO_DIR:-.}/<path>`. Run-state you write (`.specrails/agent-memory/`)
+stays relative to the working directory; `.specrails/local-tickets.json` is
+likewise relative (and owned by the orchestrator — you never write it).
+
 You are the **developer** in the specrails implement pipeline. The
 architect produced an OpenSpec change package (proposal + design +
 tasks + spec deltas) and a plan artefact. Your job is to **apply**
@@ -27,14 +36,14 @@ note it in your reply — do not block on the architect.
 1. **Read the inputs**, in this order:
    - `<plan-path>` (the architect's plan artefact under
      `.specrails/agent-memory/explanations/`).
-   - `openspec/changes/<slug>/proposal.md` — the why + what.
-   - `openspec/changes/<slug>/design.md` — the deep design.
+   - `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<slug>/proposal.md` — the why + what.
+   - `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<slug>/design.md` — the deep design.
      Read **every section**, especially "Architecture", "Data
      shapes", "State & lifecycle", "Public API / surface",
      "Trade-offs" (so you know what NOT to revisit), and "Open
      questions".
-   - `openspec/changes/<slug>/tasks.md` — your execution checklist.
-   - `openspec/changes/<slug>/specs/<cap>/spec.md` — the
+   - `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<slug>/tasks.md` — your execution checklist.
+   - `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<slug>/specs/<cap>/spec.md` — the
      behavioural contracts the tests must encode.
 
    **About design.md's "Open questions" section** — if the

--- a/templates/codex-skills/rails/sr-doc-sync/SKILL.md
+++ b/templates/codex-skills/rails/sr-doc-sync/SKILL.md
@@ -29,8 +29,9 @@ Two ways:
   specrails-managed:start -->` … `<!--
   specrails-managed:end -->` block. Outside that block
   is user-authored; don't touch it.
-- `docs/` (any markdown files).
-- `openspec/specs/<capability>/spec.md` (capabilities
+- `${SPECRAILS_REPO_DIR:-.}/docs/` (any markdown files; repo-resident — unset
+  `SPECRAILS_REPO_DIR` ⇒ `.` ⇒ classic in-repo run).
+- `${SPECRAILS_REPO_DIR:-.}/openspec/specs/<capability>/spec.md` (capabilities
   documentation — drift here is the most serious; this
   is the contract).
 - Inline JSDoc / TSDoc / Python docstrings on exported

--- a/templates/codex-skills/rails/sr-frontend-developer/SKILL.md
+++ b/templates/codex-skills/rails/sr-frontend-developer/SKILL.md
@@ -15,9 +15,12 @@ instead.
 ## Your scope
 
 Same TDD contract as `$sr-developer` — read the architect's
-plan, walk `openspec/changes/<slug>/tasks.md` in order, write
+plan, walk `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<slug>/tasks.md` in order, write
 the failing test first, then the production code, then re-run.
 Tick boxes only after observing the expected runner state.
+(openspec + the source files named in `tasks.md` live under
+`${SPECRAILS_REPO_DIR:-.}` — unset ⇒ `.` ⇒ classic in-repo run; edit each
+source file as `${SPECRAILS_REPO_DIR:-.}/<path>`.)
 
 What's different: you bias the test surface toward UI.
 

--- a/templates/codex-skills/rails/sr-product-manager/SKILL.md
+++ b/templates/codex-skills/rails/sr-product-manager/SKILL.md
@@ -25,14 +25,16 @@ Two ways:
 
 ### 1. Read the existing artefacts
 
-- `README.md` (project intent and surface).
-- `openspec/specs/` (existing specs — what the product
+  (Repo-resident reads live under `${SPECRAILS_REPO_DIR:-.}` — unset ⇒ `.` ⇒
+  classic in-repo run.)
+- `${SPECRAILS_REPO_DIR:-.}/README.md` (project intent and surface).
+- `${SPECRAILS_REPO_DIR:-.}/openspec/specs/` (existing specs — what the product
   contract is today).
-- `.specrails/local-tickets.json` (existing backlog —
-  don't propose duplicates).
-- A representative slice of the source code (5-10 files,
-  drawn from the relevant theme).
-- The desktop app's own `openspec/specs/` if relevant
+- `.specrails/local-tickets.json` (existing backlog — run-state, relative to
+  the working directory — don't propose duplicates).
+- A representative slice of the source code (5-10 files under
+  `${SPECRAILS_REPO_DIR:-.}`, drawn from the relevant theme).
+- The desktop app's own `${SPECRAILS_REPO_DIR:-.}/openspec/specs/` if relevant
   (cross-component changes).
 
 ### 2. Identify gaps

--- a/templates/codex-skills/rails/sr-reviewer/SKILL.md
+++ b/templates/codex-skills/rails/sr-reviewer/SKILL.md
@@ -11,6 +11,12 @@ implemented it. Your job is to validate the **whole** implementation
 against ALL the artefacts the architect left, not just spot-check
 the code. You emit a structured verdict and never touch the code.
 
+**Repository location.** `openspec/**`, `.git`, and the source live under
+`${SPECRAILS_REPO_DIR:-.}` (unset ⇒ `.` ⇒ classic in-repo run). Read change
+artefacts from `${SPECRAILS_REPO_DIR:-.}/openspec/...`, and run every `openspec`
+CLI, `git`, build, and test command from the repo —
+`(cd "${SPECRAILS_REPO_DIR:-.}" && …)`.
+
 ## Your scope
 
 You **validate**. You read every artefact, you re-run every check,
@@ -23,12 +29,12 @@ the completed OpenSpec change with the `openspec` CLI.
 
 ### 1. Validate the OpenSpec change package
 
-Load `openspec/changes/<slug>/` (the orchestrator gave you the
+Load `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<slug>/` (the orchestrator gave you the
 slug). **Run the OpenSpec validator first** — it is the canonical
 structural check and is mandatory:
 
 ```
-openspec validate "<slug>" --strict --json
+(cd "${SPECRAILS_REPO_DIR:-.}" && openspec validate "<slug>" --strict --json)
 ```
 
 A non-empty error list is a blocker finding: record each under
@@ -200,13 +206,13 @@ orchestrator has aggregated all reviewer verdicts. Therefore:
 When archiving is authorized and the verdict is clean, run these exact
 checks in order:
 
-1. Re-run `openspec validate "<slug>" --strict`.
-2. Read `openspec/changes/<slug>/tasks.md` and search for unchecked
+1. Re-run `(cd "${SPECRAILS_REPO_DIR:-.}" && openspec validate "<slug>" --strict)`.
+2. Read `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<slug>/tasks.md` and search for unchecked
    tasks (`- [ ]`). If any remain, do not archive; change the verdict to
    `fix needed: OpenSpec tasks remain unchecked`.
-3. Run `openspec archive "<slug>" -y`.
-4. Verify the archive landed: confirm `openspec/changes/<slug>/` is gone
-   and `openspec/changes/archive/` contains a directory whose name
+3. Run `(cd "${SPECRAILS_REPO_DIR:-.}" && openspec archive "<slug>" -y)`.
+4. Verify the archive landed: confirm `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<slug>/` is gone
+   and `${SPECRAILS_REPO_DIR:-.}/openspec/changes/archive/` contains a directory whose name
    includes `<slug>`.
 
 If validation, archive, or verification fails, do not report `clean`.

--- a/templates/codex-skills/retry/SKILL.md
+++ b/templates/codex-skills/retry/SKILL.md
@@ -13,8 +13,13 @@ You are NOT a separate pipeline. You inspect what `$implement`
 left behind, summarise the current state, and re-invoke
 `$implement` with a hint about what's already in place. The
 implement skill is idempotent — architect reuses an existing
-`openspec/changes/<slug>/`, developer detects ticked tasks and
+`${SPECRAILS_REPO_DIR:-.}/openspec/changes/<slug>/`, developer detects ticked tasks and
 already-correct files, reviewer re-validates from scratch.
+
+**Repository location.** `openspec/**` and `.git` live under
+`${SPECRAILS_REPO_DIR:-.}` (unset ⇒ `.` ⇒ classic in-repo run); inspect change
+artefacts there. The ticket store and `.specrails/agent-memory/` are run-state,
+relative to the working directory.
 
 ## How the user invokes you
 
@@ -25,8 +30,8 @@ already-correct files, reviewer re-validates from scratch.
 
 ### 0. Locate the prior run's artefacts
 
-1. Confirm `pwd` matches the git root.
-2. Load the ticket:
+1. Confirm the repo root with `git -C "${SPECRAILS_REPO_DIR:-.}" rev-parse --show-toplevel`.
+2. Load the ticket (run-state, relative to the working directory):
    `jq '.tickets["<ID>"]' .specrails/local-tickets.json`. If
    the ticket doesn't exist, stop and report.
 3. Inspect what's already on disk for this ticket:
@@ -34,11 +39,11 @@ already-correct files, reviewer re-validates from scratch.
      `.specrails/agent-memory/explanations/` named
      `*-architect-ticket-<ID>.md`. List the latest.
    - **OpenSpec change package**: any
-     `openspec/changes/<slug>/` whose proposal.md mentions
+     `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<slug>/` whose proposal.md mentions
      the ticket title or whose tasks.md has tasks scoped to
      the ticket. Find the slug.
    - **tasks.md progress**: count `[x]` vs `[ ]` boxes in
-     `openspec/changes/<slug>/tasks.md`.
+     `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<slug>/tasks.md`.
    - **Reviewer verdict**: latest matching
      `*-reviewer-ticket-<ID>.confidence-score.json`. Read
      the issues list and overall score.

--- a/templates/commands/specrails/implement.md
+++ b/templates/commands/specrails/implement.md
@@ -14,6 +14,20 @@ Full OpenSpec lifecycle with specialized agents: architect designs, developer im
 
 ---
 
+## Repository location (read first)
+
+Your working directory may NOT be the user's source repository. **Repo-resident** things — the source code, `openspec/**`, `.git`, and the GitHub remote — live under **`${SPECRAILS_REPO_DIR:-.}`**. The spawner sets `SPECRAILS_REPO_DIR` to the repo path; **when it is unset it defaults to `.` (the current directory), making every command below byte-identical to a classic in-repo run.**
+
+Rules used throughout this pipeline:
+- **openspec reads/writes** → `${SPECRAILS_REPO_DIR:-.}/openspec/...`
+- **git commands** → `git -C "${SPECRAILS_REPO_DIR:-.}" ...`
+- **`gh` commands** (issue/PR — they need the repo's remote) → run them from the repo: `(cd "${SPECRAILS_REPO_DIR:-.}" && gh ...)`
+- **worktree merge-back** → the merge *target* side (the main working tree) is `${SPECRAILS_REPO_DIR:-.}/<file>`
+
+**Run-state stays with the working directory** (NOT the repo): `.claude/pipeline-state/`, `.claude/agent-memory/`, `.claude/backlog-cache.json`, and the dry-run cache `.claude/.dry-run/` are all written relative to the current directory. **Profile/agent files** (`.claude/agents/sr-*.md`) are likewise resolved relative to the current directory — do NOT prefix them with `${SPECRAILS_REPO_DIR:-.}`.
+
+---
+
 ## Phase -1: Environment Setup (cloud pre-flight)
 
 **This phase runs BEFORE anything else.** Detect if we're in a cloud/remote environment and ensure all required tools are available.
@@ -353,7 +367,7 @@ If the write fails: print `[backlog-cache] Warning: could not write cache. Confl
 For each resolved issue number, run:
 
 ```bash
-gh issue view {number} --json number,title,state,assignees,labels,body,updatedAt
+(cd "${SPECRAILS_REPO_DIR:-.}" && gh issue view {number} --json number,title,state,assignees,labels,body,updatedAt)
 ```
 
 Build a snapshot object for each issue:
@@ -502,7 +516,7 @@ Otherwise, re-fetch each issue in scope and diff against the Phase 0 snapshot:
 **If `BACKLOG_PROVIDER=github`:** For each issue number in `ISSUE_REFS`:
 
 ```bash
-gh issue view {number} --json number,title,state,assignees,labels,body,updatedAt
+(cd "${SPECRAILS_REPO_DIR:-.}" && gh issue view {number} --json number,title,state,assignees,labels,body,updatedAt)
 ```
 
 If the `gh` command returns non-zero (issue deleted or inaccessible): treat as a CRITICAL conflict — field `"state"`, was `<cached state>`, now `"deleted"`.
@@ -558,7 +572,7 @@ For `body_sha` rows in the table, display only the first 8 characters of each SH
 
 For each chosen idea, launch an **sr-architect** agent (`subagent_type: sr-architect`, `run_in_background: true`).
 
-Each architect creates OpenSpec artifacts in `openspec/changes/<name>/`.
+Each architect creates OpenSpec artifacts in `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<name>/`.
 
 Each agent's prompt should include:
 - Description of the feature
@@ -574,7 +588,7 @@ After all architect agents complete, before launching any developer agent:
 
 #### Step 1: Extract file references
 
-For each `openspec/changes/<name>/tasks.md`, extract all paths listed under `**Files:**` entries (both `Create:` and `Modify:` lines). Normalize paths: strip leading `./`.
+For each `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<name>/tasks.md`, extract all paths listed under `**Files:**` entries (both `Create:` and `Modify:` lines). Normalize paths: strip leading `./`.
 
 #### Step 2: Build the shared-file registry
 
@@ -653,7 +667,7 @@ Before launching any developer agent, run a trivial Bash command to confirm Bash
 
 #### Choosing the right developer agent
 
-For each feature, read `openspec/changes/<name>/tasks.md` and classify every task by its layer tags and file references.
+For each feature, read `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<name>/tasks.md` and classify every task by its layer tags and file references.
 
 **Step 1 — Classify tasks into layers:**
 
@@ -857,6 +871,8 @@ If a doc-sync agent fails or times out:
 
 #### Merge Algorithm
 
+The merge **target** (the main repo working tree where merged files land) is `<target>` = **`${SPECRAILS_REPO_DIR:-.}`**. Every `<target>/<file>` below therefore resolves to `${SPECRAILS_REPO_DIR:-.}/<file>` so merged code lands in the real repo, not the working directory. (`<worktree-path>` is an absolute git-worktree path supplied by the runtime; `git -C <worktree-path>` already targets it directly.)
+
 Process features in `MERGE_ORDER` sequence. For each feature:
 
 **Step 1: Identify changed files**
@@ -871,7 +887,7 @@ Split into `exclusive_files` (only this feature modifies them) and `shared_files
 
 Copy directly from worktree to target:
 ```bash
-cp <worktree-path>/<file> <target>/<file>
+cp <worktree-path>/<file> "${SPECRAILS_REPO_DIR:-.}"/<file>
 ```
 Log: `Copied (exclusive): <file>`
 
@@ -880,7 +896,7 @@ Log: `Copied (exclusive): <file>`
 For each shared file, choose strategy by file type:
 
 **Strategy A — Markdown section-aware merge** (`.md` files):
-1. Read base: current content of `<target>/<file>`.
+1. Read base: current content of `${SPECRAILS_REPO_DIR:-.}/<file>` (the merge target).
 2. Read incoming: `<worktree-path>/<file>`.
 3. Parse both into sections using `##` heading boundaries (heading line + all content until next `##` or EOF).
 4. Build section maps: `{heading_text: content}` for base and incoming.
@@ -897,7 +913,7 @@ For each shared file, choose strategy by file type:
      >>>>>>> base
      ```
      Log: `CONFLICT: <file> — section "<heading>" requires manual resolution.`
-6. Write merged result to `<target>/<file>`.
+6. Write merged result to `${SPECRAILS_REPO_DIR:-.}/<file>` (the merge target).
 
 **Strategy B — Unified diff sequential apply** (all other file types):
 1. Generate incoming diff against original `main`:
@@ -906,7 +922,7 @@ For each shared file, choose strategy by file type:
    ```
 2. Apply to current target:
    ```bash
-   patch --forward --fuzz=3 <target>/<file> < <diff>
+   patch --forward --fuzz=3 "${SPECRAILS_REPO_DIR:-.}"/<file> < <diff>
    ```
 3. If `patch` succeeds: log `Merged (diff-apply): <file>`.
 4. If `patch` fails: insert conflict markers around rejected hunks. Log: `CONFLICT: <file> — N hunks rejected.`
@@ -949,7 +965,7 @@ If `MERGE_REPORT.requires_resolution` is non-empty:
 
 Build `CONTEXT_BUNDLES` from the features in `MERGE_ORDER`:
 ```
-{ "<feature-a>": "openspec/changes/<feature-a>/context-bundle.md", "<feature-b>": "openspec/changes/<feature-b>/context-bundle.md" }
+{ "<feature-a>": "${SPECRAILS_REPO_DIR:-.}/openspec/changes/<feature-a>/context-bundle.md", "<feature-b>": "${SPECRAILS_REPO_DIR:-.}/openspec/changes/<feature-b>/context-bundle.md" }
 ```
 
 Load merge resolver config from `.claude/merge-resolver-config.json` if it exists. Extract `confidence_threshold` (default: 70) and `mode` (default: `auto`).
@@ -959,7 +975,7 @@ Construct the `sr-merge-resolver` agent prompt with:
 - `CONTEXT_BUNDLES`: the map above
 - `CONFIDENCE_THRESHOLD`: from config or default (70)
 - `RESOLUTION_MODE`: from config or default (`auto`)
-- `REPORT_PATH`: `openspec/changes/<first-feature-in-MERGE_ORDER>/merge-resolution-report.md`
+- `REPORT_PATH`: `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<first-feature-in-MERGE_ORDER>/merge-resolution-report.md`
 
 Launch the **sr-merge-resolver** agent (`subagent_type: sr-merge-resolver`, foreground, `run_in_background: false`). Wait for it to complete.
 
@@ -1107,7 +1123,7 @@ After the generalist reviewer agent completes, evaluate the confidence score bef
 
 #### Step 1 — Read score file
 
-Path: `openspec/changes/<name>/confidence-score.json`
+Path: `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<name>/confidence-score.json`
 
 - If the file does not exist:
   - Set `CONFIDENCE_STATUS=MISSING`
@@ -1213,7 +1229,7 @@ Re-fetch each issue in `ISSUE_REFS` and diff against `.claude/backlog-cache.json
 
 **If `BACKLOG_PROVIDER=github`:**
 ```bash
-gh issue view {number} --json number,title,state,assignees,labels,body,updatedAt
+(cd "${SPECRAILS_REPO_DIR:-.}" && gh issue view {number} --json number,title,state,assignees,labels,body,updatedAt)
 ```
 
 If the cache file is missing or malformed JSON at this point: log `[conflict-check] Warning: cache file missing or unreadable. Skipping diff for this run.` and proceed to Phase 4c (treat as clean).
@@ -1270,13 +1286,15 @@ This phase respects the `GIT_AUTO` and `BACKLOG_WRITE` settings from configurati
 
 #### If `GIT_AUTO=true` (automatic shipping)
 
-1. Create branch from `main`: `git checkout -b feat/<descriptive-name>`
-2. One commit per feature with descriptive messages
-3. If the reviewer modified files, create an additional commit: `fix: resolve CI issues (reviewer)`
-4. Push with `-u` flag: `git push -u origin <branch-name>`
-5. Create PR (if GitHub CLI is available):
+All git operations run against the repo via `git -C "${SPECRAILS_REPO_DIR:-.}"`, and `gh` runs from inside the repo so it can detect the remote.
+
+1. Create branch from `main`: `git -C "${SPECRAILS_REPO_DIR:-.}" checkout -b feat/<descriptive-name>`
+2. One commit per feature with descriptive messages (`git -C "${SPECRAILS_REPO_DIR:-.}" add … && git -C "${SPECRAILS_REPO_DIR:-.}" commit -m …`)
+3. If the reviewer modified files, create an additional commit: `git -C "${SPECRAILS_REPO_DIR:-.}" commit -m "fix: resolve CI issues (reviewer)"`
+4. Push with `-u` flag: `git -C "${SPECRAILS_REPO_DIR:-.}" push -u origin <branch-name>`
+5. Create PR (if GitHub CLI is available), running it from the repo:
    ```bash
-   {{PR_CREATE_CMD}}
+   (cd "${SPECRAILS_REPO_DIR:-.}" && {{PR_CREATE_CMD}})
    ```
    If `gh` is not authenticated, print a compare URL for manual PR creation.
 
@@ -1293,9 +1311,9 @@ All implementation is complete and CI checks pass.
 - [list all modified/created files per feature]
 
 ### Suggested Next Steps
-1. Review the changes: `git diff`
-2. Create a branch: `git checkout -b feat/<name>`
-3. Stage and commit: `git add <files> && git commit -m "feat: ..."`
+1. Review the changes: `git -C "${SPECRAILS_REPO_DIR:-.}" diff`
+2. Create a branch: `git -C "${SPECRAILS_REPO_DIR:-.}" checkout -b feat/<name>`
+3. Stage and commit: `git -C "${SPECRAILS_REPO_DIR:-.}" add <files> && git -C "${SPECRAILS_REPO_DIR:-.}" commit -m "feat: ..."`
 4. Push and create PR manually
 ```
 
@@ -1307,7 +1325,7 @@ All implementation is complete and CI checks pass.
   {{BACKLOG_COMMENT_CMD}}
   ```
   - **Local:** Update the ticket status to `"done"` using `{{BACKLOG_UPDATE_CMD}}` and add a comment: `"Implemented in PR #XX. All acceptance criteria met."` via `{{BACKLOG_COMMENT_CMD}}`. Local tickets are closed directly — there is no auto-close-on-merge mechanism.
-  - **GitHub:** `gh issue comment {number} --body "Implemented in PR #XX. All acceptance criteria met."` — do NOT close the issue explicitly. Use `Closes #N` in the PR body so GitHub auto-closes on merge.
+  - **GitHub:** `(cd "${SPECRAILS_REPO_DIR:-.}" && gh issue comment {number} --body "Implemented in PR #XX. All acceptance criteria met.")` — do NOT close the issue explicitly. Use `Closes #N` in the PR body so GitHub auto-closes on merge.
   - **JIRA:** `jira issue comment {key} --message "Implemented in PR #XX. All acceptance criteria met."`
   - For GitHub/JIRA: ensure the PR body includes `Closes #N` for each fully resolved issue (auto-closes on merge)
 - For partially resolved issues/tickets: add a comment noting progress:

--- a/templates/commands/specrails/retry.md
+++ b/templates/commands/specrails/retry.md
@@ -19,6 +19,8 @@ Resume a failed `/specrails:implement` run for **{{PROJECT_NAME}}**. Reads pipel
 
 **MANDATORY: Follow this pipeline exactly. Do NOT skip phases or re-run phases that already succeeded. Read all context from the pipeline state file — do not rely on memory. Do not re-implement anything yourself; delegate to the same agents used by `/specrails:implement`.**
 
+**Repository location.** Your working directory may NOT be the user's source repository. Repo-resident things — `openspec/**`, source, `.git`, the GitHub remote — live under **`${SPECRAILS_REPO_DIR:-.}`** (set by the spawner; unset ⇒ `.` ⇒ byte-identical to a classic in-repo run). The pipeline-state file itself is **run-state**, read from `.claude/pipeline-state/` relative to the working directory — do NOT prefix it. The `openspec_artifacts` value stored in that file is a repo-relative path (`openspec/changes/<name>/`); prefix it with `${SPECRAILS_REPO_DIR:-.}/` when you read those files on disk. All git/PR operations are delegated to `/specrails:implement` Phase 4c, which already runs them against the repo.
+
 **Input:** $ARGUMENTS — accepted forms:
 
 1. `<feature-name>` — kebab-case feature name matching a `.claude/pipeline-state/<feature-name>.json` file
@@ -214,7 +216,7 @@ Wait for all architects to complete.
 Before launching, verify architect artifacts exist:
 
 ```bash
-ls <OPENSPEC_ARTIFACTS>tasks.md <OPENSPEC_ARTIFACTS>context-bundle.md
+ls "${SPECRAILS_REPO_DIR:-.}/<OPENSPEC_ARTIFACTS>tasks.md" "${SPECRAILS_REPO_DIR:-.}/<OPENSPEC_ARTIFACTS>context-bundle.md"
 ```
 
 If missing and `RESUME_PHASE=developer`: print:

--- a/templates/gemini-commands/implement.toml
+++ b/templates/gemini-commands/implement.toml
@@ -58,14 +58,18 @@ The change is archived BY THE REVIEWER as part of a passing review — never by 
 
 ## Pipeline
 
-0. **Bootstrap.** Confirm `pwd` is the git repo root and load the ticket from
-   `.specrails/local-tickets.json` (or use the free-form description). Then go
-   STRAIGHT to phase 1 — do not analyse, design, scaffold, or write anything
-   yourself; the architect does that.
+0. **Bootstrap.** The source repo (with `openspec/**` and `.git`) lives at
+   `${SPECRAILS_REPO_DIR:-.}` — when `SPECRAILS_REPO_DIR` is unset it defaults to
+   `.`, i.e. your current directory is the repo (classic behaviour). Confirm the
+   repo root with `git -C "${SPECRAILS_REPO_DIR:-.}" rev-parse --show-toplevel`,
+   then load the ticket from `.specrails/local-tickets.json` (run-state — relative
+   to the working directory, NOT the repo). Then go STRAIGHT to phase 1 — do not
+   analyse, design, scaffold, or write anything yourself; the architect does that.
 
 1. **DESIGN — `invoke_agent` `sr-architect`.** Pass it the ticket/description.
    It creates an OpenSpec change (proposal + spec deltas + tasks) under
-   `openspec/changes/<id>/` and validates it (`openspec validate <id> --strict`).
+   `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<id>/` and validates it
+   (`openspec validate <id> --strict`).
    Apply the outcome rules above.
 
 2. **APPLY — `invoke_agent` `sr-developer`.** Only after the architect reports
@@ -89,7 +93,7 @@ The change is archived BY THE REVIEWER as part of a passing review — never by 
    or ambiguous review: the reviewer's PASS is the ONLY gate to archive.
 
 4. **ARCHIVE (verify only).** Confirm the change moved under
-   `openspec/changes/archive/`. If the reviewer PASSED but the change was somehow
+   `${SPECRAILS_REPO_DIR:-.}/openspec/changes/archive/`. If the reviewer PASSED but the change was somehow
    not archived, re-`invoke_agent` `sr-reviewer` to complete it. Never archive by
    hand to substitute for the reviewer.
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     environment: 'node',
     globals: false,
+    // Safety net: pin SPECRAILS_REGISTRY_HOME to a throwaway tmp dir so no test
+    // can write the relocation registry/workspace into the real ~/.specrails.
+    setupFiles: ['src/installer/__tests__/vitest-setup.ts'],
     // Windows runners under load take 25-40s for git + scaffold
     // integration tests and trip the 20s ceiling, leaving subprocesses
     // holding files open which cascades into EBUSY rmdir failures


### PR DESCRIPTION
## What

Move every specrails artifact out of the target repo into the user's `$HOME`, and install the provider-invariant **framework once** (bundled in the desktop app) instead of scaffolding it per-project. **Imported repos stay pristine** — zero `.specrails/.claude/.codex/.gemini` and zero modifications; only `openspec/**` (intentional, repo-resident) remains.

## How

- **Registry** (`util/registry.ts`): canonical-realpath key → per-project workspace under `~/.specrails/projects/<slug>/workspace`; `frameworkRoot()`; atomic temp+rename writes under an advisory lock (**fail-closed** on timeout); fail-open legacy fallback; slug immutable once allocated.
- **codeRoot/artifactRoot split** (relocate-always): the installer writes artifacts to the workspace, never the repo (`ensureGitignore`/`pruneLegacyArtifacts` are no-ops against the repo). `openspec/**` stays at `codeRoot`.
- **Bundled framework**: `installFramework` + `ensureCurrentSymlink` + `assembleProjectWorkspace` materialize the framework **once** to `framework/<version>/<provider>`; each workspace **symlinks** `framework/current` (agents per-file so `custom-*.md` coexist; commands/skills/rules dir-symlinked; `agent-memory` a real writable dir; **copy fallback on Windows**). Offline CLI subcommands `install-framework` / `assemble` / `swap-current` (+ `--no-swap` so a multi-provider install swaps `current` exactly once after all providers materialize).
- **Runtime re-pointing**: templates + opsx skills resolve repo-resident I/O (openspec, source edits, git, the user's `CLAUDE.md`) via `${SPECRAILS_REPO_DIR:-.}` — **default-unset = byte-identical legacy**. A lint test fails on any unwrapped `openspec`/`git`. openspec pinned **1.4.1**; `buildOpenSpecInvocation` runs a bundled node-script openspec (offline) or falls back to npx.
- **Hardening**: Windows force-copies agents (no EPERM file-symlink); gemini ack keyed on the workspace; a `vitest-setup` safety net pins `SPECRAILS_REGISTRY_HOME` to a tmp so no test writes the real `~/.specrails`.

## Tests
311 tests; coverage 88% stmts / 79% branch / 98% funcs / 91% lines (gates 75/70).

> Pairs with the matching specrails-desktop PR (desktop bundles this core, drives the offline assembly, and owns the registry writer). Tauri/CI bundling validated by mirroring the runtimes pattern; needs a real `.dmg`/`.exe` build to smoke end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yDpwMwyGtwYF9mh5tTKk4