### PR TITLE
fix(update): add --provider flag so multi-provider workspaces update the right provider

### DIFF
--- a/src/installer/commands/update.test.ts
+++ b/src/installer/commands/update.test.ts
@@ -231,6 +231,46 @@ describe('runUpdate', () => {
     })
   })
 
+  describe('--provider override (multi-provider)', () => {
+    it('updates the FORCED provider even when .claude exists (auto-detect would pick claude)', async () => {
+      const scriptDir = path.join(tmpDir, 'core')
+      const repoRoot = path.join(tmpDir, 'repo')
+      await setupFakeScriptDir(scriptDir, '5.0.0')
+      await simulateExistingInstall(repoRoot, '4.2.0')
+      // Multi-provider workspace: both .claude (created by simulateExistingInstall)
+      // and .gemini are present. Auto-detection returns claude (.claude first).
+      mkdirp(path.join(workspaceFor(repoRoot), '.gemini', 'commands', 'specrails'))
+      process.env.SPECRAILS_CORE_SCRIPT_DIR = scriptDir
+
+      const result = await runUpdate({ 'root-dir': repoRoot, provider: 'gemini' })
+      expect(result.provider).toBe('gemini')
+    })
+
+    it('auto-detects (claude first) when --provider is omitted — backward compatible', async () => {
+      const scriptDir = path.join(tmpDir, 'core')
+      const repoRoot = path.join(tmpDir, 'repo')
+      await setupFakeScriptDir(scriptDir, '5.0.0')
+      await simulateExistingInstall(repoRoot, '4.2.0')
+      mkdirp(path.join(workspaceFor(repoRoot), '.gemini', 'commands', 'specrails'))
+      process.env.SPECRAILS_CORE_SCRIPT_DIR = scriptDir
+
+      const result = await runUpdate({ 'root-dir': repoRoot })
+      expect(result.provider).toBe('claude')
+    })
+
+    it('rejects an invalid --provider value', async () => {
+      const scriptDir = path.join(tmpDir, 'core')
+      const repoRoot = path.join(tmpDir, 'repo')
+      await setupFakeScriptDir(scriptDir, '5.0.0')
+      await simulateExistingInstall(repoRoot, '4.2.0')
+      process.env.SPECRAILS_CORE_SCRIPT_DIR = scriptDir
+
+      await expect(
+        runUpdate({ 'root-dir': repoRoot, provider: 'bogus' }),
+      ).rejects.toThrow(/--provider value must be 'claude', 'codex', or 'gemini'/)
+    })
+  })
+
   describe('--only flag', () => {
     it('defaults to scope=all when --only is omitted', async () => {
       const scriptDir = path.join(tmpDir, 'core')

--- a/src/installer/commands/update.ts
+++ b/src/installer/commands/update.ts
@@ -51,6 +51,14 @@ export interface UpdateFlags {
   'dry-run'?: boolean
   yes?: boolean
   'agent-teams'?: boolean
+  /**
+   * Force the provider to update. Without it, the provider is auto-detected
+   * from the existing install (`.claude` > `.codex` > `.gemini`), which on a
+   * MULTI-PROVIDER workspace always picks `.claude` first — so codex/gemini
+   * could never be updated. specrails-desktop (and standalone users) pass
+   * `--provider <name>` to update one specific provider. Mirrors `init`.
+   */
+  provider?: string | boolean
 }
 
 export interface UpdateResult {
@@ -108,8 +116,24 @@ export async function runUpdate(flags: UpdateFlags): Promise<UpdateResult> {
   }
   const previousVersion = readExistingVersion(artifactRoot)
 
-  step('Update: resolving provider from existing install')
-  const provider = await resolveExistingProvider(artifactRoot)
+  // Provider can be FORCED via --provider (e.g. specrails-desktop updating one
+  // provider on a multi-provider workspace, where auto-detection would always
+  // resolve `.claude` first and never reach codex/gemini). Absent ⇒ auto-detect
+  // from the existing install — byte-identical single-provider behaviour.
+  let provider: Provider
+  if (typeof flags.provider === 'string') {
+    if (flags.provider !== 'claude' && flags.provider !== 'codex' && flags.provider !== 'gemini') {
+      throw new InstallerError(
+        `--provider value must be 'claude', 'codex', or 'gemini', got: ${flags.provider}`,
+        40,
+      )
+    }
+    provider = flags.provider as Provider
+    step(`Update: using requested provider ${provider}`)
+  } else {
+    step('Update: resolving provider from existing install')
+    provider = await resolveExistingProvider(artifactRoot)
+  }
   const { providerDir } = derivedPaths(provider)
   ok(`Detected provider: ${provider} (${providerDir})`)
 


### PR DESCRIPTION
## Problem

`npx specrails-core update` resolves which provider to update by **filesystem auto-detection** (`resolveExistingProvider`: `.claude` > `.codex` > `.gemini`). On a **multi-provider** workspace where all three dirs exist, that **always picks `.claude` first** — so `codex` / `gemini` can never be updated, with no error or warning.

## Fix

Add a `--provider <claude|codex|gemini>` flag, mirroring `init`: passed → validated and used directly; omitted → existing auto-detection (backward-compatible). Lets a standalone user — and specrails-desktop — target one provider's update on a multi-provider project.

## Tests
- Forced `--provider gemini` wins over auto-detected `.claude`; omitted flag still auto-detects; invalid value rejected.
- Full suite green: 26 files, 316 tests.

> **Re-targeted to `main`.** This was originally opened as #307 against the stale `feat/relocate-artifacts-to-home` branch — but relocation is already on `main` (released as 4.9.0 via #306), so #307 never reached `main`. This PR puts the fix where it belongs. Closes #307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yDpwMwyGtwYF9mh5tTKk4