### PR TITLE
feat(init): re-land #313 onto main — install in-repo by default

### DIFF
--- a/src/installer/commands/init.test.ts
+++ b/src/installer/commands/init.test.ts
@@ -119,11 +119,14 @@ describe('runInit', () => {
     await initRepo(repoRoot)
 
     process.env.SPECRAILS_CORE_SCRIPT_DIR = scriptDir
+    // `--relocate` keeps the $HOME-workspace symlink layout this test asserts;
+    // standalone in-repo placement is exercised by the dedicated in-repo test.
     const result = await runInit({
       'root-dir': repoRoot,
       yes: true,
       provider: 'claude',
       quick: true,
+      relocate: true,
     })
 
     expect(result.provider).toBe('claude')
@@ -194,6 +197,7 @@ describe('runInit', () => {
       'root-dir': repoRoot,
       yes: true,
       'from-config': true,
+      relocate: true,
     })
 
     expect(result.tier).toBe('quick')
@@ -214,7 +218,7 @@ describe('runInit', () => {
     const repoRoot = path.join(tmpDir, 'repo-codex')
     mkdirp(repoRoot)
     await initRepo(repoRoot)
-    const result = await runInit({ 'root-dir': repoRoot, yes: true, provider: 'codex', quick: true })
+    const result = await runInit({ 'root-dir': repoRoot, yes: true, provider: 'codex', quick: true, relocate: true })
     expect(result.provider).toBe('codex')
     const ws = workspaceFor(repoRoot)
     // Provider-derived layout: .codex/ + AGENTS.md — under the workspace.
@@ -237,6 +241,104 @@ describe('runInit', () => {
     await expect(
       runInit({ 'root-dir': repoRoot, yes: true, provider: 'turbofake' as never }),
     ).rejects.toThrow(/must be 'claude', 'codex', or 'gemini'/)
+  })
+
+  it('installs IN-REPO by default (no --relocate, no pre-existing registry entry): real files, not symlinks', async () => {
+    const scriptDir = path.join(tmpDir, 'core')
+    const repoRoot = path.join(tmpDir, 'repo-inrepo')
+    mkdirp(repoRoot)
+    await setupFakeScriptDir(scriptDir)
+    await initRepo(repoRoot)
+    process.env.SPECRAILS_CORE_SCRIPT_DIR = scriptDir
+
+    // No registry entry exists for this repo and no --relocate is passed → the
+    // standalone in-repo layout: artifacts land in the repo as REAL files so a
+    // user's `claude` running in the repo finds them.
+    const result = await runInit({
+      'root-dir': repoRoot,
+      yes: true,
+      provider: 'claude',
+      quick: true,
+    })
+    expect(result.provider).toBe('claude')
+
+    // The repo received the framework agents as REAL regular files — NOT symlinks
+    // into $HOME/.specrails/framework.
+    const repoArch = path.join(repoRoot, '.claude', 'agents', 'sr-architect.md')
+    expect(pathExists(repoArch), 'repo has sr-architect.md').toBe(true)
+    expect(lstatSync(repoArch).isSymbolicLink(), 'sr-architect.md is NOT a symlink').toBe(false)
+    expect(lstatSync(repoArch).isFile(), 'sr-architect.md is a regular file').toBe(true)
+    expect(readTextFile(repoArch).length, 'sr-architect.md has content').toBeGreaterThan(0)
+
+    // Whole-dir subtrees (commands) are also REAL dirs, not symlinks, in-repo.
+    const repoCommands = path.join(repoRoot, '.claude', 'commands', 'specrails')
+    expect(isDir(repoCommands)).toBe(true)
+    expect(isSymlink(path.join(repoRoot, '.claude', 'commands'))).toBe(false)
+
+    // The in-repo marker: the specrails-version file lives in the repo's
+    // .specrails/, not in a relocated $HOME workspace.
+    expect(pathExists(path.join(repoRoot, '.specrails', 'specrails-version'))).toBe(true)
+    expect(
+      readFileSync(path.join(repoRoot, '.specrails', 'specrails-version'), 'utf8').trim(),
+    ).toBe('4.2.0')
+
+    // agent-memory is a REAL writable dir either way (never linked).
+    expect(isDir(path.join(repoRoot, '.claude', 'agent-memory', 'sr-architect'))).toBe(true)
+
+    // No relocated workspace was allocated for this repo: the resolver falls back
+    // to the in-repo layout (artifactRoot === the repo's canonical realpath).
+    expect(workspaceFor(repoRoot)).toBe(realpathSync(repoRoot))
+  })
+
+  it('relocates to the $HOME workspace with --relocate (repo stays pristine)', async () => {
+    const scriptDir = path.join(tmpDir, 'core')
+    const repoRoot = path.join(tmpDir, 'repo-relocate')
+    mkdirp(repoRoot)
+    await setupFakeScriptDir(scriptDir)
+    await initRepo(repoRoot)
+    process.env.SPECRAILS_CORE_SCRIPT_DIR = scriptDir
+
+    await runInit({
+      'root-dir': repoRoot,
+      yes: true,
+      provider: 'claude',
+      quick: true,
+      relocate: true,
+    })
+
+    // The repo got NOTHING Specrails-owned — it stays pristine.
+    assertRepoHasNoSpecrailsArtifacts(repoRoot)
+
+    // The relocated $HOME workspace (under SPECRAILS_REGISTRY_HOME) holds the
+    // agents instead.
+    const ws = workspaceFor(repoRoot)
+    expect(ws).not.toBe(repoRoot)
+    expect(pathExists(path.join(ws, '.claude', 'agents', 'sr-architect.md'))).toBe(true)
+    expect(pathExists(path.join(ws, '.specrails', 'specrails-version'))).toBe(true)
+  })
+
+  it('relocates when SPECRAILS_RELOCATE=1 is set (env opt-in)', async () => {
+    const scriptDir = path.join(tmpDir, 'core')
+    const repoRoot = path.join(tmpDir, 'repo-relocate-env')
+    mkdirp(repoRoot)
+    await setupFakeScriptDir(scriptDir)
+    await initRepo(repoRoot)
+    process.env.SPECRAILS_CORE_SCRIPT_DIR = scriptDir
+
+    const prevRelocate = process.env.SPECRAILS_RELOCATE
+    process.env.SPECRAILS_RELOCATE = '1'
+    try {
+      await runInit({ 'root-dir': repoRoot, yes: true, provider: 'claude', quick: true })
+    } finally {
+      if (prevRelocate === undefined) delete process.env.SPECRAILS_RELOCATE
+      else process.env.SPECRAILS_RELOCATE = prevRelocate
+    }
+
+    // Repo pristine; artifacts in the relocated workspace.
+    assertRepoHasNoSpecrailsArtifacts(repoRoot)
+    const ws = workspaceFor(repoRoot)
+    expect(ws).not.toBe(repoRoot)
+    expect(pathExists(path.join(ws, '.claude', 'agents', 'sr-architect.md'))).toBe(true)
   })
 
   // Uses a POSIX shell script as a fake openspec binary, pointed at via

--- a/src/installer/commands/init.ts
+++ b/src/installer/commands/init.ts
@@ -31,6 +31,14 @@ import { frameworkRoot, resolveArtifacts } from '../util/registry.js'
  *   --provider <claude>   Force provider (only `claude` accepted in v1)
  *   --from-config [<p>]   Read provider + tier from install-config.yaml
  *   --quick               Quick tier (direct template placement, skip enrich)
+ *   --relocate            Relocate artifacts to the $HOME workspace (symlinked
+ *                         from the bundled framework) instead of installing them
+ *                         IN-REPO. Default is in-repo so a standalone user's
+ *                         `claude`/`codex`/`gemini` finds the agents/commands in
+ *                         their own repo. specrails-desktop pre-creates a registry
+ *                         entry (so it always relocates regardless of this flag);
+ *                         standalone users opt in with `--relocate` or
+ *                         `SPECRAILS_RELOCATE=1`.
  */
 
 export interface InitFlags {
@@ -39,6 +47,7 @@ export interface InitFlags {
   provider?: string | boolean
   'from-config'?: string | boolean
   quick?: boolean
+  relocate?: boolean
   'hub-json'?: boolean
 }
 
@@ -104,17 +113,27 @@ export async function runInit(flags: InitFlags): Promise<InitResult> {
     skipPrereqs,
   })
 
-  // ─── Relocate-always: resolve where artifacts live ───────────────────
-  // EVERY Specrails artifact lands under `artifactRoot` (the $HOME workspace),
-  // never in the repo. The ONLY in-repo writes are `openspec/**` (below) and
-  // git/worktree ops. `codeRoot` is always the repo.
+  // ─── Resolve where artifacts live: in-repo (default) vs relocated ─────
+  // Standalone `init` installs IN-REPO by default so a user's CLI finds the
+  // agents/commands in their own repo. Relocation (the $HOME workspace, with the
+  // framework symlinked in) is opt-in via `--relocate` / `SPECRAILS_RELOCATE=1`,
+  // and is what specrails-desktop drives (it pre-creates the registry entry, so
+  // `allocate:false` still resolves an EXISTING relocated entry → relocated).
+  //
+  // `allocate:false` + no existing entry ⇒ legacy in-repo layout where
+  // `artifactRoot === codeRoot === repoRoot`. `allocate:true` (relocate) allocates
+  // a $HOME workspace entry. EVERY Specrails artifact lands under `artifactRoot`;
+  // the ONLY in-repo writes are `openspec/**` (below) and git/worktree ops.
+  const relocate = flags.relocate === true || process.env.SPECRAILS_RELOCATE === '1'
   const { artifactRoot, codeRoot } = resolveArtifacts(repoRoot, {
-    allocate: true,
+    allocate: relocate,
     allocator: 'core-standalone',
     home: process.env.SPECRAILS_REGISTRY_HOME,
     providers: [prereqs.provider],
     coreVersion: version,
   })
+  // In-repo when the resolution did NOT relocate the artifacts out of the repo.
+  const inRepo = artifactRoot === codeRoot
 
   // ─── Phase 2 + 3 ──────────────────────────────────────────────────────
   // Bundled-framework flow: materialize the provider-INVARIANT framework ONCE
@@ -144,8 +163,15 @@ export async function runInit(flags: InitFlags): Promise<InitResult> {
     codeRoot,
     scriptDir,
     selectedAgents: selectedAgentsHint,
+    // In-repo: COPY the framework statics as real, committable files. Relocated:
+    // symlink from the framework store (O(1) update on a version swap).
+    copyStatics: inRepo,
   })
-  ok(`Linked ${providerDir}/ from framework ${version} + seeded project layer`)
+  if (inRepo) {
+    ok(`Copied ${providerDir}/ from framework ${version} into the repo + seeded project layer`)
+  } else {
+    ok(`Linked ${providerDir}/ from framework ${version} + seeded project layer`)
+  }
 
   // openspec STAYS in the repo (codeRoot) — unchanged behaviour.
   await installOpenSpecProject(codeRoot, prereqs.provider)

--- a/src/installer/commands/update.ts
+++ b/src/installer/commands/update.ts
@@ -58,6 +58,13 @@ export interface UpdateFlags {
    * `--provider <name>` to update one specific provider. Mirrors `init`.
    */
   provider?: string | boolean
+  /**
+   * Relocate artifacts to the $HOME workspace (symlinked) instead of in-repo.
+   * Mirrors `init --relocate`: standalone updates resolve in-repo by default,
+   * desktop relocates (its registry entry already exists, so `allocate:false`
+   * still resolves the relocated entry). Also honoured via `SPECRAILS_RELOCATE=1`.
+   */
+  relocate?: boolean
 }
 
 export interface UpdateResult {
@@ -84,13 +91,16 @@ export async function runUpdate(flags: UpdateFlags): Promise<UpdateResult> {
   // Read install-config.yaml so the user's original choices (tier) survive
   // the update. Flag overrides win when present; missing config falls back to
   // defaults (tier=full).
-  // ─── Relocate-always: resolve where artifacts live ───────────────────
-  // All Specrails artifacts (incl. the specrails-version marker, manifest,
-  // install-config) live under `artifactRoot` (the $HOME workspace), never the
-  // repo. On update the registry entry already exists (created by init), so the
-  // `providers` hint is ignored; we resolve first, then read the install.
+  // ─── Resolve where artifacts live: in-repo (default) vs relocated ─────
+  // Mirrors init: standalone updates resolve IN-REPO by default (`allocate:false`
+  // + no registry entry ⇒ `artifactRoot === codeRoot === repoRoot`); desktop and
+  // `--relocate`/`SPECRAILS_RELOCATE=1` users resolve the relocated $HOME
+  // workspace (desktop's registry entry already exists, so even `allocate:false`
+  // returns it). All Specrails artifacts (the specrails-version marker, manifest,
+  // install-config) live under `artifactRoot`.
+  const relocate = flags.relocate === true || process.env.SPECRAILS_RELOCATE === '1'
   const { artifactRoot, codeRoot } = resolveArtifacts(repoRoot, {
-    allocate: true,
+    allocate: relocate,
     allocator: 'core-standalone',
     home: process.env.SPECRAILS_REGISTRY_HOME,
     coreVersion: currentVersion,
@@ -180,6 +190,8 @@ export async function runUpdate(flags: UpdateFlags): Promise<UpdateResult> {
       codeRoot,
       scriptDir,
       selectedAgents,
+      // In-repo updates COPY real files; relocated workspaces symlink.
+      copyStatics: artifactRoot === codeRoot,
     })
     ok(`Re-linked ${providerDir}/ at framework ${currentVersion} + rewrote manifest`)
   } else if (scope === 'rules' || scope === 'agents') {

--- a/src/installer/phases/scaffold.ts
+++ b/src/installer/phases/scaffold.ts
@@ -559,6 +559,18 @@ export interface AssembleProjectWorkspaceInput {
    * is always the full superset; this is where per-project filtering happens.
    */
   selectedAgents?: string[]
+  /**
+   * When true, the static provider subtrees (`agents`/`commands`/`skills`/`rules`)
+   * and the settings file are COPIED as real files from the framework store into
+   * the workspace instead of SYMLINKED. Used by the in-repo standalone install
+   * (`init`/`update` with `artifactRoot === codeRoot`) so the repo gets real,
+   * committable files — a symlink into `$HOME/.specrails/framework` would be
+   * invisible to a standalone user's `claude`/`codex`/`gemini` running in the
+   * repo. The PROJECT layer (agent-memory, manifest, instruction files) is real
+   * either way. Defaults to false (relocated workspaces symlink — the desktop /
+   * `--relocate` path).
+   */
+  copyStatics?: boolean
 }
 
 export interface AssembleProjectWorkspaceResult {
@@ -598,6 +610,10 @@ export function assembleProjectWorkspace(
     ? new Set([...input.selectedAgents, ...CORE_AGENTS])
     : new Set([...CORE_AGENTS])
 
+  // In-repo standalone install COPIES the static subtrees as real files; the
+  // relocated (desktop / --relocate) path symlinks them. Defaults to symlink.
+  const preferCopy = input.copyStatics === true
+
   const links: Record<string, 'symlink' | 'junction' | 'copy'> = {}
   for (const sub of LINKED_PROVIDER_SUBTREES[input.provider]) {
     const target = path.join(currentProviderDir, sub)
@@ -606,10 +622,10 @@ export function assembleProjectWorkspace(
     if (sub === 'agents') {
       // `agents/` is linked PER-FILE so the workspace can carry user/desktop
       // `custom-*.md` agents alongside the framework agents.
-      links[sub] = linkAgentFiles(target, dest, selectedAgentSet)
+      links[sub] = linkAgentFiles(target, dest, selectedAgentSet, preferCopy)
     } else {
       // Every other subtree holds no user files → whole-dir symlink (single inode).
-      links[sub] = symlinkOrCopy(target, dest)
+      links[sub] = symlinkOrCopy(target, dest, preferCopy)
     }
   }
 
@@ -622,7 +638,7 @@ export function assembleProjectWorkspace(
     const settingsTarget = path.join(currentProviderDir, settingsFile)
     const settingsLink = path.join(workspaceProviderDir, settingsFile)
     if (pathExists(settingsTarget) && !pathExists(settingsLink)) {
-      links[settingsFile] = symlinkOrCopy(settingsTarget, settingsLink)
+      links[settingsFile] = symlinkOrCopy(settingsTarget, settingsLink, preferCopy)
     }
   }
 
@@ -717,13 +733,19 @@ function seedProjectLayer(input: AssembleProjectWorkspaceInput, currentProviderD
  * superset, so this is where per-project filtering lands. `undefined` ⇒ link
  * every framework agent (used by the legacy callers / parity tests).
  *
+ * When `preferCopy` is true each agent is COPIED as a real file rather than
+ * symlinked (the in-repo standalone install — so a standalone user's CLI finds
+ * real agent files in the repo, not links into `$HOME`).
+ *
  * Returns the dominant mechanism used across the linked files (`copy` if any
- * file fell back to copy — the normal case on Windows without Developer Mode).
+ * file fell back to copy — the normal case on Windows without Developer Mode, or
+ * always when `preferCopy` is set).
  */
 function linkAgentFiles(
   frameworkAgentsDir: string,
   workspaceAgentsDir: string,
   selectedIds?: Set<string>,
+  preferCopy = false,
 ): 'symlink' | 'junction' | 'copy' {
   mkdirp(workspaceAgentsDir)
   // Names the framework currently PROVIDES (regardless of selection) — used to
@@ -739,7 +761,7 @@ function linkAgentFiles(
     const id = name.slice(0, -3)
     if (selectedIds && (!selectedIds.has(id) || QUICK_EXCLUDED_AGENTS.has(id))) continue
     linkedNames.add(name)
-    const m = symlinkOrCopy(src, path.join(workspaceAgentsDir, name))
+    const m = symlinkOrCopy(src, path.join(workspaceAgentsDir, name), preferCopy)
     if (m === 'copy') mechanism = 'copy'
     else if (m === 'junction' && mechanism !== 'copy') mechanism = 'junction'
   }

--- a/src/installer/util/fs.ts
+++ b/src/installer/util/fs.ts
@@ -228,14 +228,27 @@ export function removePath(p: string): void {
  *   2. Windows: try a junction (dirs) / file symlink first, then a plain symlink.
  *   3. Both failed (e.g. unprivileged Windows): COPY the target subtree verbatim.
  *
+ * When `preferCopy` is true the symlink/junction attempts are SKIPPED entirely
+ * and the target is copied directly — used by the in-repo standalone install so
+ * the repo receives real, committable files instead of symlinks pointing into
+ * `$HOME/.specrails/framework`. (An existing correct symlink at `linkPath` is
+ * still honoured idempotently before the copy so a re-run of a relocated install
+ * does not thrash.)
+ *
  * Returns the mechanism used so the caller can record it (copy-fallback loses the
  * O(1) `current`-swap update path; the caller may warn). Idempotent: when the
  * link already points at `target` it is left untouched and `'symlink'` returned.
  */
-export function symlinkOrCopy(target: string, linkPath: string): 'symlink' | 'junction' | 'copy' {
+export function symlinkOrCopy(
+  target: string,
+  linkPath: string,
+  preferCopy = false,
+): 'symlink' | 'junction' | 'copy' {
   const targetIsDir = isDir(target)
 
-  // Idempotency: an existing correct symlink is left alone.
+  // Idempotency: an existing correct symlink is left alone (even when preferCopy
+  // is requested — a relocated workspace that re-runs an in-repo install must not
+  // thrash a link it already created correctly).
   if (isSymlink(linkPath)) {
     try {
       const current = readlinkSync(linkPath)
@@ -248,6 +261,16 @@ export function symlinkOrCopy(target: string, linkPath: string): 'symlink' | 'ju
 
   removePath(linkPath)
   mkdirp(path.dirname(linkPath))
+
+  // In-repo install: skip the symlink/junction dance and copy real files.
+  if (preferCopy) {
+    if (targetIsDir) {
+      copyDir(target, linkPath)
+    } else {
+      copyFile(target, linkPath)
+    }
+    return 'copy'
+  }
 
   if (process.platform === 'win32') {
     if (targetIsDir) {


### PR DESCRIPTION
## Why

#313 (`feat/standalone-in-repo-install`) was merged into its base branch `chore/remove-team-agents` instead of `main`. That base branch had already merged into `main` via #312 nine seconds earlier, so **#313's changes never reached `main`**.

## What

Re-applies #313's diff cleanly onto `main` (the team-agents removal from #312 is already in main, so this PR is just the in-repo-install feat — no conflicts, clean diff).

- Same change as #313: `init` installs in-repo by default; relocate only for desktop / `--relocate`.
- Files: `init.ts`, `init.test.ts`, `update.ts`, `scaffold.ts`, `util/fs.ts`.

After merge, the stale `chore/remove-team-agents` and `feat/standalone-in-repo-install` branches can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)