### PR TITLE
fix(windows): assemble reads the framework from the version dir, not the current junction

### DIFF
--- a/src/installer/phases/framework.test.ts
+++ b/src/installer/phases/framework.test.ts
@@ -247,6 +247,40 @@ describe('bundled framework — installFramework / ensureCurrentSymlink / assemb
       expect(readFileSync(path.join(ws, '.specrails', 'specrails-version'), 'utf8').trim()).toBe('5.0.0')
     })
 
+    it('win32: reads the framework from the VERSION dir, not the (untraversable) current junction', () => {
+      // Windows "untrusted mount point" repro: on the user's box Node's fs throws
+      // UNKNOWN/scandir reading THROUGH the `current` junction, but the versioned
+      // dir reads fine. The assemble must source the framework from the version
+      // dir on Windows — else linkAgentFiles links nothing and the workspace has
+      // no sr-* agents, so the implement pipeline can't delegate and runs inline.
+      const orig = process.platform
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+      try {
+        const scriptDir = path.join(tmpDir, 'core')
+        const fwDir = path.join(tmpDir, 'framework')
+        const ws = path.join(tmpDir, 'ws')
+        const repo = path.join(tmpDir, 'repo')
+        setupFakeScriptDir(scriptDir)
+        materialize(fwDir, scriptDir)
+        // Make reading THROUGH `current` fail (replace the link with a plain file)
+        // — exactly the symptom on the user's box. The version dir is untouched.
+        rmSync(path.join(fwDir, 'current'), { recursive: true, force: true })
+        writeFileLf(path.join(fwDir, 'current'), 'broken-junction\n')
+
+        assembleProjectWorkspace({
+          workspace: ws, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude',
+          version: '5.0.0', codeRoot: repo, scriptDir,
+        })
+
+        const wsArch = path.join(ws, '.claude', 'agents', 'sr-architect.md')
+        const fwArch = path.join(fwDir, '5.0.0', '.claude', 'agents', 'sr-architect.md')
+        expect(pathExists(wsArch)).toBe(true) // populated despite a broken `current`
+        expect(readTextFile(wsArch)).toBe(readTextFile(fwArch))
+      } finally {
+        Object.defineProperty(process, 'platform', { value: orig, configurable: true })
+      }
+    })
+
     it('preserves a pre-existing custom-*.md agent (reserved path) while linking framework agents', () => {
       const scriptDir = path.join(tmpDir, 'core')
       const fwDir = path.join(tmpDir, 'framework')

--- a/src/installer/phases/scaffold.ts
+++ b/src/installer/phases/scaffold.ts
@@ -591,7 +591,19 @@ export interface AssembleProjectWorkspaceResult {
 export function assembleProjectWorkspace(
   input: AssembleProjectWorkspaceInput,
 ): AssembleProjectWorkspaceResult {
-  const currentProviderDir = path.join(input.frameworkDir, 'current', input.providerDir)
+  // Source root for the framework subtrees. On POSIX read through the `current`
+  // symlink so the per-file workspace symlinks track the atomic `current`-swap
+  // (O(1) framework updates). On WINDOWS the `current` junction can be
+  // UNTRAVERSABLE by Node's `fs` ("UNKNOWN: scandir" / "untrusted mount point")
+  // — `readdirSync(<frameworkDir>/current/<providerDir>/agents)` then throws and
+  // `linkAgentFiles` links NOTHING, leaving the workspace with no agents (and no
+  // commands/skills): the implement pipeline has no sr-* sub-agents to delegate
+  // to and silently runs everything inline. The versioned dir is a real,
+  // traversable directory and `version` is always passed, so read from it
+  // directly on Windows (the subtrees become copies / version-pinned junctions —
+  // the already-accepted O(projects) Windows update cost). POSIX is unchanged.
+  const sourceRoot = process.platform === 'win32' ? input.version : 'current'
+  const currentProviderDir = path.join(input.frameworkDir, sourceRoot, input.providerDir)
   const workspaceProviderDir = path.join(input.workspace, input.providerDir)
   mkdirp(workspaceProviderDir)
 


### PR DESCRIPTION
On Windows, Node's `fs.readdirSync` can fail to traverse the `<frameworkDir>/current` junction with `UNKNOWN: scandir` / *"the path cannot be traversed because it contains an untrusted mount point"* — even though the junction target (`<frameworkDir>/<version>`) reads fine (confirmed on a user's box: `framework/current/.claude/agents` → `ERR UNKNOWN scandir`, `framework/4.10.0/.claude/agents` → 14 files).

`assembleProjectWorkspace` sourced every provider subtree from `<frameworkDir>/current/<providerDir>`, so on those machines `linkAgentFiles`'s `listDir(.../current/.claude/agents)` threw and linked **nothing** → the workspace got no `sr-*` agents (and no commands/skills) → the specrails implement pipeline had no sub-agents to delegate to and silently ran architect→developer→reviewer inline in one session.

## Fix
Source the subtrees from the real versioned dir (`<frameworkDir>/<version>/<providerDir>`) on **win32** (`version` is already passed). POSIX unchanged (keeps `current` → per-file workspace symlinks track the `current`-swap = O(1) updates). On Windows the subtrees become copies / version-pinned junctions — the already-accepted O(projects) Windows cost.

## Test
A win32-mocked assemble with a deliberately-broken `current` still populates the workspace agents from the version dir. `framework.test.ts`: 14 pass.

> Base is `feat/standalone-in-repo-install` (current WIP) for a clean diff. Merge + cut a core release, then the desktop bundle picks it up. A desktop-side stopgap (repair from the version dir) ships separately so existing installs are fixed without waiting for a core republish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)