### PR TITLE
feat(implement): honour SPECRAILS_GIT_AUTO=false so a host can own version control

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ specrails is not a chat interface. It's a **development pipeline** that coordina
 
 Architect designs → developer builds → reviewer validates → PR created. Multiple features run in parallel with git worktrees.
 
+#### Letting a host own version control (`SPECRAILS_GIT_AUTO`)
+
+By default the pipeline ships automatically (`GIT_AUTO=true`): it creates a branch, commits, pushes, and opens a pull request. When specrails-core runs **inside a host that owns version control itself** — such as [specrails-desktop](https://github.com/fjpulidop/specrails-desktop), which runs each pipeline in an isolated git worktree and opens the pull request for you — that host sets the `SPECRAILS_GIT_AUTO` environment variable to `false`.
+
+When `SPECRAILS_GIT_AUTO=false` (or `0`), the Ship phase is forced onto the **manual** path regardless of configuration: the pipeline stops at "code written and verified" and makes **no branch, commit, push, or PR** — the host does that. This prevents a second, uncoordinated pull request. Leave the variable unset for the normal standalone behaviour (automatic shipping, subject to your `GIT_AUTO` configuration). It composes with `--dry-run`, which independently skips all git/GitHub/backlog operations.
+
 #### Dry-run / preview mode
 
 Not ready to commit? Run the full pipeline without touching git or GitHub:

--- a/templates/commands/specrails/implement.md
+++ b/templates/commands/specrails/implement.md
@@ -1213,6 +1213,8 @@ Then skip the rest of Phase 4c and proceed directly to Phase 4e.
 
 This phase respects the `GIT_AUTO` and `BACKLOG_WRITE` settings from configuration.
 
+**Environment override (host owns version control).** Before applying the `GIT_AUTO` logic below, check the `SPECRAILS_GIT_AUTO` environment variable. If it is set to `false` or `0`, treat `GIT_AUTO` as `false` for the rest of this phase (and Phase 4d) **regardless of configuration** — do not create a branch, commit, push, or open a PR; follow the `GIT_AUTO=false` (manual shipping) path instead. A host such as [specrails-desktop](https://github.com/fjpulidop/specrails-desktop) sets this when it owns version control (it runs the pipeline in an isolated worktree and opens the pull request itself), so honouring it prevents a second, uncoordinated PR. When `SPECRAILS_GIT_AUTO` is unset or any other value, resolve `GIT_AUTO` from configuration as normal.
+
 #### If `GIT_AUTO=true` (automatic shipping)
 
 All git operations run against the repo via `git -C "${SPECRAILS_REPO_DIR:-.}"`, and `gh` runs from inside the repo so it can detect the remote.


### PR DESCRIPTION
## What & why

When specrails-core's pipeline runs **inside a host that owns git itself** — such as [specrails-desktop](https://github.com/fjpulidop/specrails-desktop), which isolates each run in a git worktree and opens the pull request for you — that host now sets `SPECRAILS_GIT_AUTO=false`. Phase 4c honours it: before applying the `GIT_AUTO` logic it checks the env var and, when `false`/`0`, forces the **manual-shipping** path regardless of configuration (no branch, commit, push, or PR). This prevents a second, uncoordinated pull request.

Unset (or any other value) keeps the normal standalone behaviour — automatic shipping subject to your `GIT_AUTO` configuration.

## Changes

- `templates/commands/specrails/implement.md`: an "Environment override" note at the head of **Phase 4c** (covers the Phase 4d CI monitor too), reusing the existing `GIT_AUTO=false` path — no new shipping logic.
- `README.md`: documents `SPECRAILS_GIT_AUTO` under the `/specrails:implement` command.

## Safety

Additive and default-off — unset ⇒ byte-identical behaviour. Composes with `--dry-run`. Full test suite **296 pass**, typecheck clean; the strict `template-repo-dir` git-scoping test is green (the note is prose, no `git`/`gh` commands).

## Context

This is the specrails-core side of the desktop "safe PR workflow": desktop already sends the signal; releasing core first lets desktop's implement rails stop double-shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R982uLJYJxAepBa3EQzvw9