### PR TITLE
fix(architect): calibrate investigation + design effort to the change's blast radius

### DIFF
--- a/templates/agents/sr-architect.md
+++ b/templates/agents/sr-architect.md
@@ -98,6 +98,15 @@ Only after Step 0's proof gate passes do you proceed to Steps 1–6.
   - **Why this approach**: Justify key design decisions, especially when trade-offs exist
   - **What to watch out for**: Identify risks, edge cases, potential regressions, and concurrency concerns
 
+### 2.5 Calibrate effort to the change's blast radius
+
+Right-size BOTH your investigation depth and your written output to how much the change actually touches. Over-investigating a small change burns time and tokens without adding correctness — `detail_level: full` means *complete where it matters*, not *maximal everywhere*.
+
+- **Scope the blast radius first.** Before deep-diving, estimate what the change touches: a handful of files in one layer, or many files across layers / a contract surface (commands, agents, flags, config keys).
+- **Localized change** (few files, one layer, no new contract surface): produce a FOCUSED impact analysis and design. Do NOT emit exhaustive call-site catalogs, whole-file transcriptions, or multi-section codebase surveys — name the specific files/identifiers that matter and move on. The Step 6 compatibility check will still confirm "no contract surface changes."
+- **Cross-cutting change** (many modules, a migration, contract-surface edits, real concurrency): the full depth of Steps 2–6 is warranted — go deep and be exhaustive.
+- Investigate only as far as it changes a design decision. When you already know the answer, state it — don't prove it at length. Depth must earn its cost in correctness, not thoroughness for its own sake.
+
 ### 3. Organize Tasks
 - Break the implementation into **ordered, atomic tasks** that can be executed sequentially
 - Each task should:


### PR DESCRIPTION
## Why

The `sr-architect` agent has no effort-proportionality guidance and defaults to `tone: verbose` / `detail_level: full`. A small, localized change gets the same exhaustive treatment as a cross-cutting one — deep call-site catalogs, whole-file transcriptions, multi-section codebase surveys — which burns time and tokens without adding correctness.

Observed in a real `/specrails:implement` run: a ~5-file change (add a `git fetch` before worktree creation) cost **~$17 / 30 turns**, the bulk of it the architect over-investigating (a 6-section survey of call sites, `withRepoLock`, etc. for what was a localized edit). `implement.md:5` mandates the full pipeline "even if simple", so the compatible lever is right-sizing effort *within* each phase — not skipping phases.

## What

Adds a **"2.5 Calibrate effort to the change's blast radius"** step to `templates/agents/sr-architect.md`:
- Scope the blast radius before deep-diving.
- Localized change (few files, one layer, no contract surface) → focused impact analysis; no exhaustive catalogs.
- Cross-cutting change (many modules, migration, contract-surface, concurrency) → full depth of Steps 2–6 is warranted.
- Investigate only as far as it changes a design decision.
- Clarifies `detail_level: full` as "complete where it matters", not "maximal everywhere".

**Provider-invariant** — the shared agent definition, so this applies to claude, codex, and gemini in one edit. No new `{{placeholders}}`. Rigor is unchanged (all phases still run; the Step 6 compatibility check still confirms "no contract surface changes"); only the effort is proportioned.

## Verification

`npm test` — 298/298 pass. No test asserts the architect template's byte content, and the edit adds no placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)