### PR TITLE
fix(batch-implement): run wave invocations in the foreground

### DIFF
--- a/specrails-plugin/skills/batch-implement/SKILL.md
+++ b/specrails-plugin/skills/batch-implement/SKILL.md
@@ -22,7 +22,7 @@ Macro-orchestrator above `/specrails:implement`. Accepts a set of feature refere
 - **`--wave-size N`**: max features per wave regardless of concurrency (default: unlimited)
 - **`--dry-run` / `--preview`**: passed through to each `/specrails:implement` invocation; no git or backlog operations will run
 
-**IMPORTANT:** Before running, ensure Read/Write/Bash/Glob/Grep permissions are set to "allow" — background agents cannot request permissions interactively.
+**IMPORTANT:** Before running, ensure Read/Write/Bash/Glob/Grep permissions are set to "allow" — subagents cannot request permissions interactively.
 
 ---
 
@@ -205,7 +205,8 @@ For each wave `W`:
      ```
      /specrails:implement <ref1> <ref2> ... [--dry-run]
      ```
-   - Run invocations in the batch in parallel (`run_in_background: true`).
+   - Run invocations in the batch **concurrently in the FOREGROUND**: emit every agent invocation for the batch in a single message with `run_in_background: false`. They still run in parallel, and your turn blocks until all of them return.
+   - **NEVER use `run_in_background: true`, and NEVER end your reply while a wave is still running.** In headless/pipeline execution (`claude -p`, specrails-desktop loops) the host tears the process down as soon as your turn ends — background agents are killed before they write a single file. Replies like "wave 1 is running in the background, I'll pick it up when it finishes" lose the entire wave.
    - Wait for all in the batch to complete before starting the next batch.
    - **COMPLETION GUARD**: Do not exit the wave loop early. Even if invocations take a long time or return errors, record outcomes and continue to the next batch/wave. Always reach Phase 3 (Batch Report).
 3. For each completed invocation, record outcome in `WAVE_RESULTS`:

--- a/templates/commands/specrails/batch-implement.md
+++ b/templates/commands/specrails/batch-implement.md
@@ -12,7 +12,7 @@ Macro-orchestrator above `/specrails:implement`. Accepts a set of feature refere
 - **`--wave-size N`**: max features per wave regardless of concurrency (default: unlimited)
 - **`--dry-run` / `--preview`**: passed through to each `/specrails:implement` invocation; no git or backlog operations will run
 
-**IMPORTANT:** Before running, ensure Read/Write/Bash/Glob/Grep permissions are set to "allow" — background agents cannot request permissions interactively.
+**IMPORTANT:** Before running, ensure Read/Write/Bash/Glob/Grep permissions are set to "allow" — subagents cannot request permissions interactively.
 
 ---
 
@@ -198,7 +198,8 @@ For each wave `W`:
      SPECRAILS_PROFILE_PATH=<resolved-per-rail-path> /specrails:implement <ref> [--dry-run]
      ```
    - Each ref in the batch spawns with its own resolved profile path — **distinct rails in the same batch MAY use distinct profiles concurrently**.
-   - Run invocations in the batch in parallel (`run_in_background: true`).
+   - Run invocations in the batch **concurrently in the FOREGROUND**: emit every agent invocation for the batch in a single message with `run_in_background: false`. They still run in parallel, and your turn blocks until all of them return.
+   - **NEVER use `run_in_background: true`, and NEVER end your reply while a wave is still running.** In headless/pipeline execution (`claude -p`, specrails-desktop loops) the host tears the process down as soon as your turn ends — background agents are killed before they write a single file. Replies like "wave 1 is running in the background, I'll pick it up when it finishes" lose the entire wave.
    - Wait for all in the batch to complete before starting the next batch.
 3. For each completed invocation, record outcome in `WAVE_RESULTS`:
    - `{ref, wave, status: "done" | "failed", profile: "<name or empty>", error_summary: "..." | null}`


### PR DESCRIPTION
## Problem

Launching **Milestone 1** from the Desktop Project Builder (factory `Batch Implement` loop over N tickets) reproducibly fails: wave 1 never writes a single file, the orchestrator relaunches it, it dies again, and the loop ends in `LOOP_BLOCKED`.

Root cause: `batch-implement` instructed wave invocations to run with `run_in_background: true`. The orchestrator then ends its turn ("wave 1 is running in the background, no action needed"). In headless/pipeline execution (`claude -p`, specrails-desktop interactive loop steps with auto-settle) the host tears the process down as soon as the turn ends — background agents live inside that process and are killed with zero work done.

## Fix

- Wave invocations now launch **concurrently in the foreground**: every agent call for the batch goes out in a single message with `run_in_background: false` — same parallelism, but the turn blocks until the wave completes.
- Explicit prohibition added: never use `run_in_background: true`, never end the reply while a wave is running, with the headless-teardown rationale spelled out.
- Applied to both `templates/commands/specrails/batch-implement.md` and `specrails-plugin/skills/batch-implement/SKILL.md` (codex/gemini variants carry no background instruction — unchanged).

## Verification

Prompt-template-only change; no code paths touched. Grep confirms no remaining `run_in_background: true` in any batch-implement variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ud2PVGVtgTDQFJVj1Ty7UK