### PR TITLE
fix(batch-implement): teach the orchestrator its desktop rail execution context

### DIFF
--- a/specrails-plugin/skills/batch-implement/SKILL.md
+++ b/specrails-plugin/skills/batch-implement/SKILL.md
@@ -26,6 +26,17 @@ Macro-orchestrator above `/specrails:implement`. Accepts a set of feature refere
 
 ---
 
+## Desktop rail execution context (isolated worktree)
+
+specrails-desktop launches this command INSIDE an isolated rail worktree allocated for the batch. Detect it: the working directory path contains `/worktrees/` (e.g. `~/.specrails/projects/<slug>/worktrees/ticket-N`), typically on a `feat/...` branch. When that is the case, ALL of the following hold — they override any instinct to the contrary:
+
+- **You ARE the assigned executor of this rail.** The desktop's own bookkeeping (rail slots, ticket-ownership rows in its `jobs.sqlite`, state under `~/.specrails/`) describes THIS very launch — it is never evidence of a competing process. NEVER read specrails-desktop's internal databases or state files, and NEVER stop to ask "which process should run this batch".
+- **The current worktree + current branch ARE the workspace for the WHOLE batch.** Implement every ticket here, in dependency order — including tickets whose refs differ from the branch name. The desktop assembles this branch into a batch PR after you finish; nothing needs to land on the integration branch (main) first. Do NOT create sibling worktrees, do NOT switch branches, do NOT run any ticket "against main in the base repo".
+- **Run tickets SEQUENTIALLY (effective concurrency 1)** regardless of `--concurrency`: parallel pipelines editing one shared checkout corrupt each other. Wave order still sequences the work; only the parallelism collapses.
+- Everything else (per-ticket `/specrails:implement` delegation, wave gates, failure isolation, final report) applies unchanged.
+
+---
+
 ## Phase 0: Parse Input
 
 ### Step 1: Extract feature refs

--- a/templates/codex-skills/batch-implement/SKILL.md
+++ b/templates/codex-skills/batch-implement/SKILL.md
@@ -43,6 +43,10 @@ ticket, no more nesting. The contract that `$implement` enforces
 
 Default execution mode is sequential.
 
+## Desktop rail execution context
+
+When the working directory is a specrails-desktop isolated rail worktree (path contains `/worktrees/`, typically on a `feat/...` branch), you are the ASSIGNED executor of that rail: implement every ticket sequentially in THIS worktree on THIS branch — the desktop assembles it into a batch PR afterwards, nothing needs to land on the integration branch first. The desktop's own bookkeeping (ticket-ownership rows in its `jobs.sqlite`, state under `~/.specrails/`) describes this very launch — never read those internals, and never stop to ask which process should run the batch.
+
 ## Steps
 
 ### 0. Bootstrap

--- a/templates/commands/specrails/batch-implement.md
+++ b/templates/commands/specrails/batch-implement.md
@@ -16,6 +16,17 @@ Macro-orchestrator above `/specrails:implement`. Accepts a set of feature refere
 
 ---
 
+## Desktop rail execution context (isolated worktree)
+
+specrails-desktop launches this command INSIDE an isolated rail worktree allocated for the batch. Detect it: the working directory path contains `/worktrees/` (e.g. `~/.specrails/projects/<slug>/worktrees/ticket-N`), typically on a `feat/...` branch. When that is the case, ALL of the following hold — they override any instinct to the contrary:
+
+- **You ARE the assigned executor of this rail.** The desktop's own bookkeeping (rail slots, ticket-ownership rows in its `jobs.sqlite`, state under `~/.specrails/`) describes THIS very launch — it is never evidence of a competing process. NEVER read specrails-desktop's internal databases or state files, and NEVER stop to ask "which process should run this batch".
+- **The current worktree + current branch ARE the workspace for the WHOLE batch.** Implement every ticket here, in dependency order — including tickets whose refs differ from the branch name. The desktop assembles this branch into a batch PR after you finish; nothing needs to land on the integration branch (main) first. Do NOT create sibling worktrees, do NOT switch branches, do NOT run any ticket "against main in the base repo".
+- **Run tickets SEQUENTIALLY (effective concurrency 1)** regardless of `--concurrency`: parallel pipelines editing one shared checkout corrupt each other. Wave order still sequences the work; only the parallelism collapses.
+- Everything else (per-ticket `/specrails:implement` delegation, wave gates, failure isolation, final report) applies unchanged.
+
+---
+
 ## Phase 0: Parse Input
 
 ### Step 1: Extract feature refs

--- a/templates/gemini-commands/batch-implement.toml
+++ b/templates/gemini-commands/batch-implement.toml
@@ -11,6 +11,10 @@ How the user invokes you:
 - `/specrails:batch-implement #1 #2 --parallel` — opt-in parallel, only when the
   tickets touch disjoint files (run a safety check first; fall back to sequential).
 
+## Desktop rail execution context
+
+When the working directory is a specrails-desktop isolated rail worktree (path contains `/worktrees/`, typically on a `feat/...` branch), you are the ASSIGNED executor of that rail: implement every ticket sequentially in THIS worktree on THIS branch — the desktop assembles it into a batch PR afterwards, nothing needs to land on the integration branch first. The desktop's own bookkeeping (ticket-ownership rows in its `jobs.sqlite`, state under `~/.specrails/`) describes this very launch — never read those internals, and never stop to ask which process should run the batch.
+
 ## Why this drives the spawns at the ROOT level
 
 Do NOT delegate to a nested `/specrails:implement` subagent per ticket that then


### PR DESCRIPTION
## Problem

With the foreground-waves fix (#324) in, a desktop `factory:batch` launch (Milestone 1, 8 tickets) still stalled: the orchestrator — running inside the isolated rail worktree the desktop allocated (`worktrees/ticket-2`, branch `feat/2-…`) — inspected the desktop's `jobs.sqlite`, found its OWN launch's `rail_ticket_ownership` rows, concluded a competing process owned the batch, decided the per-ticket branch was 'wrong' for the other tickets, and ended its turn asking the human which process should proceed → the loop paused with zero implementation progress.

## Fix

New **Desktop rail execution context** section (claude command template + plugin skill; compact variant in the codex skill and gemini command):

- cwd containing `/worktrees/` ⇒ you ARE the assigned executor of this rail; the desktop's bookkeeping describes this very launch, never a competing process.
- The current worktree + branch are the workspace for the WHOLE batch — the desktop assembles the batch PR at settle; nothing lands on the integration branch first. No sibling worktrees, no branch switching.
- Tickets run SEQUENTIALLY inside the shared checkout regardless of `--concurrency` (parallel pipelines in one checkout corrupt each other).
- Never read desktop-internal databases/state; never pause to ask which process should run the batch.

Prompt-template-only change; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ud2PVGVtgTDQFJVj1Ty7UK