### PR TITLE
feat: add Kimi Code as a first-class AI provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,9 @@ jobs:
       - name: Scan for secrets
         run: gitleaks detect --source . --redact --exit-code 1
 
-  # Typecheck + build are platform-independent — run each exactly once
-  # here instead of in every test matrix cell. No test consumes dist/
-  # (vitest transpiles src/ via esbuild), so the matrix below only runs
-  # vitest.
+  # Keep one explicit typecheck/build gate. The matrix also builds because the
+  # packaged-dispatcher integration tests intentionally execute dist/ exactly
+  # as consumers do from the published tarball.
   typecheck-build:
     runs-on: ubuntu-latest
     steps:
@@ -53,6 +52,7 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: npm
       - run: npm ci
+      - run: npm run build
       - run: npx vitest run
 
   coverage:
@@ -65,6 +65,7 @@ jobs:
           node-version: 20.19.0
           cache: npm
       - run: npm ci
+      - run: npm run build
       - name: Run tests with coverage
         run: npx vitest run --coverage
       - name: Upload coverage report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,21 +30,21 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: 20
+          node-version: 20.19.0
           cache: npm
       - run: npm ci
       - run: npm run typecheck
       - run: npm run build
 
   # Cross-platform Node test matrix. Runs on macOS, Linux, and Windows;
-  # covers Node 20 (current LTS) and Node 22 (next LTS) per
-  # package.json#engines.
+  # covers the exact Node 20.19.0 minimum required by OpenSpec 1.4.1 and
+  # Node 22 per package.json#engines.
   test:
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: ['20', '22']
+        node: ['20.19.0', '22']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: 20
+          node-version: 20.19.0
           cache: npm
       - run: npm ci
       - name: Run tests with coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - if: ${{ steps.release.outputs.release_created }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: 20
+          node-version: 20.19.0
           registry-url: https://registry.npmjs.org
           cache: npm
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Agent Workflow System installer for Claude Code. Installs a complete product-dri
 
 | Layer | Tech |
 |-------|------|
-| Installer | TypeScript / Node ≥ 20 (cross-platform: macOS, Linux, Windows) |
+| Installer | TypeScript / Node ≥ 20.19.0 (cross-platform: macOS, Linux, Windows) |
 | Templates | Markdown with `{{PLACEHOLDER}}` substitution |
 | Commands | Claude Code slash commands (Markdown) |
 | Prompts | Markdown guide prompts |
@@ -67,7 +67,7 @@ unsubstituted placeholders after a dogfood with
 ## Environment
 
 - Distributed as an npm package: `npx specrails-core@latest init`
-- Cross-platform from v4.2.0: macOS, Linux, Windows (Node ≥ 20). No bash / python required.
+- Cross-platform from v4.2.0: macOS, Linux, Windows (Node ≥ 20.19.0). No bash / python required.
 - Test framework: vitest with a cross-OS / cross-Node matrix in `.github/workflows/ci.yml`
 - CI/CD: GitHub Actions (release-please + npm publish)
 - GitHub Issues used for backlog (label: `product-driven-backlog`)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 [![GitHub Stars](https://img.shields.io/github/stars/fjpulidop/specrails-core?style=social)](https://github.com/fjpulidop/specrails-core)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![npm downloads](https://img.shields.io/npm/dw/specrails-core.svg)](https://www.npmjs.com/package/specrails-core)
-[![Claude Code](https://img.shields.io/badge/Built%20for-Claude%20Code-blueviolet)](https://docs.anthropic.com/en/docs/claude-code)
-[![Codex — Coming Soon](https://img.shields.io/badge/OpenAI%20Codex-Coming%20Soon%20(in%20lab)-lightgrey)](https://github.com/openai/codex)
+[![AI providers](https://img.shields.io/badge/providers-Claude%20%7C%20Codex%20%7C%20Gemini%20%7C%20Kimi-6f42c1)](#provider-support)
 
 **Your agentic development team. From idea to production code.**
 
@@ -13,12 +12,12 @@ One command turns your repo into a spec-driven pipeline with a team of specializ
 
 ```bash
 npx specrails-core@latest init   # install into the current repo
-/specrails:enrich                # optional: deep codebase analysis
+/specrails:enrich                # Claude/Gemini (Kimi: /skill:specrails-enrich)
 ```
 
-> **Requirements:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code), git, Node 20+. Cross-platform: macOS, Linux, Windows.
->
-> **🧪 Codex (OpenAI) support — Coming Soon:** We are testing Codex integration in our lab. Installation is disabled for now, but the feature will be available shortly. Follow the repo for updates.
+> **Requirements:** one supported AI CLI, git, and Node 20.19.0+. Cross-platform:
+> macOS, Linux, and Windows. Use `--provider claude|codex|gemini|kimi` to
+> override auto-detection.
 
 ---
 
@@ -44,7 +43,8 @@ npx specrails-core@latest init
 
 The TUI asks you to pick a tier:
 
-- **Quick** (default) — agents and commands installed straight to `.claude/`, ready to use immediately. No AI interaction.
+- **Quick** (default) — provider-native agents/skills and commands are installed
+  under `.claude/`, `.codex/`, `.gemini/`, or `.kimi-code/`. No AI interaction.
 - **Full** — same as Quick plus `/specrails:enrich` (5-phase deep analysis: stack detection, VPC personas, competitive research). ~5 min.
 
 ```bash
@@ -61,15 +61,34 @@ That's it. The pipeline takes over.
 
 ---
 
+## Provider support
+
+| Provider | Runtime command | Project surface | Workflow syntax |
+|----------|-----------------|-----------------|-----------------|
+| Claude Code | `claude` | `.claude/` | `/specrails:<command>` |
+| Codex CLI | `codex` | `.codex/` | provider-native skills |
+| Gemini CLI | `gemini` | `.gemini/` | `/specrails:<command>` |
+| Kimi Code | managed Node skill runner → external `kimi -p` | `.kimi-code/` | `/skill:specrails-<command>` in the TUI |
+
+Kimi is an external CLI dependency, just like the other providers. SpecRails
+does not bundle a Kimi binary, start `kimi web`, or own a Kimi server. Install
+Kimi Code separately, run `kimi login` once, then select it explicitly or let
+the installer detect it. Parallel Kimi roles are submitted as one bounded
+foreground wave; Core creates/reuses their git worktrees, attributes each
+child stream, and waits for aggregate completion—without a server. See the
+[Kimi setup guide](./docs/user-docs/getting-started-kimi.md).
+
 ## What gets installed
 
 Everything lands in your repo — nothing auto-updates, nothing phones home. You own it, you commit it.
 
 | Category | Location | Purpose |
 |----------|----------|---------|
-| **Agents** | `.claude/agents/` | 14 specialised AI agents |
-| **Commands** | `.claude/commands/specrails/` | 17 workflow commands (`/specrails:implement`, `/specrails:get-backlog-specs`, `/specrails:why`, …) |
-| **OpenSpec skills** | `.claude/commands/opsx/` | `/opsx:*` commands for spec artefacts |
+| **Provider workflows** | `.claude/`, `.codex/`, `.gemini/`, or `.kimi-code/` | Provider-native SpecRails commands and role definitions |
+| **Kimi workflow skills** | `.kimi-code/skills/specrails-*/SKILL.md` | `/skill:specrails-*` directory-form skills |
+| **Kimi role skills** | `.kimi-code/skills/sr-*/SKILL.md` | Specialized role prompts used by Kimi workflows; Kimi discovers only direct skill children |
+| **Kimi headless runner** | `.kimi-code/specrails/run-skill.mjs` | Materializes Kimi's native skill-activation prompt before launching the external CLI |
+| **OpenSpec skills** | Provider-native skills directory | Structured proposal/design/tasks/apply workflows |
 | **Config** | `.specrails/config.yaml` | Stack, CI commands, git workflow |
 | **Personas** | `.specrails/personas/*.md` | VPC user profiles, generated from your users |
 | **Rules** | `.specrails/rules/*.md` | Per-layer coding conventions |
@@ -204,7 +223,8 @@ Profiles are declarative JSON files that tell `/specrails:implement` which agent
 When running the pipeline, the active profile is resolved in this order:
 
 1. `$SPECRAILS_PROFILE_PATH` environment variable (absolute path to a JSON snapshot)
-2. `<cwd>/.specrails/profiles/project-default.json`
+2. Provider default: `<cwd>/.specrails/profiles/project-default.json` for
+   Claude, or `<cwd>/.specrails/profiles/kimi-default.json` for Kimi
 3. No profile — legacy behavior (identical to pre-4.1.0)
 
 Tools such as [specrails-desktop](https://github.com/fjpulidop/specrails-desktop) set `$SPECRAILS_PROFILE_PATH` to a job-scoped snapshot so concurrent rails can run independent profiles.
@@ -240,6 +260,9 @@ The following paths are **reserved** — `specrails-core update` will never crea
 
 - `.specrails/profiles/**` — profile JSON files (yours and desktop-authored).
 - `.claude/agents/custom-*.md` — your custom agents. Use the `custom-` prefix to opt in to this protection.
+- `.kimi-code/skills/custom-*/**` — your custom Kimi role skills. Pre-release
+  `.kimi-code/skills/rails/custom-*` roles are also reserved while Core safely
+  migrates them into this discoverable direct-child layout.
 
 This contract is what lets you safely hand-author (or let specrails-desktop author) profiles and custom agents without fear of the next `update` overwriting your work. Other paths managed by specrails-core (`.specrails/install-config.yaml`, `.specrails/specrails-version`, etc.) remain under update's control. Audited by `src/installer/__tests__/reserved-paths.test.ts` on every CI run.
 
@@ -287,10 +310,10 @@ Each persona scores features 0–5. Features are ranked by score / effort ratio.
 
 | Tool | Required | Purpose |
 |------|----------|---------|
-| **Claude Code** | Yes | AI agent runtime |
-| **Codex CLI** _(coming soon — in lab)_ | 🧪 Not yet | OpenAI Codex support is being tested in our lab and will be available shortly. |
+| **One supported AI CLI** | Yes | Claude Code, Codex CLI, Gemini CLI, or Kimi Code |
+| **Kimi Code 0.27.0+** | For Kimi projects | Install from the [official Kimi Code guide](https://www.kimi.com/code/docs/en/kimi-code-cli/guides/getting-started), then run `kimi login` |
 | **git** | Yes | Repository detection |
-| **Node 20+** | Yes | Needed for `npx specrails-core@latest init`. Cross-platform: macOS, Linux, Windows (10/11, x64 + ARM64 via emulation). |
+| **Node 20.19.0+** | Yes | Needed for `npx specrails-core@latest init` (the floor required by the pinned OpenSpec 1.4.1 CLI). Cross-platform: macOS, Linux, Windows (10/11, x64 + ARM64 via emulation). |
 | **GitHub CLI** (`gh`) | Optional | Backlog sync to GitHub Issues, PR creation. Not needed with local tickets. |
 | **JIRA CLI** (`jira`) | Optional | Backlog sync to JIRA. Not needed with local tickets. |
 
@@ -324,7 +347,9 @@ Stack-agnostic. The `/specrails:enrich` wizard detects and adapts to whatever yo
 ## FAQ
 
 **Can I customise the agents after installation?**
-Yes. Everything under `.claude/` and `.specrails/` is yours to edit — agent prompts, personas, rules, config. Commit what makes sense, gitignore what's transient.
+Yes. Everything in the selected provider tree and `.specrails/` is yours to
+edit. For Kimi, customize `.kimi-code/skills/`, `.kimi-code/rules/`, and the
+managed block in `.kimi-code/AGENTS.md`; `custom-*` role skills are preserved.
 
 **Can I re-run the wizard?**
 Run `/specrails:enrich` again at any time to regenerate or update project data files. Re-running `npx specrails-core@latest init` refreshes the agents/commands without touching `.specrails/`.
@@ -336,13 +361,24 @@ Yes. Local tickets are the default and need no external tools. `/specrails:imple
 Not simultaneously for the same project — backlog commands use one active provider at a time. You can migrate from GitHub Issues to local tickets using the [migration guide](./docs/migration-guide.md).
 
 **How much does it cost to run?**
-A full `/specrails:implement` cycle for one feature typically costs a few dollars in Claude API usage. The sr-product-manager uses Opus; all other agents use Sonnet or Haiku.
+Cost depends on the selected provider, model, and workload. SpecRails does not
+add a model surcharge. Kimi's stream output does not currently report a native
+USD cost, so consumers must display it as unavailable rather than inventing an
+estimate.
 
 **Does it work with private repos?**
-Yes. Everything runs locally through Claude Code. No external services beyond the model API.
+Yes. Orchestration runs through the selected local CLI. The provider still
+connects to its model API and any MCP/integration endpoints you configure.
 
-**How do I use specrails with Codex?**
-🧪 **Coming Soon — in lab.** OpenAI Codex support is currently being tested in our lab and will be available shortly. The install path will remain the same (`npx specrails-core@latest init --root-dir .`) — the installer will detect Codex and adjust the agent configuration automatically. See [docs/user-docs/getting-started-codex.md](./docs/user-docs/getting-started-codex.md) for the preview documentation.
+**How do I use specrails with Kimi?**
+Install and authenticate Kimi Code, then run
+`npx specrails-core@latest init --provider kimi`. Invoke the generated workflows
+as `/skill:specrails-implement`, `/skill:specrails-enrich`, and so on in Kimi's
+interactive TUI. Headless callers use the managed
+`.kimi-code/specrails/run-skill.mjs` helper: Kimi 0.27 sends a slash command
+passed directly to `kimi -p` as literal text, so the helper first renders the
+same skill prompt as Kimi's native activation path and then starts external
+`kimi -p --output-format stream-json`. No server installation is required.
 
 ---
 

--- a/bin/specrails-core.mjs
+++ b/bin/specrails-core.mjs
@@ -6,8 +6,8 @@
  * in-process via the Node installer under dist/installer/. This file
  * only keeps logic that is local to the dispatcher:
  *   - `profile validate` / `profile show` — schema validation via ajv.
- *   - `enrich`                            — spawns Claude Code with
- *                                           the /specrails:enrich command.
+ *   - `enrich`                            — launches the installed provider's
+ *                                           native enrich workflow.
  *   - `init` TUI short-circuit            — spawns tui-installer.mjs
  *                                           then re-enters init with
  *                                           --from-config.
@@ -31,7 +31,11 @@ const subcommand = args[0]
 
 // ─── Global --version / -V flag ──────────────────────────────────────────────
 
-if (args.includes('--version') || args.includes('-V')) {
+// Treat version as a GLOBAL flag only when it is the command itself. Offline
+// lifecycle commands also carry a required `--version <target>` option; scanning
+// the whole argv would intercept `swap-current --version 4.12.0` here and exit 0
+// without ever validating or moving the framework pointer.
+if (subcommand === '--version' || subcommand === '-V') {
   const pkg = require_(path.resolve(ROOT, 'package.json'))
   console.log(`specrails-core v${pkg.version}`)
   process.exit(0)
@@ -51,6 +55,7 @@ const KNOWN_SUBCOMMANDS = new Set([
   'update',
   'doctor',
   'install-framework',
+  'swap-current',
   'assemble',
   'enrich',
   'version',
@@ -61,7 +66,7 @@ const KNOWN_SUBCOMMANDS = new Set([
 if (!KNOWN_SUBCOMMANDS.has(subcommand)) {
   console.error(`Unknown command: ${subcommand}\n`)
   console.error(
-    'Available commands: init, update, doctor, install-framework, assemble, enrich, version, profile, help',
+    'Available commands: init, update, doctor, install-framework, swap-current, assemble, enrich, version, profile, help',
   )
   process.exit(1)
 }
@@ -90,25 +95,91 @@ if (subcommand === 'profile') {
 }
 
 // ─── enrich ──────────────────────────────────────────────────────────────────
-// Launches Claude Code with the /specrails:enrich slash command.
+// Launches the configured provider's native enrich workflow.
 
 if (subcommand === 'enrich') {
-  const enrichFlags = subargs.join(' ')
-  const claudeCmd = `/specrails:enrich${enrichFlags ? ' ' + enrichFlags : ''}`
+  const workspace = await resolveEnrichWorkspace(process.cwd())
+  const { provider, model: explicitModel, workflowArgs } = resolveEnrichOptions(
+    workspace.codeRoot,
+    subargs,
+    workspace.artifactRoot,
+  )
+  const model =
+    explicitModel ??
+    resolveConfiguredEnrichModel(workspace.codeRoot, workspace.artifactRoot) ??
+    'k3'
+  const enrichFlags = serializeWorkflowArgs(workflowArgs)
+  const launch =
+    provider === 'kimi'
+      ? {
+          command: process.execPath,
+          args: [
+            path.resolve(
+              workspace.artifactRoot,
+              '.kimi-code',
+              'specrails',
+              'run-skill.mjs',
+            ),
+            '--skill',
+            'specrails-enrich',
+            '--model',
+            model,
+            '--add-dir',
+            workspace.codeRoot,
+            ...(enrichFlags ? ['--args', enrichFlags] : []),
+          ],
+          label: 'Kimi Code',
+        }
+      : provider === 'gemini'
+        ? {
+            command: 'gemini',
+            args: [
+              '-p',
+              `/specrails:enrich${enrichFlags ? ` ${enrichFlags}` : ''}`,
+              '--output-format',
+              'stream-json',
+            ],
+            label: 'Gemini CLI',
+          }
+        : provider === 'codex'
+          ? {
+              command: 'codex',
+              args: [
+                'exec',
+                `run enrich${enrichFlags ? ` ${enrichFlags}` : ''}`,
+              ],
+              label: 'Codex CLI',
+            }
+          : {
+              command: 'claude',
+              args: [
+                '--command',
+                `/specrails:enrich${enrichFlags ? ` ${enrichFlags}` : ''}`,
+                '--dangerously-skip-permissions',
+              ],
+              label: 'Claude Code',
+            }
   const result = spawnSync(
-    'claude',
-    ['--command', claudeCmd, '--dangerously-skip-permissions'],
+    launch.command,
+    launch.args,
     {
       stdio: 'inherit',
-      cwd: process.cwd(),
-      shell: process.platform === 'win32',
+      cwd: provider === 'kimi' ? workspace.artifactRoot : process.cwd(),
+      env:
+        provider === 'kimi'
+          ? {
+              ...process.env,
+              SPECRAILS_REPO_DIR: workspace.codeRoot,
+            }
+          : process.env,
+      shell: process.platform === 'win32' && provider !== 'kimi',
     },
   )
   if (result.error) {
     console.error(
-      '\nFailed to launch Claude CLI for enrich:',
+      `\nFailed to launch ${launch.label} for enrich:`,
       result.error.message,
-      '\nEnsure Claude Code is installed: npm install -g @anthropic-ai/claude-code\n',
+      `\nEnsure the configured ${provider} provider is installed and initialized.\n`,
     )
     process.exit(1)
   }
@@ -144,6 +215,7 @@ if (subcommand === 'init') {
     const tuiArgs = [path.resolve(ROOT, 'bin', 'tui-installer.mjs'), rootDir]
     if (providerVal) tuiArgs.push('--provider', providerVal)
     else if (providerEqArg) tuiArgs.push(providerEqArg)
+    if (subargs.includes('--with-profiles')) tuiArgs.push('--with-profiles')
     const tuiResult = spawnSync('node', tuiArgs, {
       stdio: 'inherit',
       cwd: process.cwd(),
@@ -189,20 +261,25 @@ process.exit(0)
 // ─────────────────────────────────────────────────────────────────────────────
 
 function printUsage() {
-  console.log(`specrails-core — Agent Workflow System for Claude Code
+  console.log(`specrails-core — Provider-independent AI agent workflow system
 
 Usage:
   specrails-core init       [--root-dir <path>] [--yes|-y] [--no-tui]  Install into a repository
   specrails-core update     [--only <component>] [--dry-run]           Update an existing installation
   specrails-core doctor                                                 Run health checks
-  specrails-core enrich     [--from-config <path>]                      Run /specrails:enrich via Claude CLI
+  specrails-core install-framework --framework-dir <path> --provider <value> --version <value>
+                                                                        Materialize an offline framework version
+  specrails-core swap-current --framework-dir <path> --version <value> [--providers <csv>]
+                                                                        Validate and atomically expose a framework version
+  specrails-core assemble   --workspace <path> --framework-dir <path>   Assemble a workspace from the framework
+  specrails-core enrich     [--provider <value>] [workflow flags]       Run the configured provider's enrich workflow
   specrails-core profile    <validate|show> [<path>]                    Validate or pretty-print a profile JSON
   specrails-core version                                                Show installed version
 
 Flags for init:
   --root-dir <path>   Target repository path (default: current directory)
   --yes | -y          Non-interactive; use defaults, skip TUI
-  --provider <value>  Force provider: claude (codex coming soon)
+  --provider <value>  Force provider: claude, codex, gemini, or kimi
   --no-tui            Skip TUI; use defaults / flags directly
   --from-config       Skip TUI; use existing .specrails/install-config.yaml
 
@@ -210,6 +287,174 @@ Global flags:
   --version | -V    Show installed version
 
 More info: https://github.com/fjpulidop/specrails-core`)
+}
+
+function resolveEnrichOptions(cwd, argv, artifactRoot = cwd) {
+  const workflowArgs = []
+  let explicitProvider
+  let model
+  for (let index = 0; index < argv.length; index++) {
+    const token = argv[index]
+    if (token === '--provider' || token === '--model') {
+      const value = argv[++index]
+      if (!value) {
+        console.error(`${token} requires a value`)
+        process.exit(1)
+      }
+      if (token === '--provider') explicitProvider = value
+      else model = value
+      continue
+    }
+    if (token.startsWith('--provider=')) {
+      explicitProvider = token.slice('--provider='.length)
+      continue
+    }
+    if (token.startsWith('--model=')) {
+      model = token.slice('--model='.length)
+      continue
+    }
+    workflowArgs.push(token)
+  }
+
+  const supported = new Set(['claude', 'codex', 'gemini', 'kimi'])
+  if (explicitProvider && !supported.has(explicitProvider)) {
+    console.error(
+      `Unsupported provider "${explicitProvider}". Expected claude, codex, gemini, or kimi.`,
+    )
+    process.exit(1)
+  }
+
+  let provider = explicitProvider
+  if (!provider) {
+    for (const root of [cwd, artifactRoot]) {
+      const manifestPath = path.join(
+        root,
+        '.specrails',
+        'specrails-manifest.json',
+      )
+      if (existsSync(manifestPath)) {
+        try {
+          const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+          if (supported.has(manifest.primary_provider)) {
+            provider = manifest.primary_provider
+            break
+          }
+        } catch {
+          // A malformed manifest is diagnosed by `specrails-core doctor`;
+          // enrich continues to config/directory fallback.
+        }
+      }
+    }
+  }
+  if (!provider) {
+    for (const root of [cwd, artifactRoot]) {
+      const configPath = path.join(root, '.specrails', 'install-config.yaml')
+      if (!existsSync(configPath)) continue
+      const match = readFileSync(configPath, 'utf8').match(
+        /^provider:\s*(claude|codex|gemini|kimi)\s*$/m,
+      )
+      if (match) {
+        provider = match[1]
+        break
+      }
+    }
+  }
+  if (!provider) {
+    provider =
+      ['claude', 'codex', 'gemini', 'kimi'].find((candidate) =>
+        existsSync(
+          path.join(
+            artifactRoot,
+            candidate === 'kimi' ? '.kimi-code' : `.${candidate}`,
+          ),
+        ),
+      ) ?? 'claude'
+  }
+  return { provider, model, workflowArgs }
+}
+
+async function resolveEnrichWorkspace(cwd) {
+  const registryModulePath = path.resolve(
+    ROOT,
+    'dist',
+    'installer',
+    'util',
+    'registry.js',
+  )
+  if (!existsSync(registryModulePath)) {
+    return { artifactRoot: cwd, codeRoot: cwd }
+  }
+  try {
+    const registry = await import(pathToFileURL(registryModulePath).href)
+    const resolution = registry.resolveArtifacts(cwd, { allocate: false })
+    return {
+      artifactRoot: path.resolve(resolution.artifactRoot),
+      codeRoot: path.resolve(resolution.codeRoot),
+    }
+  } catch {
+    // Doctor reports malformed registry state. Enrich retains the legacy
+    // in-repository fallback instead of guessing another relocated workspace.
+    return { artifactRoot: cwd, codeRoot: cwd }
+  }
+}
+
+function resolveConfiguredEnrichModel(codeRoot, artifactRoot) {
+  const activeProfile = process.env.SPECRAILS_PROFILE_PATH
+  if (activeProfile) {
+    const activePath = path.isAbsolute(activeProfile)
+      ? activeProfile
+      : path.resolve(codeRoot, activeProfile)
+    const activeModel = readProfileOrchestratorModel(activePath)
+    if (activeModel) return activeModel
+  }
+  const configCandidates = [
+    path.join(codeRoot, '.specrails', 'install-config.yaml'),
+    path.join(artifactRoot, '.specrails', 'install-config.yaml'),
+  ]
+  for (const configPath of configCandidates) {
+    if (!existsSync(configPath)) continue
+    try {
+      const config = require_('js-yaml').load(readFileSync(configPath, 'utf8'))
+      const configured = config?.models?.defaults?.model
+      if (typeof configured === 'string' && configured.trim() !== '') {
+        return configured.trim()
+      }
+    } catch {
+      // The installer/doctor owns full config diagnostics. Continue to a
+      // provider profile rather than extracting a value from malformed YAML.
+    }
+  }
+  const profileCandidates = [
+    path.join(artifactRoot, '.specrails', 'profiles', 'kimi-default.json'),
+    path.join(codeRoot, '.specrails', 'profiles', 'kimi-default.json'),
+  ]
+  for (const profilePath of profileCandidates) {
+    const configured = readProfileOrchestratorModel(profilePath)
+    if (configured) return configured
+  }
+  return null
+}
+
+function readProfileOrchestratorModel(profilePath) {
+  if (!existsSync(profilePath)) return null
+  try {
+    const profile = JSON.parse(readFileSync(profilePath, 'utf8'))
+    const configured = profile?.orchestrator?.model
+    return typeof configured === 'string' && configured.trim() !== ''
+      ? configured.trim()
+      : null
+  } catch {
+    // Profile validation provides the actionable error. Fall through.
+    return null
+  }
+}
+
+function serializeWorkflowArgs(argv) {
+  return argv
+    .map((value) =>
+      value === '' || /\s|["']/u.test(value) ? JSON.stringify(value) : value,
+    )
+    .join(' ')
 }
 
 /**
@@ -244,11 +489,33 @@ async function runProfile(subargs) {
     process.exit(1)
   }
 
+  const workspace = await resolveEnrichWorkspace(process.cwd())
   const resolveProfilePath = () => {
     if (pathArg) return path.resolve(pathArg)
     if (process.env.SPECRAILS_PROFILE_PATH) return path.resolve(process.env.SPECRAILS_PROFILE_PATH)
-    const projectDefault = path.resolve(process.cwd(), '.specrails', 'profiles', 'project-default.json')
-    if (existsSync(projectDefault)) return projectDefault
+    const configRoots = [workspace.codeRoot, workspace.artifactRoot]
+    let provider
+    for (const root of configRoots) {
+      const configPath = path.join(root, '.specrails', 'install-config.yaml')
+      if (!existsSync(configPath)) continue
+      const match = readFileSync(configPath, 'utf8').match(
+        /^provider:\s*(claude|codex|gemini|kimi)\s*$/m,
+      )
+      if (match) {
+        provider = match[1]
+        break
+      }
+    }
+    const names =
+      provider === 'kimi'
+        ? ['kimi-default.json', 'project-default.json']
+        : ['project-default.json', 'kimi-default.json']
+    for (const root of [workspace.artifactRoot, workspace.codeRoot]) {
+      for (const name of names) {
+        const candidate = path.join(root, '.specrails', 'profiles', name)
+        if (existsSync(candidate)) return candidate
+      }
+    }
     return null
   }
 
@@ -256,7 +523,9 @@ async function runProfile(subargs) {
   if (!profilePath) {
     console.error('No profile path given and none could be resolved.')
     console.error('Pass an explicit path or set SPECRAILS_PROFILE_PATH, or place a profile at')
-    console.error('  .specrails/profiles/project-default.json')
+    console.error(
+      '  .specrails/profiles/project-default.json (or kimi-default.json for Kimi)',
+    )
     process.exit(1)
   }
   if (!existsSync(profilePath)) {
@@ -298,8 +567,12 @@ async function runProfile(subargs) {
   const schema = JSON.parse(readFileSync(schemaPath, 'utf8'))
   const ajv = new Ajv({ allErrors: true, strict: false })
   const validate = ajv.compile(schema)
+  const schemaValid = validate(profile)
+  const semanticErrors = schemaValid
+    ? validateProfileSemantics(profile)
+    : []
 
-  if (validate(profile)) {
+  if (schemaValid && semanticErrors.length === 0) {
     console.log(`✓ ${profilePath} is a valid v1 profile.`)
     process.exit(0)
   }
@@ -307,5 +580,55 @@ async function runProfile(subargs) {
   for (const err of validate.errors || []) {
     console.error(`    ${err.instancePath || '/'} ${err.message} (${JSON.stringify(err.params)})`)
   }
+  for (const err of semanticErrors) {
+    console.error(`    ${err}`)
+  }
   process.exit(1)
+}
+
+/**
+ * JSON Schema validates each profile entry in isolation. These invariants span
+ * multiple array entries and therefore require a second, semantic validation
+ * pass after AJV has established the profile's structural shape.
+ */
+function validateProfileSemantics(profile) {
+  const errors = []
+  const firstAgentIndex = new Map()
+
+  for (const [index, agent] of profile.agents.entries()) {
+    const previous = firstAgentIndex.get(agent.id)
+    if (previous !== undefined) {
+      errors.push(
+        `/agents/${index}/id duplicates agent id "${agent.id}" first declared at /agents/${previous}/id`,
+      )
+    } else {
+      firstAgentIndex.set(agent.id, index)
+    }
+  }
+
+  const knownAgents = new Set(firstAgentIndex.keys())
+  const defaultIndices = []
+  for (const [index, rule] of profile.routing.entries()) {
+    if (!knownAgents.has(rule.agent)) {
+      errors.push(
+        `/routing/${index}/agent references unknown agent "${rule.agent}"`,
+      )
+    }
+    if (rule.default === true) {
+      defaultIndices.push(index)
+    }
+  }
+
+  if (defaultIndices.length > 1) {
+    errors.push(
+      `/routing must contain at most one default rule (found ${defaultIndices.length})`,
+    )
+  }
+  for (const index of defaultIndices) {
+    if (index !== profile.routing.length - 1) {
+      errors.push(`/routing/${index} default rule must be the last routing entry`)
+    }
+  }
+
+  return errors
 }

--- a/bin/tui-installer.mjs
+++ b/bin/tui-installer.mjs
@@ -10,9 +10,10 @@
  */
 
 import { checkbox, select, Separator } from '@inquirer/prompts';
-import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { writeFileSync, mkdirSync, existsSync, readFileSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // ─── Alternate screen buffer (fullscreen mode) ──────────────────────────────
 
@@ -72,10 +73,10 @@ const DEFAULT_SELECTED = new Set([
   ...CORE_AGENTS,
 ]);
 
-// ─── Model presets (Claude only — see PROVIDER_DEFAULT_MODEL) ────────────────────
-// Claude has real cost/quality tiers (sonnet/haiku/opus). Codex and gemini are
-// single-model in the scaffold (it hardcodes the per-agent model and ignores the
-// install-config preset), so these presets apply to Claude only.
+// ─── Model presets ──────────────────────────────────────────────────────────────
+// Claude exposes distinct Core-defined cost/quality tiers. Other providers use
+// an explicit provider-native default for every named preset; preset names never
+// imply that Claude aliases should be copied into another provider's config.
 
 const MODEL_PRESETS = {
   balanced: {
@@ -95,15 +96,23 @@ const MODEL_PRESETS = {
   },
 };
 
-// Per-provider default agent model. For codex/gemini the scaffold hardcodes this
-// (the install-config model is advisory), so the TUI writes the provider's real
-// model instead of a Claude-flavoured preset. Keep in sync with scaffold.ts
-// (GEMINI_DEFAULT_MODEL / the codex config.toml model).
+// Per-provider default agent model. Keep in sync with install-config.ts and the
+// provider renderers.
 const PROVIDER_DEFAULT_MODEL = {
   claude: 'sonnet',
   codex:  'gpt-5.5-mini',
   gemini: 'gemini-3.5-flash',
+  kimi:   'k3',
 };
+
+function resolveProviderModelPreset(provider, preset = 'balanced') {
+  if (provider === 'claude') return MODEL_PRESETS[preset];
+  return {
+    label: `${PROVIDER_DEFAULT_MODEL[provider]} for all agents`,
+    defaults: PROVIDER_DEFAULT_MODEL[provider],
+    overrides: {},
+  };
+}
 
 // ─── Provider registry ─────────────────────────────────────────────────────────
 // Single source of truth for the AI CLIs the TUI can target. Add a provider here
@@ -112,8 +121,19 @@ const PROVIDERS = [
   { id: 'claude', label: 'Claude Code (recommended)', versionCmd: 'claude --version', installLabel: 'Claude Code', installUrl: 'https://claude.ai/download' },
   { id: 'codex',  label: 'Codex (OpenAI)',            versionCmd: 'codex --version',  installLabel: 'Codex CLI',   installUrl: 'https://developers.openai.com/codex' },
   { id: 'gemini', label: 'Gemini CLI (Google)',       versionCmd: 'gemini --version', installLabel: 'Gemini CLI',  installUrl: 'https://github.com/google-gemini/gemini-cli' },
+  { id: 'kimi',   label: 'Kimi Code',                 versionCmd: 'kimi --version',   installLabel: 'Kimi Code',   installUrl: 'https://www.kimi.com/code/docs/en/' },
 ];
 const VALID_PROVIDER_IDS = new Set(PROVIDERS.map(p => p.id));
+const providerProbeTimeoutOverride = Number.parseInt(
+  process.env.SPECRAILS_PROVIDER_PROBE_TIMEOUT_MS ?? '',
+  10,
+);
+const PROVIDER_PROBE_TIMEOUT_MS =
+  Number.isFinite(providerProbeTimeoutOverride) &&
+  providerProbeTimeoutOverride >= 100 &&
+  providerProbeTimeoutOverride <= 30_000
+    ? providerProbeTimeoutOverride
+    : 3_000;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -121,25 +141,46 @@ const VALID_PROVIDER_IDS = new Set(PROVIDERS.map(p => p.id));
 function detectInstalledProviders() {
   const installed = new Set();
   for (const p of PROVIDERS) {
-    try { execSync(p.versionCmd, { stdio: 'ignore' }); installed.add(p.id); } catch { /* not installed */ }
+    try {
+      execSync(p.versionCmd, {
+        stdio: 'ignore',
+        timeout: PROVIDER_PROBE_TIMEOUT_MS,
+      });
+      installed.add(p.id);
+    } catch { /* absent, broken, or hung — do not block the installer */ }
   }
   return installed;
 }
 
-// Parse `--provider <id>` or `--provider=<id>` from process.argv. Returns a valid
-// provider id or null (unknown values warn-then-null so the TUI falls back to the
-// interactive picker).
-function parseProviderArg() {
-  const args = process.argv.slice(2);
+// Parse `--provider <id>` or `--provider=<id>` from process.argv. An explicit
+// but invalid value is a configuration error, never an invitation to silently
+// open a picker and install a different provider.
+function parseProviderArg(args = process.argv.slice(2)) {
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
-    if (a === '--provider' && args[i + 1]) {
+    if (a === '--provider') {
+      if (!args[i + 1] || args[i + 1].startsWith('-')) {
+        throw new Error(
+          `--provider requires one of: ${[...VALID_PROVIDER_IDS].join(', ')}`,
+        );
+      }
       const v = args[i + 1].trim().toLowerCase();
-      return VALID_PROVIDER_IDS.has(v) ? v : null;
+      if (!VALID_PROVIDER_IDS.has(v)) {
+        throw new Error(
+          `unsupported --provider '${args[i + 1]}' (expected: ${[...VALID_PROVIDER_IDS].join(', ')})`,
+        );
+      }
+      return v;
     }
     if (a.startsWith('--provider=')) {
       const v = a.slice('--provider='.length).trim().toLowerCase();
-      return VALID_PROVIDER_IDS.has(v) ? v : null;
+      if (!VALID_PROVIDER_IDS.has(v)) {
+        throw new Error(
+          `unsupported --provider '${a.slice('--provider='.length)}' ` +
+            `(expected: ${[...VALID_PROVIDER_IDS].join(', ')})`,
+        );
+      }
+      return v;
     }
   }
   return null;
@@ -205,15 +246,38 @@ function writeInstallConfig(specrailsDir, cfg) {
 function writeDefaultConfig(specrailsDir, provider) {
   const defaultSelected = [...DEFAULT_SELECTED];
   const defaultExcluded = ALL_AGENT_IDS.filter(id => !DEFAULT_SELECTED.has(id));
+  const modelSelection = resolveProviderModelPreset(provider);
   writeInstallConfig(specrailsDir, {
     provider,
     tier:           'full',
     selectedAgents: defaultSelected,
     excludedAgents: defaultExcluded,
     modelPreset:    'balanced',
-    modelDefaults:  PROVIDER_DEFAULT_MODEL[provider] ?? 'sonnet',
-    modelOverrides: {},
+    modelDefaults:  modelSelection.defaults,
+    modelOverrides: modelSelection.overrides,
   });
+}
+
+function scaffoldDefaultProfile(specrailsDir, provider) {
+  try {
+    const scriptDir = fileURLToPath(new URL('..', import.meta.url));
+    const templateName = provider === 'kimi' ? 'kimi-default.json' : 'default.json';
+    const templatePath = resolve(scriptDir, 'templates/profiles', templateName);
+    const profilesDir = resolve(specrailsDir, 'profiles');
+    // Provider-bound defaults must coexist in a multi-provider project. Keep
+    // the historical filename for Claude and give Kimi its own stable fallback.
+    const targetName = provider === 'kimi' ? 'kimi-default.json' : 'project-default.json';
+    const targetPath = resolve(profilesDir, targetName);
+    if (existsSync(templatePath) && !existsSync(targetPath)) {
+      mkdirSync(profilesDir, { recursive: true });
+      writeFileSync(targetPath, readFileSync(templatePath));
+      console.log(`  ✓ Profile scaffolded at .specrails/profiles/${targetName}`);
+    } else if (existsSync(targetPath)) {
+      console.log(`  ↷ Profile already exists at .specrails/profiles/${targetName} — skipped`);
+    }
+  } catch (e) {
+    console.warn(`  ⚠  Could not scaffold profile: ${e.message}`);
+  }
 }
 
 // ─── Main ─────────────────────────────────────────────────────────────────────
@@ -222,6 +286,7 @@ async function run() {
   const rawArgs  = process.argv.slice(2);
   const autoYes  = rawArgs.includes('--yes') || rawArgs.includes('-y');
   const withProfiles = rawArgs.includes('--with-profiles');
+  const argvProvider = parseProviderArg(rawArgs);
   // First positional arg (skipping flag values that follow `--provider`,
   // `--root-dir`, etc.) is the target directory.
   const FLAGS_WITH_VALUES = new Set(['--provider', '--root-dir', '--from-config']);
@@ -246,35 +311,12 @@ async function run() {
 
   const specrailsDir = resolve(rootDir, '.specrails');
 
-  // Optional: scaffold .specrails/profiles/project-default.json from the shipped template.
-  // Off by default to keep standalone installs zero-noise.
-  if (withProfiles) {
-    try {
-      const { readFileSync, writeFileSync, existsSync, mkdirSync } = await import('node:fs');
-      const { dirname } = await import('node:path');
-      const scriptDir = new URL('..', import.meta.url).pathname;
-      const templatePath = resolve(scriptDir, 'templates/profiles/default.json');
-      const profilesDir = resolve(specrailsDir, 'profiles');
-      const targetPath = resolve(profilesDir, 'project-default.json');
-      if (existsSync(templatePath) && !existsSync(targetPath)) {
-        mkdirSync(profilesDir, { recursive: true });
-        writeFileSync(targetPath, readFileSync(templatePath));
-        console.log(`  ✓ Profile scaffolded at .specrails/profiles/project-default.json`);
-      } else if (existsSync(targetPath)) {
-        console.log(`  ↷ Profile already exists at .specrails/profiles/project-default.json — skipped`);
-      }
-    } catch (e) {
-      console.warn(`  ⚠  Could not scaffold profile: ${e.message}`);
-    }
-  }
-
   // Auto-yes: write defaults and exit (no TUI needed)
   //
   // Honours an explicit --provider <id> argv flag when present; otherwise
   // picks claude → codex → first-detected. Errors only when none detected.
   if (autoYes) {
     const installed = detectInstalledProviders();
-    const argvProvider = parseProviderArg();
     let provider;
     if (argvProvider) {
       if (!installed.has(argvProvider)) {
@@ -291,12 +333,13 @@ async function run() {
       provider = PROVIDERS.find(p => installed.has(p.id))?.id;
       if (!provider) {
         console.error('');
-        console.error('  ⚠  No supported AI CLI detected on PATH (Claude Code, Codex, or Gemini CLI).');
+        console.error('  ⚠  No supported AI CLI detected on PATH (Claude Code, Codex, Gemini CLI, or Kimi Code).');
         for (const p of PROVIDERS) console.error(`     Install ${p.installLabel}: ${p.installUrl}`);
         console.error('');
         process.exit(1);
       }
     }
+    if (withProfiles) scaffoldDefaultProfile(specrailsDir, provider);
     writeDefaultConfig(specrailsDir, provider);
     console.log(`  ✓ Default config written to .specrails/install-config.yaml`);
     console.log(`  ✓ Provider: ${provider}, Tier: full, Agents: ${DEFAULT_SELECTED.size}/${ALL_AGENT_IDS.length}, Preset: balanced\n`);
@@ -328,7 +371,6 @@ async function run() {
   // ── Step 1: Provider ────────────────────────────────────────────────────────
 
   const installed = detectInstalledProviders();
-  const argvProvider = parseProviderArg();
   let provider;
 
   if (argvProvider) {
@@ -359,6 +401,7 @@ async function run() {
       });
     }
   }
+  if (withProfiles) scaffoldDefaultProfile(specrailsDir, provider);
 
   // ── Step 2: Installation tier ───────────────────────────────────────────────
 
@@ -377,7 +420,10 @@ async function run() {
       {
         value:       'full',
         name:        'Full — AI-powered setup',
-        description: 'After install, run /specrails:enrich to AI-customize all agents for your codebase',
+        description:
+          provider === 'kimi'
+            ? 'After install, run /skill:specrails-enrich to AI-customize all agents for your codebase'
+            : 'After install, run /specrails:enrich to AI-customize all agents for your codebase',
       },
     ],
   });
@@ -409,11 +455,13 @@ async function run() {
   clearScreen();
   console.log(`  Provider: ${provider}  |  Tier: ${tier}  |  Agents: ${selectedAgents.length}/${ALL_AGENT_IDS.length}\n`);
 
-  // Claude exposes real model tiers; codex/gemini are single-model in the scaffold,
-  // so skip the (Claude-flavoured) preset picker for them and use the fixed model.
+  // Claude exposes real model tiers. Other providers retain the same config
+  // shape but resolve the preset through their provider-native catalog.
   let modelPreset = 'balanced';
-  let modelDefaults = PROVIDER_DEFAULT_MODEL[provider] ?? 'sonnet';
-  let modelOverrides = {};
+  let {
+    defaults: modelDefaults,
+    overrides: modelOverrides,
+  } = resolveProviderModelPreset(provider, modelPreset);
   if (provider === 'claude') {
     modelPreset = await select({
       message: 'Model configuration:',
@@ -424,7 +472,7 @@ async function run() {
     });
     ({ defaults: modelDefaults, overrides: modelOverrides } = MODEL_PRESETS[modelPreset]);
   } else {
-    console.log(`  → Model: ${modelDefaults}  (${provider} uses one model for all agents)\n`);
+    console.log(`  → Model: ${modelDefaults}  (${provider} provider preset)\n`);
   }
 
   // ── Write config & exit fullscreen ──────────────────────────────────────────
@@ -444,7 +492,10 @@ async function run() {
   console.log(`\n  ✓ Config written to .specrails/install-config.yaml`);
   console.log(`  ✓ Provider: ${provider} | Tier: ${tier} | Agents: ${selectedAgents.length}/${ALL_AGENT_IDS.length} | Preset: ${modelPreset}`);
   if (tier === 'full') {
-    console.log(`\n  Next: run /specrails:enrich --from-config inside ${provider} to AI-customize your agents.\n`);
+    const enrichCommand = provider === 'kimi'
+      ? '/skill:specrails-enrich --from-config'
+      : '/specrails:enrich --from-config';
+    console.log(`\n  Next: run ${enrichCommand} inside ${provider} to AI-customize your agents.\n`);
   } else {
     console.log(`\n  Agents will be installed with template defaults.\n`);
   }

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Welcome to the SpecRails docs. This guide will take you from zero to a fully aut
 | Guide | What it covers |
 |-------|----------------|
 | [Installation & Setup](installation.md) | Detailed setup, prerequisites, the `/specrails:enrich` wizard, TUI installer |
+| [Kimi Code Setup](user-docs/getting-started-kimi.md) | Install Kimi, scaffold `.kimi-code`, models, sessions, MCP, and troubleshooting |
 | [Plugin Architecture](plugin-architecture.md) | Plugin vs scaffold, what lives where, how updates work |
 | [Agents](agents.md) | Every agent explained — role, when it runs, why it exists |
 | [Workflows & Commands](workflows.md) | How to use `/specrails:implement`, `/specrails:get-backlog-specs`, and more |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,7 +1,5 @@
 # Deployment
 
-> **🧪 Codex (OpenAI) Support — Coming Soon (in Lab).** Any Codex-specific option or step below describes the planned behaviour. Codex installation is currently disabled; the installer will guide you to Claude Code instead.
-
 SpecRails runs locally — no cloud infrastructure required. Choose the setup that fits your workflow.
 
 ## Options at a glance
@@ -9,7 +7,7 @@ SpecRails runs locally — no cloud infrastructure required. Choose the setup th
 | Option | Best for | Setup time |
 |--------|----------|------------|
 | [Plugin](#plugin-recommended) | Quick start, individual developers | ~1 minute |
-| [Local (npx)](#local-npx) | Scaffold/Codex, full offline control | ~2 minutes |
+| [Local (npx)](#local-npx) | Any supported provider, full offline control | ~2 minutes |
 | [Local (git clone)](#local-git-clone) | Customization, contributing | ~5 minutes |
 | [Docker](#docker) | Reproducible environments, teams | ~5 minutes |
 | [CI/CD](#cicd-github-actions) | Automated workflows, GitHub Actions | ~10 minutes |
@@ -31,7 +29,8 @@ claude plugin install sr
 
 ## Local — npx
 
-For Codex users or when you need full control over agent files.
+For Claude Code, Codex CLI, Gemini CLI, or Kimi Code users who need full
+control over agent files.
 
 ```bash
 npx specrails-core@latest init --root-dir .
@@ -43,7 +42,7 @@ This will:
 
 After install, open Claude Code or Codex and run `/specrails:setup` to configure.
 
-**Requirements:** Node.js ≥18, Claude Code or Codex CLI
+**Requirements:** Node.js ≥20.19.0 and one supported AI CLI
 
 ---
 
@@ -147,7 +146,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '20.19.0'
 
       - name: Install SpecRails
         run: npm install -g specrails
@@ -180,7 +179,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '20.19.0'
 
       - name: Install SpecRails
         run: npm install -g specrails

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,11 @@ Get SpecRails running in your project in under 5 minutes.
 
 ## What is SpecRails?
 
-SpecRails installs a **product-driven development workflow** into any repository. It gives Claude Code a team of **12 specialized AI agents** — an architect, developers, layer reviewers, a reviewer, a product manager — that work together to go from idea to shipped PR automatically.
+SpecRails installs a **product-driven development workflow** into any
+repository. It gives Claude Code, Codex CLI, Gemini CLI, or Kimi Code a team of
+specialized AI roles — an architect, developers, layer reviewers, a reviewer,
+and a product manager — that work together to go from idea to shipped PR
+automatically.
 
 Think of it as hiring a full engineering team that lives inside your CLI.
 
@@ -13,15 +17,14 @@ Think of it as hiring a full engineering team that lives inside your CLI.
 You need:
 
 - **Git** — your project must be a git repository
-- **[Claude Code](https://claude.ai/claude-code)** — Anthropic's CLI tool
-
-> **🧪 Codex (OpenAI) Support — Coming Soon (in Lab).** OpenAI Codex integration is currently being tested in our lab. The installer will only install with Claude Code for now — Codex support will ship shortly.
+- One supported AI CLI: Claude Code, Codex CLI, Gemini CLI, or Kimi Code
 
 Optional (recommended):
 
 - **[GitHub CLI](https://cli.github.com/)** (`gh`) — for automatic PR creation and issue tracking
 
-> **Using OpenAI Codex instead of Claude Code?** See [getting-started-codex.md](user-docs/getting-started-codex.md) for Codex-specific setup.
+See the [Codex guide](user-docs/getting-started-codex.md) or
+[Kimi guide](user-docs/getting-started-kimi.md) for provider-specific setup.
 
 ## Install
 
@@ -31,7 +34,7 @@ Optional (recommended):
 claude plugin install sr
 ```
 
-**Scaffold method (for Codex users or full offline control)**
+**Scaffold method (all providers, or full offline control)**
 
 ```bash
 npx specrails-core@latest init --root-dir <your-project>
@@ -49,7 +52,8 @@ When you run `npx specrails-core@latest init`, the TUI installer lets you choose
 2. Choose a model preset
 3. Provide a brief product description
 
-Agents are ready to use immediately after install. Open Claude Code and start working.
+Agents are ready to use immediately after install. Open the selected provider
+CLI and start working.
 
 > Quick install excludes VPC personas and persona-dependent agents/commands (sr-product-manager, sr-product-analyst). These require the full enrichment process.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,19 +2,15 @@
 
 This guide covers the complete installation process in detail. For the quick version, see [Getting Started](getting-started.md).
 
-> ## 🧪 Codex (OpenAI) Support — Coming Soon (in Lab)
->
-> OpenAI Codex integration is currently being **tested in our lab** and **cannot be installed yet**. The installer will refuse any attempt to install with `--provider codex` and will guide you to use Claude Code instead. Codex-specific sections below describe the **planned behaviour** and will be activated when the feature ships.
-
 ## Installation methods
 
-SpecRails supports two distribution channels today, with a third coming soon:
+SpecRails offers a Claude plugin and a provider-independent scaffold:
 
 | Method | Command | Best for |
 |--------|---------|----------|
 | **Claude Code plugin** (recommended) | `claude plugin install sr` | Most projects — no Node.js required, auto-updates |
 | **Claude Code scaffold** | `npx specrails-core@latest init` | Full offline control, custom agent edits |
-| **Codex project** 🧪 _Coming Soon (in lab)_ | `npx specrails-core@latest init` | OpenAI Codex CLI users (not yet available) |
+| **Provider scaffold** | `npx specrails-core@latest init` | Claude, Codex, Gemini, or Kimi Code projects |
 
 ---
 
@@ -59,9 +55,9 @@ The plugin bundles the logic layer — agents, skills, commands, hooks, and refe
 
 | Tool | Why | Install |
 |------|-----|---------|
-| **Node.js 20+** | Required for the installer (macOS, Linux, Windows) | [nodejs.org](https://nodejs.org/) or via [nvm](https://github.com/nvm-sh/nvm) |
+| **Node.js 20.19.0+** | Required for the installer and pinned OpenSpec 1.4.1 CLI (macOS, Linux, Windows) | [nodejs.org](https://nodejs.org/) or via [nvm](https://github.com/nvm-sh/nvm) |
 | **Git** | SpecRails operates on git repositories | [git-scm.com](https://git-scm.com/) |
-| **Claude Code** or **Codex CLI** | The AI CLI that runs the agents | See [codex-vs-claude-code.md](user-docs/codex-vs-claude-code.md) |
+| **Supported AI CLI** | The runtime that runs the agents | Claude, Codex, Gemini, or [Kimi Code](user-docs/getting-started-kimi.md) |
 
 ### Install
 
@@ -88,7 +84,8 @@ node bin/specrails-core.mjs init --root-dir <your-project>
 The `npx specrails-core@latest init` command now includes a **TUI installer** that runs before copying files:
 
 1. **TUI agent selection** — Interactive terminal UI lets you select which agents to install and choose a model preset (balanced/budget/max). Writes `.specrails/install-config.yaml`.
-2. **Checks prerequisites** — validates Git, Claude Code; optionally installs npm and gh
+2. **Checks prerequisites** — validates Git and the selected provider CLI;
+   optionally installs npm and gh
 3. **Detects existing setup** — warns if SpecRails artifacts already exist
 4. **Installs artifacts:**
    - `.claude/commands/specrails/enrich.md` — the `/specrails:enrich` wizard
@@ -105,11 +102,25 @@ The scaffold installer only copies files. It does not modify your existing code,
 
 ## The Enrich Wizard
 
-After either installation method, open Claude Code (or Codex) in your project and run:
+After either installation method, open the selected AI CLI. Claude and Gemini
+use:
 
 ```
 /specrails:enrich
 ```
+
+Kimi uses:
+
+```text
+/skill:specrails-enrich
+```
+
+That slash form is Kimi TUI syntax. Automated callers use the managed
+`.kimi-code/specrails/run-skill.mjs` helper installed beside the skills; passing
+the slash form directly to `kimi -p` does not activate it in Kimi 0.27.
+Generated multi-role workflows give that helper one structured foreground
+role wave. It owns parallel child processes and reusable worktrees, so no
+Kimi daemon or bundled provider binary is required.
 
 There are three modes:
 
@@ -274,28 +285,35 @@ Runs a fully automated installation using `.specrails/install-config.yaml`. No i
 
 ```yaml
 version: 1
-provider: claude        # claude | codex | auto
+provider: claude        # claude | codex | gemini | kimi
 tier: full              # full (requires /specrails:enrich) | quick (agents placed directly)
 agents:
-  selected:             # list of agent names to install
+  selected:             # unique lowercase kebab-case ids (1-64 chars)
     - sr-architect
     - sr-developer
     - sr-reviewer
     - sr-test-writer
     - sr-product-manager
-  excluded: []          # agent names to skip
+  excluded: []          # unique ids to skip; must not overlap selected
 models:
   preset: balanced      # balanced | budget | max
-  overrides: {}         # per-agent overrides: { sr-architect: opus }
+  defaults:
+    model: sonnet       # exact provider model/alias; Kimi defaults to k3
+  overrides: {}         # exact per-agent models: { sr-architect: opus }
 ```
 
 **Model presets:**
 
 | Preset | Description |
 |--------|-------------|
-| `balanced` (default) | Opus for architect + PM, Sonnet for all others |
+| `balanced` (default) | Sonnet for all Claude agents |
 | `budget` | Haiku for all agents |
-| `max` | Opus for all agents |
+| `max` | Opus for Claude architect + PM, Sonnet for all others |
+
+Other providers resolve the same preset names within their own catalog. Kimi
+presets default to `k3`; exact official ids and configured aliases are retained.
+Kimi ids must be 1–128 characters matching
+`[A-Za-z0-9][A-Za-z0-9._/:-]*`, the same grammar enforced at process launch.
 
 ---
 

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -74,19 +74,22 @@ The scaffold copies the full agent+command set into `.claude/` — you own and v
 
 **Best for:** Teams that want to version the agent prompts themselves, or projects that need full offline control.
 
-### 3. Codex project 🧪 _Coming Soon (in Lab)_
-
-> **Codex installation is not yet available.** OpenAI Codex integration is being tested in our lab and will ship shortly. The block below describes the **planned behaviour** for when the feature is released.
+### 3. Provider scaffold
 
 ```bash
-npx specrails-core@latest init --root-dir .   # same as scaffold (Codex path — not yet available)
-codex                                          # open Codex
-/specrails:enrich                             # configure
+npx specrails-core@latest init --root-dir . --provider codex
+npx specrails-core@latest init --root-dir . --provider gemini
+npx specrails-core@latest init --root-dir . --provider kimi
 ```
 
-Codex does not support the Claude Code plugin system. When Codex support ships, use the scaffold method.
+Codex, Gemini, and Kimi do not use the Claude Code plugin package. The
+scaffold renders their native project surfaces under `.codex/`, `.gemini/`,
+and `.kimi-code/` respectively. Kimi interactive workflows use
+`/skill:specrails-*`; its headless workflows use the managed runner installed
+under `.kimi-code/specrails/`.
 
-**Best for (when available):** OpenAI Codex CLI users.
+**Best for:** Codex, Gemini, or Kimi users and teams that version generated
+provider artifacts.
 
 ## The `/specrails:enrich` wizard
 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -8,7 +8,8 @@ The update system uses a **manifest-based approach**:
 
 1. During installation, SpecRails generates `.specrails/specrails-manifest.json` — a checksum of every installed file
 2. On update, the new templates from the latest specrails-core release are re-applied
-3. Reserved paths (`.specrails/profiles/**`, `.claude/agents/custom-*.md`) are preserved by construction — the installer never touches them
+3. Reserved paths (`.specrails/profiles/**`, provider-specific `custom-*`
+   roles, OpenSpec skills, and user MCP entries) are preserved by construction
 
 ## Running an update
 
@@ -21,9 +22,13 @@ Cross-platform (macOS, Linux, Windows). No bash, no python required — the inst
 ### What happens
 
 1. **Version check** — reads existing `.specrails/specrails-version`; aborts if no specrails install is detected
-2. **Provider resolution** — detects whether the project uses Claude (`.claude/`) or Codex (`.codex/`)
+2. **Provider resolution** — detects Claude (`.claude/`), Codex (`.codex/`),
+   Gemini (`.gemini/`), or Kimi (`.kimi-code/`). In a multi-provider workspace,
+   pass `--provider` to select the tree being refreshed.
 3. **Re-scaffold** — re-applies templates from the latest specrails-core into `.specrails/setup-templates/` and the provider directory
-4. **Reserved paths** — `.specrails/profiles/**` and `.claude/agents/custom-*.md` are skipped; your team profiles and custom agents survive untouched
+4. **Reserved paths** — profiles and provider-specific custom roles are skipped;
+   Kimi also preserves `openspec-*`, unknown skill directories, and existing
+   `.kimi-code/mcp.json` entries
 5. **Manifest refresh** — rewrites `specrails-manifest.json` and `specrails-version` to the new core version
 
 ## Selective updates (`--only`)
@@ -49,6 +54,19 @@ Prints what the update would do without writing any files. Useful for inspecting
 | **Rules** (`.claude/rules/`) | Re-written from latest templates |
 | **Agent memory** (`.claude/agent-memory/`) | Untouched (created on first install only) |
 | **install-config.yaml** | Untouched |
+| **Kimi workflows** (`.kimi-code/skills/specrails-*`) | Re-written from latest templates |
+| **Kimi roles** (`.kimi-code/skills/sr-*`) | Re-written according to the selected agent set |
+| **Kimi custom roles** (`.kimi-code/skills/custom-*`) | **Always preserved** |
+| **Kimi OpenSpec skills** (`.kimi-code/skills/openspec-*`) | Preserved and normalized from legacy `.kimi/skills` when needed |
+| **Kimi MCP config** (`.kimi-code/mcp.json`) | Existing entries preserved; SpecRails-owned entries merged additively |
+| **Kimi headless runner** (`.kimi-code/specrails/`) | Runner, vendored YAML parser, MIT license, and provenance notice are re-written together from the latest trusted Core template; they are managed code, not user skills |
+
+Kimi discovers only immediate child directories of `.kimi-code/skills`.
+Updates therefore migrate the pre-release
+`.kimi-code/skills/rails/custom-*` layout to direct `custom-*` children when
+the destination is free, and regenerate managed `sr-*` roles at the direct
+level. If both legacy and direct versions of a custom role exist, neither is
+overwritten or deleted: `doctor` reports the conflict for manual resolution.
 
 ## Rolling back
 

--- a/docs/user-docs/cli-reference.md
+++ b/docs/user-docs/cli-reference.md
@@ -1,14 +1,14 @@
 # CLI Reference
 
-> **🧪 Codex (OpenAI) Support — Coming Soon (in Lab).** Codex-specific sections below describe the planned behaviour. Codex installation is currently disabled — only Claude Code is available today.
-
-SpecRails commands are implemented as Skills (`SKILL.md` format) and are designed to run in both Claude Code and Codex. The command syntax is identical on both platforms. Today only the Claude Code runtime is available; Codex support is being tested in our lab and will ship shortly.
+SpecRails installs provider-native workflows for Claude Code, Codex CLI,
+Gemini CLI, and Kimi Code. The workflow names and flags are shared, while each
+provider uses its own activation syntax and project directory.
 
 **Platform support key used in this reference:**
 
 | Badge | Meaning |
 |-------|---------|
-| ✅ Both | Works in Claude Code and Codex |
+| ✅ Providers | Works in Claude Code, Codex CLI, Gemini CLI, and Kimi Code |
 | 🔵 Claude Code | Claude Code only |
 | ⚠️ Limited | Works, but with known limitations (see notes) |
 
@@ -17,13 +17,20 @@ Run commands inside your AI CLI from your project directory:
 ```bash
 claude   # Claude Code
 codex    # Codex
+gemini   # Gemini CLI
+kimi     # Kimi Code
 ```
+
+Claude and Gemini use `/specrails:<command>`. Codex activates the generated
+skill from `.codex/skills/`. Kimi's interactive TUI uses
+`/skill:specrails-<command>`; headless Kimi runs must use the managed
+`.kimi-code/specrails/run-skill.mjs` helper, not a literal `/skill:` prompt.
 
 ---
 
 ## Core workflow
 
-### `/specrails:implement` ✅ Both
+### `/specrails:implement` ✅ Providers
 
 Implement a feature through the full agent pipeline: design → code → tests → docs → review → PR.
 
@@ -62,9 +69,14 @@ A single issue runs sequentially on the current branch. Multiple issues run in p
 
 ---
 
-### `/specrails:telemetry` ✅ Both
+### `/specrails:telemetry` ✅ Providers
 
 Inspect per-agent execution metrics: token usage, estimated API cost, run count, average duration, and success/failure rate.
+
+Kimi reads persisted `usage.record` events for real input/output/cache token
+counts and session duration. Its logs do not contain an authoritative USD rate
+or role outcome, so the Kimi dashboard reports cost and success rate as
+unavailable instead of applying another provider's rate card.
 
 ```
 /specrails:telemetry
@@ -81,11 +93,11 @@ Inspect per-agent execution metrics: token usage, estimated API cost, run count,
 | `--period <filter>` | Time window: `today`, `week` (default), or `all` |
 | `--agent <name>` | Focus on a single agent (e.g. `sr-developer`) |
 | `--format <fmt>` | Output format: `markdown` (default) or `json` |
-| `--save` | Write a snapshot to `.claude/telemetry/` after display |
+| `--save` | Write a snapshot under the active provider directory after display |
 
 ---
 
-### `/specrails:merge-resolve` ✅ Both
+### `/specrails:merge-resolve` ✅ Providers
 
 Resolve git conflict markers using AI-powered context analysis.
 
@@ -107,7 +119,7 @@ Reads OpenSpec context bundles from the features that produced each conflict, in
 
 ---
 
-### `/specrails:retry` ✅ Both
+### `/specrails:retry` ✅ Providers
 
 Resume a failed `/specrails:implement` run from the last successful phase.
 
@@ -128,7 +140,7 @@ Resume a failed `/specrails:implement` run from the last successful phase.
 
 **Valid `--from` values:** `architect`, `developer`, `test-writer`, `doc-sync`, `reviewer`, `ship`, `ci`
 
-Pipeline state is saved to `.claude/pipeline-state/<feature-name>.json` after each phase.
+Pipeline state is saved under the active provider directory after each phase.
 
 ---
 
@@ -148,7 +160,7 @@ Each feature gets its own worktree, its own agent pipeline, and its own PR. Use 
 
 ## Product and backlog
 
-### `/specrails:get-backlog-specs` ✅ Both
+### `/specrails:get-backlog-specs` ✅ Providers
 
 View your prioritized product backlog, ranked by VPC persona fit and estimated effort.
 
@@ -161,7 +173,7 @@ Reads GitHub Issues labeled `product-driven-backlog`. Produces a ranked table pe
 
 ---
 
-### `/specrails:auto-propose-backlog-specs` ✅ Both
+### `/specrails:auto-propose-backlog-specs` ✅ Providers
 
 Generate new feature ideas through product discovery and create GitHub Issues.
 
@@ -176,7 +188,7 @@ The Product Manager researches your competitive landscape, generates 2–4 featu
 
 ## Analysis and inspection
 
-### `/specrails:refactor-recommender` ✅ Both
+### `/specrails:refactor-recommender` ✅ Providers
 
 Scan the codebase for refactoring opportunities, ranked by impact/effort ratio.
 
@@ -188,7 +200,7 @@ Identifies duplicates, overly long functions, large files, dead code, outdated p
 
 ---
 
-### `/specrails:compat-check` ✅ Both
+### `/specrails:compat-check` ✅ Providers
 
 Analyze the backwards-compatibility impact of a proposed change.
 
@@ -205,7 +217,7 @@ The Architect runs this automatically as part of every `/specrails:implement` pi
 
 ---
 
-### `/specrails:why` ✅ Both
+### `/specrails:why` ✅ Providers
 
 Search agent explanation records in plain language.
 
@@ -215,11 +227,13 @@ Search agent explanation records in plain language.
 /specrails:why "why is pagination implemented this way"
 ```
 
-Agents write decision rationale to `.claude/agent-memory/explanations/` as they work. `/specrails:why` searches these records semantically. Useful for onboarding, code review, and revisiting past decisions.
+Agents write decision rationale under the active provider's `agent-memory/`
+directory as they work. `/specrails:why` searches these records semantically.
+Useful for onboarding, code review, and revisiting past decisions.
 
 ---
 
-### `/specrails:vpc-drift` ✅ Both
+### `/specrails:vpc-drift` ✅ Providers
 
 Detect when your VPC personas have drifted from what your product actually delivers.
 
@@ -234,7 +248,7 @@ Compares persona Jobs/Pains/Gains against your backlog, implemented features, an
 
 ---
 
-### `/specrails:memory-inspect` ✅ Both
+### `/specrails:memory-inspect` ✅ Providers
 
 Inspect and clean up agent memory directories.
 
@@ -252,11 +266,18 @@ Inspect and clean up agent memory directories.
 | `--stale <days>` | Flag files older than N days |
 | `--prune` | Delete stale files (prompts for confirmation) |
 
-Agent memory lives in `.claude/agent-memory/sr-*/` (Claude Code) or `.codex/agent-memory/sr-*/` (Codex).
+Agent memory lives below the provider root:
+
+| Provider | Memory root |
+|----------|-------------|
+| Claude Code | `.claude/agent-memory/` |
+| Codex CLI | `.codex/agent-memory/` |
+| Gemini CLI | `.gemini/agent-memory/` |
+| Kimi Code | `.kimi-code/agent-memory/` |
 
 ---
 
-### `/specrails:propose-spec` ✅ Both
+### `/specrails:propose-spec` ✅ Providers
 
 Explore a feature idea and produce a structured proposal ready for the OpenSpec pipeline.
 
@@ -272,7 +293,7 @@ Produces: problem statement, proposed solution, out-of-scope items, acceptance c
 
 OpenSpec is the structured design-to-code workflow. Use these commands when you want explicit control over each artifact: proposal → design → tasks → implementation.
 
-All OpenSpec commands work on both Claude Code and Codex (✅ Both).
+OpenSpec commands are generated for all four providers (✅ Providers).
 
 ### `/opsx:ff` — Fast Forward
 
@@ -400,7 +421,7 @@ The `npx specrails-core@latest init` command accepts:
 |------|--------|
 | `--root-dir <path>` | Install into this directory (default: current directory) |
 | `--yes` / `-y` | Skip confirmation prompts |
-| `--provider <claude\|codex>` | Force a specific AI CLI (default: auto-detect) |
+| `--provider <claude\|codex\|gemini\|kimi>` | Force a specific AI CLI (default: auto-detect) |
 
 ---
 

--- a/docs/user-docs/codex-vs-claude-code.md
+++ b/docs/user-docs/codex-vs-claude-code.md
@@ -1,10 +1,8 @@
 # Codex vs Claude Code
 
-> # 🧪 Codex Support — Coming Soon (in Lab)
->
-> OpenAI Codex integration is currently being **tested in our lab** and is not available for installation. The installer only accepts Claude Code at this time. This document describes the planned behaviour and will be activated when the feature ships.
-
-SpecRails supports **Anthropic Claude Code** as an AI agent runtime, with **OpenAI Codex** support coming soon. This page explains the differences so you can choose the right setup for your team when Codex ships.
+SpecRails supports both **Anthropic Claude Code** and **OpenAI Codex** as AI
+agent runtimes. Gemini CLI and Kimi Code are also supported; this page focuses
+only on the Claude/Codex comparison.
 
 ---
 
@@ -12,7 +10,7 @@ SpecRails supports **Anthropic Claude Code** as an AI agent runtime, with **Open
 
 | | Claude Code | Codex |
 |--|-------------|-------|
-| **Support status** | Stable | Beta |
+| **Support status** | Supported | Supported |
 | **CLI** | `claude` | `codex` |
 | **Config directory** | `.claude/` | `.codex/` |
 | **Agent instructions** | `CLAUDE.md` | `AGENTS.md` |
@@ -113,7 +111,11 @@ Skills themselves are the same — only the CLI invocation differs.
 - Different team members use different tools
 - You want to benchmark agents across platforms
 
-When both CLIs are installed, the SpecRails installer detects which is active. You can override with `CLI_PROVIDER=claude` or `CLI_PROVIDER=codex`.
+When several CLIs are installed, pass `--provider` to choose explicitly:
+
+```bash
+npx specrails-core@latest init --provider codex
+```
 
 ---
 
@@ -129,8 +131,8 @@ Generating config in .codex/
 To override:
 
 ```bash
-CLI_PROVIDER=codex npx specrails-core@latest init --root-dir .
-CLI_PROVIDER=claude npx specrails-core@latest init --root-dir .
+npx specrails-core@latest init --provider codex --root-dir .
+npx specrails-core@latest init --provider claude --root-dir .
 ```
 
 ---

--- a/docs/user-docs/faq.md
+++ b/docs/user-docs/faq.md
@@ -12,7 +12,7 @@ The plugin method (`claude plugin install sr`) installs logic into Claude Code's
 
 **Do I need Node.js if my project is not JavaScript?**
 
-Not for the plugin method (`claude plugin install sr`). Node.js 20+ is only required for the scaffold method (`npx specrails-core@latest init`). Once installed, SpecRails works with any language or framework, on macOS, Linux, or Windows.
+Not for the plugin method (`claude plugin install sr`). Node.js 20.19.0+ is only required for the scaffold method (`npx specrails-core@latest init`), because its pinned OpenSpec 1.4.1 CLI uses that runtime floor. Once installed, SpecRails works with any language or framework, on macOS, Linux, or Windows.
 
 **Do I need GitHub Issues?**
 

--- a/docs/user-docs/getting-started-codex.md
+++ b/docs/user-docs/getting-started-codex.md
@@ -1,12 +1,9 @@
 # Getting Started with SpecRails + Codex
 
-> # 🧪 Coming Soon — Currently in Lab
->
-> **OpenAI Codex support is being tested in our lab and is not yet available for installation.** The installer will refuse to install Codex and will ask you to use Claude Code. This document describes the planned behaviour and will be activated when the feature ships.
->
-> **Current status:** Preview / documentation only. For now, use [Claude Code](https://claude.ai/download) — see the [standard installation guide](installation.md).
-
-This guide gets you running SpecRails using OpenAI Codex as your AI agent. If you are using Claude Code instead, see the [standard installation guide](installation.md).
+This guide gets you running SpecRails using OpenAI Codex as your AI agent.
+Claude Code, Gemini CLI, and Kimi Code are also supported; see the
+[standard installation guide](installation.md) or the
+[Kimi-specific guide](getting-started-kimi.md).
 
 ---
 
@@ -14,7 +11,7 @@ This guide gets you running SpecRails using OpenAI Codex as your AI agent. If yo
 
 | Tool | Version | Notes |
 |------|---------|-------|
-| **Node.js** | 18+ | Required for the installer |
+| **Node.js** | 20.19.0+ | Required for the installer and pinned OpenSpec 1.4.1 CLI |
 | **Codex CLI** | Latest | `npm i -g @openai/codex` |
 | **Git** | Any | Your project must be a git repository |
 

--- a/docs/user-docs/getting-started-kimi.md
+++ b/docs/user-docs/getting-started-kimi.md
@@ -1,0 +1,423 @@
+# Getting Started with SpecRails + Kimi Code
+
+SpecRails supports Kimi Code as an independent AI provider. The integration
+uses the installed `kimi` CLI in non-interactive prompt mode; it does not embed
+Kimi Code, start `kimi web`, or require a SpecRails-owned server.
+
+## Requirements
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| Kimi Code | 0.27.0 or newer | Agentic runtime |
+| Node.js | 20.19.0 or newer | Runs the SpecRails installer and pinned OpenSpec 1.4.1 CLI |
+| Git | 2.25 or newer | Repository and worktree operations |
+
+Install Kimi Code using an official method:
+
+```bash
+# macOS / Linux
+curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash
+```
+
+```powershell
+# Windows PowerShell
+irm https://code.kimi.com/kimi-code/install.ps1 | iex
+```
+
+The optional npm distribution is `@moonshot-ai/kimi-code` and requires the
+Node.js version documented by Kimi Code (22.19 or newer at the time this
+integration was implemented). The standalone installer is preferable when the
+project itself may remain on Node 20.19.0 or newer.
+
+Verify the executable and authenticate once:
+
+```bash
+kimi --version
+kimi login
+```
+
+SpecRails checks installation and version without sending a model prompt. Kimi
+does not expose a non-billing command that conclusively proves every OAuth
+session is usable, so an inconclusive auth probe is allowed and the first real
+invocation will surface any login error.
+
+## Install SpecRails
+
+From the repository that should receive SpecRails:
+
+```bash
+npx specrails-core@latest init --root-dir . --provider kimi
+```
+
+For a quick, template-only install:
+
+```bash
+npx specrails-core@latest init --root-dir . --provider kimi --quick
+```
+
+Without `--provider`, automatic selection preserves the established priority:
+Claude, Codex, Gemini, then Kimi. Pass `--provider kimi` when several CLIs are
+installed and Kimi is the intended runtime.
+
+## Generated Kimi layout
+
+```text
+.kimi-code/
+├── AGENTS.md
+├── mcp.json
+├── personas/
+├── rules/
+├── specrails/
+│   ├── run-skill.mjs
+│   └── vendor/js-yaml/
+│       ├── js-yaml.mjs
+│       ├── LICENSE
+│       └── NOTICE.md
+└── skills/
+    ├── specrails-enrich/SKILL.md
+    ├── specrails-implement/SKILL.md
+    ├── specrails-…/SKILL.md
+    ├── openspec-…/SKILL.md
+    ├── sr-architect/SKILL.md
+    ├── sr-developer/SKILL.md
+    └── …
+```
+
+Kimi's skill loader inspects each immediate child of `.kimi-code/skills`; it
+does not recursively discover grouping directories. SpecRails therefore gives
+every workflow (`specrails-*`), OpenSpec workflow (`openspec-*`), managed role
+(`sr-*`), and custom role (`custom-*`) its own direct-child directory.
+Non-invocable persona data lives separately under `.kimi-code/personas/`, so
+the skill scanner never mistakes it for a skill. The managed headless runner
+also lives outside the scanner.
+
+Interactive workflow invocations in Kimi's TUI differ from Claude/Gemini
+syntax:
+
+```text
+/skill:specrails-enrich
+/skill:specrails-implement add passkey authentication
+/skill:specrails-batch-implement #41 #42
+```
+
+OpenSpec workflows use their complete published skill names, for example:
+
+```text
+/skill:openspec-ff-change add-passkeys
+/skill:openspec-apply-change add-passkeys
+/skill:openspec-verify-change add-passkeys
+```
+
+OpenSpec versions that initially generate `.kimi/skills/openspec-*` are
+normalized into `.kimi-code/skills/` by SpecRails. Existing `.kimi-code`
+content and user-owned skills are preserved. Normalization rejects symlinked
+or special-file sources/destinations, copies only a verified contained tree,
+and uses unpredictable same-filesystem temporary/backup directories for each
+atomic replacement.
+
+## Models and reasoning effort
+
+SpecRails persists Kimi's public model ids:
+
+- `k3` (default)
+- `kimi-for-coding`
+- `kimi-for-coding-highspeed`
+
+Managed Kimi login config exposes these as CLI aliases under `kimi-code/`.
+At process launch, SpecRails maps only those known ids:
+
+```text
+k3                            -> kimi-code/k3
+kimi-for-coding               -> kimi-code/kimi-for-coding
+kimi-for-coding-highspeed     -> kimi-code/kimi-for-coding-highspeed
+```
+
+Already-prefixed aliases and custom aliases pass through unchanged. This keeps
+profiles portable without silently rewriting custom Kimi configuration.
+At the process boundary, every model id must be 1–128 characters and match
+`^[A-Za-z0-9][A-Za-z0-9._/:-]*$`. This preserves common configured aliases such
+as `company/Kimi-Custom:v2` while rejecting leading flags, whitespace, control
+characters, and shell syntax before spawn.
+
+When profile scaffolding is requested, Kimi's provider-bound fallback is stored
+at `.specrails/profiles/kimi-default.json`. It can coexist with Claude's
+historical `project-default.json` in a multi-provider project.
+
+K3 supports `low`, `high`, and `max` reasoning effort. Desktop launches apply
+the selected value only to that child process through
+`KIMI_MODEL_THINKING_EFFORT`; SpecRails never mutates the user's global shell
+environment. The Core invocation overlay removes inherited effort unless the
+caller explicitly selects a valid value for K3. The managed helper preserves
+an inherited `low`, `high`, or `max` only for `k3`/`kimi-code/k3`; it removes
+the variable for every other model and drops invalid values. Kimi's documented
+K3 default is `high`; leaving the variable unset deliberately retains that
+upstream default. SpecRails does not substitute `low`.
+
+## Headless and session behavior
+
+Kimi 0.27 handles `/skill:...` in its TUI and ACP clients. Prompt mode does not:
+`kimi -p "/skill:specrails-implement ..."` forwards that string directly to
+the model and silently fails to call Kimi's skill activation path.
+
+The canonical headless invocation therefore uses Core's managed Node helper:
+
+```bash
+node .kimi-code/specrails/run-skill.mjs \
+  --skill specrails-implement \
+  --model k3 \
+  --args "add passkey authentication"
+```
+
+The helper validates a direct-child skill id, reads and expands its `SKILL.md`
+using Kimi 0.27's argument and XML rules, and launches the separately installed
+`kimi` executable with `-p` and `--output-format stream-json`. It passes each
+value as an argv element with `shell: false`; it never evaluates skill names,
+model aliases, or multiline arguments as shell source.
+
+Provider hosts can submit a plain user turn to the helper with
+`--plain-prompt-stdin`; Core bounds that UTF-8 input to 1 MiB and keeps it out
+of the host-to-helper argv. Kimi 0.27 exposes no native stdin/file equivalent
+to `-p`, so the helper passes the exact turn—not a file-reading envelope—to
+the external CLI. Consequently, an official native Kimi binary still exposes
+the exact prompt in its own process argv. The Windows npm shim is the one
+verified exception described below. Do not place secrets in agent prompts.
+
+Generated Kimi skills resolve project-specific stack, CI, layer, persona,
+backlog, and PR context at activation time from `.kimi-code/project-context.md`,
+`.kimi-code/personas/*.md`, and `.specrails/backlog-config.json`. Their
+`KIMI_RUNTIME_*`/`KIMI_BACKLOG_*` markers are semantic operations, never shell
+command names. Missing or read-only backlog configuration fails closed for
+writes instead of fabricating a provider command.
+
+Generated workflows use an even stricter boundary for role launches. For each
+single role or parallel group, the orchestrator writes one exact object through
+Kimi's structured WriteFile tool to `.specrails/kimi-role-wave.json`:
+
+```json
+{
+  "run": "implement-20260719",
+  "roles": [
+    {
+      "key": "developer-feature-a",
+      "skill": "sr-developer",
+      "model": "k3",
+      "profile": "inherit",
+      "args": "Complete context for feature A",
+      "workspace": "worktree:feature-a"
+    }
+  ]
+}
+```
+
+`run`, `key`, the optional profile stem, and the worktree suffix are lowercase
+letters/digits/hyphens, 1–64 characters. `profile` is `inherit` or the stem of
+a validated `.specrails/profiles/<name>.json`; the helper passes its absolute
+path only to that child. A wave contains 1–32 roles and no extra fields. The
+orchestrator then runs one static foreground command with `--role-wave-file`;
+model names and arbitrary multiline context never enter shell source. The
+runner accepts no alternate path, symlink, duplicate role/worktree, unsafe
+identifier, or file above 1 MiB, and deletes the one-shot file before setup.
+
+```bash
+node .kimi-code/specrails/run-skill.mjs \
+  --role-wave-file .specrails/kimi-role-wave.json \
+  --add-dir "${SPECRAILS_REPO_DIR:-.}"
+```
+
+`workspace: "current"` still gives each parallel role a unique execution
+directory, while `SPECRAILS_REPO_DIR` points at the repository it must edit.
+This prevents nested workflow state/request collisions. A
+`worktree:<feature-id>` entry creates or reuses a detached git worktree from a
+private synthetic commit that snapshots the initial dirty tracked and
+non-ignored untracked files without changing the user's index or branch. Reuse the
+same worktree id for that feature's developer, test, and documentation waves.
+The helper excludes managed `.kimi-code`/run-state from the role's git index
+and records source HEAD, immutable synthetic base commit, and every path under
+`.specrails/kimi-role-worktrees/<run>.json`; merge instructions use that commit
+instead of assuming `main`.
+
+Before status, merge, reuse, or cleanup, Core recomputes the only valid temp
+worktree/execution/exclude paths from the canonical repository hash and run/id,
+requires every isolated path to be that exact registered worktree, and verifies
+the private baseline ref still equals the manifest commit. Editing the manifest
+cannot redirect `git worktree remove`, status, or merge to another registered
+worktree. A Windows copied `.kimi-code` overlay is likewise accepted only with
+a managed marker and a full deterministic content hash; stale bytes are rebuilt.
+
+Child streams are emitted as attributed `specrails.role.*` JSONL frames. The
+helper waits for the whole wave and exits nonzero if any role fails. Termination
+signals reach every live child. A role failure keeps valid worktrees for retry;
+a setup failure removes only worktrees partially created by that setup, and
+retry reuses the manifest's exact run/worktree mapping.
+
+Merge begins with `--role-wave-status <run>`, which emits complete A/M/D
+inventories across committed, staged, unstaged, and non-ignored untracked
+changes. Exclusive paths are applied through the fixed
+`.specrails/kimi-role-merge.json` request and `--role-merge-file`; filenames are
+never interpolated into shell source. After a successful merge,
+`--role-wave-cleanup <run>` removes registered worktrees, execution state, the
+manifest, and the private synthetic-baseline ref. Failed or unmerged runs are
+never cleaned automatically.
+
+The supported contract is qualified against Kimi 0.27's stable v1 engine.
+SpecRails removes `KIMI_CODE_EXPERIMENTAL_FLAG` from the child environment and
+rejects experimental runner flags instead of silently opting into a different,
+unverified runtime. Every Core-managed child also receives
+`KIMI_DISABLE_CRON=1` and `KIMI_CODE_NO_AUTO_UPDATE=1`: a bounded SpecRails
+invocation must not leave persistent scheduled work behind or self-update the
+external CLI during startup. These controls do not disable Kimi print mode's
+normal foreground task drain or steering lifecycle.
+
+On Windows npm installs, large materialized workflows never travel in the
+`CreateProcess` command line. The helper launches the official Kimi JavaScript
+entry through a fixed Node bootstrap, sends the full UTF-8 prompt over stdin,
+and restores that one `-p` argv value before importing Kimi. This preserves the
+complete workflow even when it exceeds Windows' command-line limit. A native
+executable remains direct-spawned only while its command line is at most 30,000
+UTF-16 code units; larger native launches fail with guidance to use the
+standard npm shim.
+
+Once that initial skill is running, nested SpecRails and OpenSpec workflows use
+Kimi's built-in `Skill` tool with explicit `skill` and `args` fields. This is
+the native in-session path and retains Kimi's nested activation behavior and
+`skill.activated` telemetry. The external helper reproduces the exact visible
+initial prompt, but cannot emit Kimi-private activation-origin telemetry; no
+such events are synthesized.
+
+Kimi emits a `session.resume_hint` record at the end of a successful prompt.
+A host trusts and persists it only when it is the terminal non-empty JSONL
+record, its id passes the grammar below, and the Kimi child exits with code 0.
+When that session id is known, a later skill invocation can resume it explicitly:
+
+```bash
+node .kimi-code/specrails/run-skill.mjs \
+  --skill sr-reviewer \
+  --model k3 \
+  --args "continue with the review feedback" \
+  --session=<session-id>
+```
+
+`${KIMI_SESSION_ID}` cannot be populated before a fresh prompt emits that hint.
+The helper rejects a fresh invocation of a skill that uses this placeholder
+instead of silently substituting an incorrect empty id. Resume ids are bounded
+to 1–128 characters in `[A-Za-z0-9._-]`, with `.` and `..` rejected, and the
+external Kimi process receives the id as one `--session=<id>` argument.
+
+The helper forwards `SIGINT`, `SIGTERM`, and `SIGHUP` to its direct Kimi child
+and removes those handlers when the child exits. Desktop or another embedding
+host remains responsible for its normal platform-specific process-tree
+teardown. There is no background Kimi service for SpecRails to install,
+monitor, or uninstall.
+
+One JSONL assistant record may contain text and several tool calls. Consumers
+must retain every event from that record. The telemetry skill reads Kimi's
+persisted `~/.kimi-code/session_index.jsonl`, validated session `state.json`,
+and `agents/*/wire.jsonl` `usage.record` events. Those records expose
+input-other, output, cache-read, and cache-creation tokens per model. They do
+not expose an authoritative USD charge or reliable role outcome, so cost and
+success rate remain unavailable rather than being synthesized.
+
+## Permissions and attachments
+
+Kimi prompt mode is autonomous: it temporarily uses Kimi's `auto` permission
+policy and still honors static deny rules from the user's Kimi configuration.
+Run agentic workflows only in repositories and worktrees you trust. SpecRails
+does not add `--auto`, `--yolo`, or `--plan`; Kimi rejects those flags when
+combined with `-p`.
+
+Kimi has no dedicated image CLI flag. SpecRails accepts only absolute,
+readable, regular, non-symlink attachment files, canonicalizes each path, and
+adds every unique parent as `--add-dir`. It then places those canonical media
+references in the prompt so Kimi can use `ReadMediaFile` or `ReadFile`. Core's
+helper does not read or inline attachment contents. Missing files, directories,
+symlinks, and unreadable inputs fail before spawn.
+
+## MCP
+
+Kimi reads project MCP declarations from `.kimi-code/mcp.json`. SpecRails
+creates an empty file when none exists and merges its own entries additively.
+It never replaces an existing valid user configuration or copies OAuth/API
+credentials into the repository.
+
+## Updating
+
+Update a Kimi installation explicitly:
+
+```bash
+npx specrails-core@latest update --root-dir . --provider kimi
+```
+
+Framework-owned `specrails-*` and `sr-*` skills are refreshed. These remain
+outside the cleanup boundary:
+
+- OpenSpec `openspec-*` skills
+- direct-child `custom-*` role skills
+- unknown user skill directories
+- existing MCP servers
+- agent memory and runtime state
+
+The managed `.kimi-code/specrails/run-skill.mjs` file is refreshed from the
+trusted Core package and recorded in the manifest. It is executable framework
+code, not a user-authored skill; keep custom helpers outside
+`.kimi-code/specrails/`. Its complete managed bundle includes the unmodified
+`js-yaml` ESM distribution, MIT `LICENSE`, and provenance `NOTICE.md` under
+`.kimi-code/specrails/vendor/js-yaml/`; this gives the helper complete YAML
+frontmatter parsing without using the project's `node_modules`.
+
+Pre-release SpecRails builds placed role skills below `skills/rails`, where
+Kimi cannot discover them. Update moves a legacy `custom-*` role to the direct
+level only when no same-named direct role exists, and recreates managed `sr-*`
+roles from the framework. A collision preserves both copies and is reported by
+`doctor` instead of guessing which user-authored role should win.
+
+## Troubleshooting
+
+### `kimi` is not found
+
+Open a new terminal after installation and check:
+
+```bash
+kimi --version
+```
+
+On Windows, also verify that the directory containing `kimi.cmd` is present in
+`PATH`.
+
+### Login or model configuration error
+
+Run:
+
+```bash
+kimi login
+kimi -p "Reply with OK" --output-format stream-json
+```
+
+The second command is a real model request and can consume quota; SpecRails
+does not run it automatically as a setup probe.
+
+### Model alias is not configured
+
+Complete managed login again, choose an alias configured in
+`~/.kimi-code/config.toml`, or pass one of the managed aliases such as
+`kimi-code/k3`.
+
+### Legacy `.kimi/skills` remains
+
+Run the Kimi-specific update command. SpecRails moves only recognized
+`openspec-*` output and removes the legacy directory only when it is empty.
+Unknown files are left for manual review.
+
+### Doctor reports a nested `skills/rails` layout
+
+Run the Kimi-specific update command first. If the diagnostic remains, compare
+the reported legacy `skills/rails/custom-*` role with its direct
+`skills/custom-*` counterpart, keep the intended version at the direct path,
+and remove the nested duplicate. Unknown nested directories are never deleted
+automatically.
+
+## Official Kimi references
+
+- [Kimi Code documentation](https://www.kimi.com/code/docs/en/)
+- [Getting started](https://www.kimi.com/code/docs/en/kimi-code-cli/guides/getting-started.html)
+- [Environment variables](https://www.kimi.com/code/docs/en/kimi-code-cli/configuration/env-vars.html)
+- [What is new](https://www.kimi.com/code/docs/en/kimi-code/whats-new.html)

--- a/docs/user-docs/installation.md
+++ b/docs/user-docs/installation.md
@@ -1,12 +1,8 @@
 # Installation
 
-Install SpecRails into any git repository in two steps: install, then run `/specrails:enrich` inside your AI CLI.
-
-> ## 🧪 Codex (OpenAI) Support — Coming Soon (in Lab)
->
-> OpenAI Codex integration is currently being **tested in our lab** and **cannot be installed yet**. The installer will refuse any attempt to install with `--provider codex` and will guide you to use Claude Code. Codex-specific sections below describe the **planned behaviour** for when the feature ships.
-
-SpecRails supports **Claude Code** today, with **OpenAI Codex** coming soon. The installer detects which CLI you have and configures accordingly. See [Codex vs Claude Code](codex-vs-claude-code.md) for a feature comparison of the upcoming Codex support.
+Install SpecRails into any git repository in two steps: install, then run the
+provider-native enrich workflow. The scaffold supports Claude Code, Codex CLI,
+Gemini CLI, and Kimi Code.
 
 > **Looking for the comprehensive reference?** See [Installation & Setup](../installation.md) for full wizard phase details and advanced configuration.
 
@@ -21,12 +17,12 @@ SpecRails supports **Claude Code** today, with **OpenAI Codex** coming soon. The
 
 No Node.js required.
 
-### Scaffold method (npx / Codex)
+### Scaffold method (npx / any provider)
 
 | Tool | Version | Notes |
 |------|---------|-------|
-| **Node.js** | 18+ | Required for the installer |
-| **Claude Code** or **Codex CLI** | Latest | See [Codex vs Claude Code](codex-vs-claude-code.md) |
+| **Node.js** | 20.19.0+ | Required for the installer and pinned OpenSpec 1.4.1 CLI |
+| **Supported AI CLI** | Latest compatible version | Claude Code, Codex, Gemini, or Kimi 0.27.0+ |
 | **Git** | Any | Your project must be a git repository |
 
 Optional but recommended (both methods):
@@ -47,7 +43,7 @@ No cloning, no npm, nothing else. The plugin is now ready in all your Claude Cod
 
 To update later: `claude plugin update sr`
 
-### Scaffold method (Claude Code or Codex)
+### Scaffold method (Claude, Codex, Gemini, or Kimi)
 
 Run from inside your project directory:
 
@@ -56,7 +52,8 @@ cd your-project
 npx specrails-core@latest init --root-dir .
 ```
 
-The installer copies templates and commands into `.claude/` (Claude Code) or `.codex/` (Codex). It does not modify your existing code.
+The installer copies provider-native artifacts into `.claude/`, `.codex/`,
+`.gemini/`, or `.kimi-code/`. It does not modify your application source.
 
 #### Flags
 
@@ -64,7 +61,7 @@ The installer copies templates and commands into `.claude/` (Claude Code) or `.c
 |------|--------|
 | `--root-dir <path>` | Target directory (default: current directory) |
 | `--yes` / `-y` | Skip confirmation prompts |
-| `--provider <claude\|codex>` | Force a specific AI CLI (default: auto-detect) |
+| `--provider <claude\|codex\|gemini\|kimi>` | Force a specific AI CLI (default: auto-detect) |
 
 #### What gets installed (scaffold method)
 
@@ -80,9 +77,35 @@ your-project/
     └── settings.json             # Permissions
 ```
 
+**Kimi Code:**
+
+```text
+your-project/
+└── .kimi-code/
+    ├── AGENTS.md
+    ├── mcp.json
+    ├── personas/
+    ├── rules/
+    ├── specrails/
+    │   ├── run-skill.mjs
+    │   └── vendor/js-yaml/       # Managed parser + MIT license/provenance
+    └── skills/
+        ├── specrails-*/SKILL.md
+        ├── openspec-*/SKILL.md
+        └── sr-*/SKILL.md
+```
+
+Kimi discovers only direct children of `.kimi-code/skills`, so workflows,
+OpenSpec skills, managed `sr-*` roles, and user `custom-*` roles all live at
+that level rather than inside a `rails/` grouping directory. Non-skill persona
+data and the managed headless runner live outside the scanner root.
+
+See [Getting Started with Kimi](getting-started-kimi.md) for installation,
+login, models, effort, sessions, and headless execution details.
+
 **Codex (beta):**
 
-```
+```text
 your-project/
 ├── AGENTS.md                     # SpecRails agent instructions for Codex
 └── .codex/
@@ -102,10 +125,22 @@ After either installation method, open your AI CLI in your project and run:
 claude    # Claude Code
 # or
 codex     # Codex
+# or
+gemini    # Gemini CLI
+# or
+kimi      # Kimi Code
 ```
+
+Claude and Gemini:
 
 ```
 /specrails:enrich
+```
+
+Kimi:
+
+```text
+/skill:specrails-enrich
 ```
 
 By default, `/specrails:enrich` runs the full 5-phase wizard:

--- a/docs/user-docs/quick-start.md
+++ b/docs/user-docs/quick-start.md
@@ -2,12 +2,10 @@
 
 Get SpecRails running in your project in under 10 minutes.
 
-> **🧪 Using OpenAI Codex? — Coming Soon (in Lab).** Codex support is currently being tested in our lab and is not yet available for installation. The installer will refuse Codex installs and guide you to Claude Code. See the [Codex getting started guide](getting-started-codex.md) for a preview of the planned setup.
-
 ## Before you begin
 
 You need:
-- **Claude Code** — install from [docs.anthropic.com/en/docs/claude-code](https://docs.anthropic.com/en/docs/claude-code)
+- **One supported AI CLI** — Claude Code, Codex CLI, Gemini CLI, or Kimi Code
 - **A git repository** — your project must have a `.git` directory
 
 Optional:
@@ -21,7 +19,7 @@ Optional:
 claude plugin install sr
 ```
 
-### Scaffold method (if you need Node.js / Codex)
+### Scaffold method (all providers; requires Node.js)
 
 ```bash
 npx specrails-core@latest init --root-dir .
@@ -31,17 +29,22 @@ Your existing code is not touched by either method.
 
 ## Step 2: Run the enrich wizard
 
-Open Claude Code in your project:
+Open the selected provider in your project. For example:
 
 ```bash
-claude
+kimi
 ```
 
-Then run:
+Then activate enrich using that provider's syntax:
 
 ```
-/specrails:enrich
+/specrails:enrich              # Claude or Gemini
+/skill:specrails-enrich        # Kimi interactive TUI
 ```
+
+Codex activates the generated enrich skill from `.codex/skills/`. For provider
+details and headless Kimi usage, see the [installation guide](installation.md)
+and [Kimi guide](getting-started-kimi.md).
 
 The wizard runs the full 5-phase setup (about 5 minutes). It analyzes your codebase and configures SpecRails for your specific project:
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -5,11 +5,35 @@ specrails-core runs natively on Windows 10 (1809+) and Windows 11, on both x64 a
 ## Requirements
 
 - **Windows 10 1809+** or **Windows 11** (x64 or ARM64)
-- **Node.js ≥ 20** — install from [nodejs.org](https://nodejs.org/)
+- **Node.js ≥ 20.19.0** — the minimum required by the pinned OpenSpec 1.4.1 CLI; install from [nodejs.org](https://nodejs.org/)
 - **git ≥ 2.25** — install from [git-scm.com](https://git-scm.com/)
-- **Claude Code** (`claude.cmd`) — install from [claude.ai/download](https://claude.ai/download)
+- One supported provider CLI: `claude.cmd`, `codex.cmd`, `gemini.cmd`, or
+  `kimi.cmd`
 
 `npm install -g @anthropic-ai/claude-code` installs the Claude CLI as `claude.cmd` into your global npm bin (`%APPDATA%\npm\`). Make sure that directory is on your PATH so `where claude` resolves it.
+
+For Kimi Code, use the official PowerShell installer:
+
+```powershell
+irm https://code.kimi.com/kimi-code/install.ps1 | iex
+kimi login
+```
+
+Then verify `where kimi` and `kimi --version`. SpecRails does not install or
+start Kimi Server. For headless skills, its managed Node runner resolves the
+external Kimi executable from `PATH`. A native executable is spawned directly.
+For a standard npm `kimi.cmd`/`kimi.bat` shim, the runner extracts Kimi's
+JavaScript entry point and launches it with Node using `shell: false`; it never
+passes user input through `cmd.exe`. A non-standard command shim fails closed.
+The vendored YAML parser is plain ESM and introduces no native dependency.
+
+Windows `CreateProcess` cannot carry SpecRails' largest materialized workflow
+as an argv value. For the standard npm shim, a fixed Node bootstrap therefore
+receives the full prompt over stdin, replaces only Core's fixed `-p` marker in
+`process.argv`, and imports Kimi's official entry. Kimi prompt mode does not
+need stdin after startup. The transported command line is capped at 30,000
+UTF-16 code units. Native executables cannot use this npm-entry bootstrap and
+fail with actionable guidance when their argv exceeds that budget.
 
 ## Install
 
@@ -22,7 +46,8 @@ npx specrails-core@latest init
 
 The installer:
 - probes PATH with `where` (instead of the POSIX `which`),
-- spawns `.cmd` shims (`claude.cmd`, `npm.cmd`, `gh.cmd`) with `shell: true` — required by Node.js since CVE-2024-27980,
+- spawns provider and package-manager `.cmd` shims with the repository's safe
+  Windows process wrapper,
 - writes all files with LF line endings regardless of `core.autocrlf` to keep the bundled templates portable.
 
 ## PowerShell execution policy
@@ -43,7 +68,7 @@ Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
 
 ## CI
 
-The specrails-core GitHub Actions workflow runs the vitest suite on `windows-latest` in a matrix with `ubuntu-latest` and `macos-latest`, on Node 20 and Node 22. Any PR that regresses Windows behaviour fails CI immediately.
+The specrails-core GitHub Actions workflow runs the vitest suite on `windows-latest` in a matrix with `ubuntu-latest` and `macos-latest`, on the exact Node 20.19.0 floor and Node 22. Any PR that regresses Windows behaviour fails CI immediately.
 
 ## Reporting Windows-specific bugs
 

--- a/integration-contract.json
+++ b/integration-contract.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "3.0",
+  "schemaVersion": "3.2",
   "providers": {
     "claude": {
       "enrichCommand": "/specrails:enrich",
@@ -22,6 +22,59 @@
         "enrichArgs": ["exec", "run enrich"],
         "enrichFromConfigArgs": ["exec", "run enrich --from-config"]
       }
+    },
+    "gemini": {
+      "enrichCommand": "/specrails:enrich",
+      "enrichArgs": ["--from-config"],
+      "updateCommand": "/specrails:enrich",
+      "updateArgs": ["--update"],
+      "cli": {
+        "initArgs": [],
+        "enrichArgs": ["-p", "/specrails:enrich", "--output-format", "stream-json"],
+        "enrichFromConfigArgs": ["-p", "/specrails:enrich --from-config", "--output-format", "stream-json"]
+      }
+    },
+    "kimi": {
+      "enrichCommand": "/skill:specrails-enrich",
+      "enrichArgs": ["--from-config"],
+      "updateCommand": "/skill:specrails-enrich",
+      "updateArgs": ["--update"],
+      "cli": {
+        "binary": "node",
+        "providerBinary": "kimi",
+        "skillRunner": ".kimi-code/specrails/run-skill.mjs",
+        "skillMaterialization": "kimi-0.27-user-slash-prompt",
+        "nestedSkillInvocation": "Kimi built-in Skill tool with { skill, args }; never literal /skill text",
+        "modelIdPattern": "^[A-Za-z0-9][A-Za-z0-9._/:-]{0,127}$",
+        "sessionIdPattern": "^(?!\\.{1,2}$)[A-Za-z0-9._-]{1,128}$",
+        "roleWave": {
+          "path": ".specrails/kimi-role-wave.json",
+          "schema": "{ run: safe-id, roles: Array<{ key: safe-id, skill: direct-child-id, model: safe-model-id, profile: \"inherit\" | safe-id, args: string, workspace: \"current\" | \"worktree:<safe-id>\" }> } with no extra keys",
+          "maxBytes": 1048576,
+          "maxRoles": 32,
+          "transport": "structured WriteFile followed by one static foreground --role-wave-file command; the one-shot file is deleted before setup and every role is awaited. Inspection, merge, and cleanup use the separate static --role-wave-status, --role-merge-file, and --role-wave-cleanup modes",
+          "workspaces": "current roles receive unique execution directories with SPECRAILS_REPO_DIR set to the target repository; isolated roles create/reuse detached git worktrees from a synthetic baseline that includes the starting tracked/untracked overlay but excludes provider/runtime control files, with SPECRAILS_REPO_DIR set to that worktree",
+          "manifest": ".specrails/kimi-role-worktrees/<run>.json records the immutable synthetic base commit, source head, worktree ids, and role key to execution/repository paths",
+          "status": "--role-wave-status <run> validates the persisted manifest/ref/worktrees and emits one specrails.merge.inventory frame before any downstream merge",
+          "merge": ".specrails/kimi-role-merge.json is the only accepted merge request path; { run, actions: Array<{ worktree: safe-id, path: safe-relative-path, operation: \"copy\" | \"delete\" }> } applies an explicit A/M/D inventory through --role-merge-file without attributing the starting overlay or provider control files",
+          "cleanup": "--role-wave-cleanup <run> removes owned worktrees, temporary execution roots, persisted manifest, and synthetic baseline ref, then emits specrails.role.cleanup",
+          "output": "newline-delimited attributed specrails.role.workspace, specrails.role.event/output, specrails.role.completed, specrails.merge.inventory, specrails.merge.applied, and specrails.role.cleanup frames; aggregate role-wave exit is nonzero when any role fails"
+        },
+        "stableEngineEnv": {
+          "KIMI_CODE_EXPERIMENTAL_FLAG": null,
+          "KIMI_DISABLE_CRON": "1",
+          "KIMI_CODE_NO_AUTO_UPDATE": "1",
+          "KIMI_MODEL_THINKING_EFFORT": "low|high|max only for kimi-code/k3; omitted K3 effort preserves Kimi's documented high default; unset for every other model"
+        },
+        "windowsPromptTransport": "For the standard npm kimi.cmd/bat shim, prompt bytes travel over stdin to a fixed Node bootstrap which restores process.argv before importing Kimi; native executables fail above a 30000 UTF-16 command-line budget.",
+        "initialActivationTelemetry": "Visible prompt parity only; the external materializer cannot emit Kimi-private skill.activated/origin telemetry.",
+        "cancellation": "Single-skill mode forwards SIGINT/SIGTERM/SIGHUP to its direct Kimi child. Role-wave mode forwards each termination signal to every live Kimi child and waits for aggregate completion; the embedding host remains responsible for platform process-tree teardown.",
+        "initArgs": [],
+        "enrichArgs": [".kimi-code/specrails/run-skill.mjs", "--skill", "specrails-enrich", "--model", "k3"],
+        "enrichFromConfigArgs": [".kimi-code/specrails/run-skill.mjs", "--skill", "specrails-enrich", "--model", "k3", "--args", "--from-config"],
+        "resumeArgs": ["--session=<session-id>"],
+        "notes": "CLI-only integration. enrichCommand/updateCommand are interactive Kimi TUI syntax only. Headless callers must execute binary + enrichArgs; plain `kimi -p \"/skill:...\"` is literal prompt text in Kimi 0.27 and does not activate a skill. The managed Node runner materializes the upstream user-slash prompt, then launches external Kimi with stream-json and no shell. Generated multi-role workflows use one bounded role-wave file so context never enters shell source and parallel roles cannot race on request paths. Do not start kimi web/server; authenticate once with `kimi login`."
+      }
     }
   },
   "tiers": {
@@ -43,13 +96,13 @@
     "version": 1,
     "fields": {
       "version": "number — schema version, currently 1",
-      "provider": "string — claude | codex | gemini | auto",
+      "provider": "string — claude | codex | gemini | kimi",
       "tier": "string — full | quick",
-      "agents.selected": "string[] — agent names to install",
-      "agents.excluded": "string[] — agent names to skip",
-      "models.preset": "string — balanced | budget | max",
-      "models.defaults.model": "string — sonnet | opus | haiku (overrides preset)",
-      "models.overrides": "Record<string, string> — per-agent model (highest priority)"
+      "agents.selected": "string[] — unique lowercase kebab-case agent ids to install (1-64 characters)",
+      "agents.excluded": "string[] — unique lowercase kebab-case agent ids to skip; must not overlap agents.selected",
+      "models.preset": "string — balanced | budget | max; resolved within the selected provider catalog",
+      "models.defaults.model": "string — exact provider model id or configured alias (overrides preset; Kimi: 1-128 characters matching [A-Za-z0-9][A-Za-z0-9._/:-]*; default: k3)",
+      "models.overrides": "Record<safe-agent-id, string> — exact per-agent provider model ids or configured aliases with the same provider-specific validation (highest priority)"
     }
   },
   "checkpoints": {
@@ -63,19 +116,38 @@
   },
   "modelPresets": {
     "balanced": {
-      "description": "Flagship models for architects and PMs, efficient models for others",
+      "scope": "claude",
+      "description": "Legacy Claude preset view retained for existing consumers. Other providers resolve this preset through providerModelCatalogs.",
       "defaults": { "model": "sonnet" },
-      "overrides": { "sr-architect": "opus", "sr-product-manager": "opus" }
+      "overrides": {}
     },
     "budget": {
-      "description": "All agents use the most cost-efficient model",
+      "scope": "claude",
+      "description": "Legacy Claude preset view retained for existing consumers. Other providers resolve this preset through providerModelCatalogs.",
       "defaults": { "model": "haiku" },
       "overrides": {}
     },
     "max": {
-      "description": "All agents use the most capable model",
-      "defaults": { "model": "opus" },
-      "overrides": {}
+      "scope": "claude",
+      "description": "Legacy Claude preset view retained for existing consumers. Other providers resolve this preset through providerModelCatalogs.",
+      "defaults": { "model": "sonnet" },
+      "overrides": { "sr-architect": "opus", "sr-product-manager": "opus" }
+    }
+  },
+  "providerModelCatalogs": {
+    "kimi": {
+      "default": "k3",
+      "models": ["k3", "kimi-for-coding", "kimi-for-coding-highspeed"],
+      "presets": {
+        "balanced": { "defaults": { "model": "k3" }, "overrides": {} },
+        "budget": { "defaults": { "model": "k3" }, "overrides": {} },
+        "max": { "defaults": { "model": "k3" }, "overrides": {} }
+      },
+      "cliAliasPrefix": "kimi-code/",
+      "reasoningEfforts": {
+        "k3": ["low", "high", "max"]
+      },
+      "note": "Install config and profiles retain exact ids or safe custom aliases. Preset names do not imply Claude aliases for Kimi. Process launch prefixes only the three documented official short ids with kimi-code/; every custom alias that matches the published model grammar passes through unchanged."
     }
   },
   "legacyCompat": {

--- a/openspec/changes/add-kimi-provider/.openspec.yaml
+++ b/openspec/changes/add-kimi-provider/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-19

--- a/openspec/changes/add-kimi-provider/design.md
+++ b/openspec/changes/add-kimi-provider/design.md
@@ -1,0 +1,318 @@
+## Context
+
+Core currently treats providers as a closed union duplicated across installer modules and renders from Claude-authored canonical templates into provider-specific trees. Claude receives commands, agents, skills, rules, and memory; Codex and Gemini use dedicated render paths. Kimi Code 0.27 provides an agentic CLI with headless prompt mode, JSONL output, project `AGENTS.md`, direct-child project skills, MCP, sessions, model selection, and file/shell tools.
+
+The requested integration must work in standalone and Desktop-relocated installs, coexist with other providers, and remain usable without a daemon. Published OpenSpec releases currently place Kimi skills under legacy `.kimi/skills`, while the current Kimi runtime scans `.kimi-code/skills`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `kimi` a fully validated Core provider with explicit detection, version, auth guidance, paths, scaffold, update, doctor, and framework behavior.
+- Render every applicable SpecRails workflow and selected rail role as a valid Kimi skill.
+- Preserve the observable architect/developer/reviewer, profile, batch, retry, worktree, memory, and OpenSpec behavior.
+- Define a deterministic headless invocation contract that Desktop and scripts can consume.
+- Preserve existing Claude, Codex, and Gemini output byte-for-byte except where generic provider lists must include Kimi.
+- Work on macOS and Linux with native or npm-installed `kimi`; on Windows,
+  support short native-executable prompts and require the standard npm shim
+  for complete SpecRails workflows that exceed `CreateProcess`'s argv limit.
+
+**Non-Goals:**
+
+- Bundling or installing Kimi Code.
+- Starting `kimi server`, registering an OS service, or implementing ACP.
+- Reporting a fabricated USD cost.
+- Depending on undocumented custom Kimi subagent profile files.
+- Translating Claude model aliases silently into Kimi models.
+
+## Decisions
+
+### Materialize the initial skill before `kimi -p`
+
+Kimi 0.27 does not interpret arbitrary slash commands in print mode:
+`run-prompt.ts` forwards the `-p` value to `session.prompt()`, while TUI and ACP
+clients explicitly call `activateSkill`. Therefore
+`kimi -p "/skill:<name> ..."` is ordinary user text, not skill activation.
+
+Core installs a self-contained
+`.kimi-code/specrails/run-skill.mjs` helper. It validates a canonical
+direct-child skill id, loads `.kimi-code/skills/<id>/SKILL.md`, parses full YAML
+frontmatter through a vendored `js-yaml` ESM distribution, applies Kimi 0.27's
+argument tokenizer and placeholder order, and renders the exact
+`renderUserSlashSkillPrompt` envelope. Only then does it spawn external
+`kimi -m <model> -p <materialized-prompt> --output-format stream-json` with an
+argv array and `shell: false`.
+
+For valid generated skills the helper canonicalizes the skill directory with
+`realpath`, matching Kimi's scanner for ordinary and relocated/symlinked
+installations. That canonical path is used in both `${KIMI_SKILL_DIR}` and the
+activation wrapper. The helper deliberately fails closed on an empty body or a
+frontmatter name that differs from its direct-child directory. Upstream may
+load those malformed shapes, but SpecRails never generates them and treating
+them as install corruption is an explicit hardening, not claimed
+malformed-input parity. A present `type` still follows upstream validation and
+must be a non-empty supported string.
+
+The runner and its vendored parser, MIT license, and provenance notice are one
+managed static subtree. This avoids relying on the target project's
+`node_modules`, works in relocated installs, and remains daemon-free.
+
+Plain-prompt invocations use the same managed helper with
+`--plain-prompt-stdin`: Core sends one non-empty prompt of at most 1 MiB over
+stdin, so the prompt does not cross the host-to-helper argv boundary. The
+helper then passes that exact string as Kimi's native `-p` value. This second
+boundary is deliberately explicit: Kimi 0.27 exposes no documented
+stdin/file-prompt equivalent, so native Kimi processes necessarily expose the
+prompt in their own OS argv. Replacing the prompt with a file-reading envelope
+was rejected because it changes the first user turn, requires an additional
+tool call, and changes telemetry and failure semantics. The official Windows
+npm shim remains the qualified exception: its fixed Node bootstrap can
+reconstruct the exact `-p` value from stdin inside the child process.
+
+Alternative considered: Kimi Server. Rejected for this change because Core is an installer/framework package, not a long-lived process supervisor.
+
+### Render Kimi-native skills rather than Claude command files
+
+Kimi artifacts live under `.kimi-code/`. Its loader enumerates only immediate
+children of `.kimi-code/skills`, so every invocable directory uses a disjoint
+flat namespace: `specrails-*` workflows, `openspec-*` OpenSpec workflows,
+`sr-*` managed roles, and `custom-*` user roles. Workflow commands become
+directory-form skills with valid `name` and `description` frontmatter. Agent
+definitions become rail-role skills, while non-invocable persona data lives
+outside the scanner at `.kimi-code/personas/`. Claude
+`Skill("opsx:<id>")` references are translated to calls to Kimi's built-in
+`Skill` tool with the mapped `openspec-*` name and raw `args`. Internal
+`/specrails:*` references are likewise rendered as native `Skill` tool
+instructions, never as slash text. Interactive `/skill:*` examples remain only
+in `AGENTS.md` and user documentation. Provider-specific paths and tool
+terminology are removed or mapped to `.specrails`/`.kimi-code`.
+
+Generated workflow and role skills retain semantic `KIMI_RUNTIME_*`,
+`KIMI_BACKLOG_*`, and `KIMI_PR_CREATE` markers instead of silently erasing
+Claude-time placeholders. At activation time their instructions resolve
+project, persona, architecture, CI, backlog, and pull-request context from
+`.kimi-code/project-context.md`, `.kimi-code/personas/*.md`, and
+`.specrails/backlog-config.json`. These identifiers are declarative markers,
+never executable command names, and backlog access fails closed to read-only
+behavior when configuration is absent or invalid.
+
+The pre-release renderer placed roles under `skills/rails`, which Kimi never
+discovers. Init/update removes nested managed `sr-*` copies and regenerates
+them as direct children. A nested `custom-*` role is atomically renamed to the
+direct level only when that target is absent. If a same-named direct role
+already exists, both copies remain byte-untouched and doctor requires manual
+resolution. Unknown nested directories are also preserved and diagnosed.
+
+### Keep orchestration provider-owned but role execution process-addressable
+
+The Kimi implement/batch/retry skills retain the same lifecycle and receipts as
+the other provider ports. Kimi's built-in Agent/AgentSwarm may be used for
+homogeneous subtasks, but SpecRails role identity and model choice are
+represented by a role skill and a separate top-level helper-launched Kimi
+process. This avoids relying on child-agent model overrides that Kimi does not
+expose. Once a role session is running, nested workflow activation uses Kimi's
+native `Skill` tool so native behavior and private `skill.activated` telemetry
+remain available for those nested calls.
+
+Role instructions never interpolate model or context into a shell command.
+For each single or parallel launch they write one bounded wave through Kimi's
+structured WriteFile tool to the fixed
+`.specrails/kimi-role-wave.json` path. Its exact schema is
+`{run, roles:[{key, skill, model, profile, args, workspace}]}`; `profile` is
+`inherit` or a validated profile filename stem, and `run`, `key`, profile, and
+the optional `worktree:<id>` suffix use a lowercase 1–64 character safe grammar.
+The orchestrator then executes one static foreground
+`run-skill.mjs --role-wave-file ...` command. The helper accepts only that
+regular, non-symlink path, bounds it to 1 MiB and 32 roles, rejects extra keys,
+validates all identifiers, and deletes the one-shot file before setup. One
+helper owns and awaits the complete concurrent wave, eliminating the
+WriteFile→spawn race even for roles that target the same repository.
+
+`workspace: current` gives each role a private execution directory with a
+managed `.kimi-code` overlay while setting the child's `SPECRAILS_REPO_DIR` to
+the target repository. This separates nested request paths and run-state
+without redirecting source edits. `workspace: worktree:<id>` creates or reuses
+a detached git worktree using argv arrays and `shell: false`. At the first
+isolated wave, a temporary index snapshots starting tracked and non-ignored
+untracked files into a private synthetic commit, excluding `.kimi-code` and
+SpecRails run-state without changing the user's HEAD, branch, or index. It sets both
+the Kimi cwd and `SPECRAILS_REPO_DIR` to that worktree. Sequential developer,
+test, and documentation roles reuse the same id; concurrent entries may not
+share it.
+
+The helper atomically persists source HEAD, immutable synthetic base commit,
+worktree id→path,
+and role key→execution/repository mapping at
+`.specrails/kimi-role-worktrees/<run>.json`. Generated Kimi merge instructions
+consume `--role-wave-status` A/M/D inventories and apply exclusive copy/delete
+actions through a fixed, schema-validated merge request, never shell filename
+interpolation. A setup failure removes worktrees created by that failed setup.
+A role failure leaves valid worktrees and the manifest for retry; pipeline state
+persists and reuses the exact run/workspace mapping. After successful merge,
+`--role-wave-cleanup` removes registered worktrees, execution state, manifest,
+git excludes, and the private synthetic ref.
+
+Every status, merge, reuse, and cleanup operation treats the persisted manifest
+as untrusted input. The helper recomputes each permitted canonical worktree,
+execution, and git-exclude path from the canonical base repository,
+repository key, run id, role key, and worktree id; verifies every worktree is
+still registered to that repository; checks each workspace mapping and the
+exclude file's exact managed contents; and requires the private synthetic ref
+to resolve to the manifest's immutable base commit. Absolute paths supplied by
+the manifest are never accepted merely because they exist.
+
+When a platform cannot use the preferred linked provider overlay and must copy
+it, an ownership marker alone is insufficient. The helper records and
+revalidates a deterministic SHA-256 over the complete provider tree, including
+relative paths, entry types, executable bits, and file bytes. A validly owned
+but stale or corrupted copy is rebuilt; unmarked or invalidly marked
+directories remain user-owned and fail closed. Symlinks and special files are
+never admitted into either the managed source tree or its copy.
+
+Concurrent child JSONL streams are never inherited into one ambiguous stdout.
+The helper captures each child's stdout/stderr, emits attributed
+`specrails.role.*` frames, waits for every child, and returns nonzero if any
+required role fails. SIGINT/SIGTERM/SIGHUP are forwarded once to every live
+child. Current-repository execution directories also make a nested workflow's
+fixed wave path unique per parent role; isolated roles naturally use their
+distinct worktree paths. There is still no server or daemon.
+
+The initial helper-materialized activation reproduces the complete visible
+user prompt but cannot manufacture Kimi's internal `skill.activated` telemetry
+or activation-origin metadata: those are emitted inside the private
+`activateSkill` path, before `session.prompt`. This is an explicit telemetry
+limitation, not a claim of private-internal parity.
+
+### Validate every spawn-boundary identifier
+
+Role ids are lowercase direct-child identifiers. Model ids and configured
+aliases must be 1–128 characters and match
+`^[A-Za-z0-9][A-Za-z0-9._/:-]*$`; leading dashes, whitespace, controls, shell
+metacharacters, and oversized values fail before spawn. Only `k3`,
+`kimi-for-coding`, and `kimi-for-coding-highspeed` gain the documented
+`kimi-code/` prefix. Other safe aliases, such as
+`company/Kimi-Custom:v2`, remain byte-identical.
+
+The Kimi branch of profile schema validation applies that same 128-character
+model grammar before a workflow can render a role wave; provider-generic
+model ids remain unchanged for Codex and Gemini.
+
+On Windows, the helper launches a native Kimi executable directly. For the
+standard npm `.cmd`/`.bat` shim it extracts the JavaScript entry and launches
+that entry with Node, still with `shell: false`; a non-standard shim fails
+closed rather than sending user-controlled values through `cmd.exe`.
+
+The largest complete workflows exceed Windows `CreateProcess`'s command-line
+limit when placed directly after `-p`. For the official npm shim, a fixed,
+user-input-free Node `-e` bootstrap reads the materialized UTF-8 prompt from
+stdin, replaces Core's fixed marker in `process.argv`, and imports Kimi's
+official ESM entry. Kimi then observes the original full `-p` value without the
+prompt ever crossing the OS argv boundary. The transported command line is
+limited to 30,000 UTF-16 code units. A native executable is direct-spawned only
+under that budget and otherwise fails with npm-shim remediation.
+
+Known session ids are passed to Kimi as one `--session=<id>` argv element.
+This keeps even option-like values bound to the session option instead of
+allowing Commander to reinterpret them as new flags. The Windows bootstrap
+locates the fixed marker only as the value immediately following `-p`.
+
+The qualified execution contract targets Kimi 0.27's stable v1 engine. The
+runtime overlay explicitly unsets `KIMI_CODE_EXPERIMENTAL_FLAG`, and the helper
+also removes that key case-insensitively from its child environment. Unknown
+experimental CLI flags fail argument parsing rather than selecting an
+unverified engine with different policy or stream semantics.
+
+Every managed child forces `KIMI_DISABLE_CRON=1` because SpecRails owns one
+bounded invocation and has no scheduler lifecycle/UI for persistent CronCreate
+work. It also forces `KIMI_CODE_NO_AUTO_UPDATE=1` so a job cannot mutate its
+external CLI/version during startup. Both keys override inherited casing and
+values. Print mode's normal foreground task drain/steer semantics remain
+unchanged.
+
+The helper forwards `SIGINT`, `SIGTERM`, and `SIGHUP` to its direct Kimi child
+and removes listeners after exit. An embedding host such as Desktop still owns
+platform-specific process-tree teardown; Core does not claim that forwarding a
+signal to one PID replaces the host's tree-kill policy.
+
+`KIMI_MODEL_THINKING_EFFORT` is equally model-scoped. Core's invocation overlay
+unsets inherited effort unless the caller explicitly supplies `low`, `high`,
+or `max` for K3. The standalone helper preserves an inherited valid value only
+when the normalized model is `kimi-code/k3`; non-K3 and invalid values are
+removed before spawn. With no explicit value, Kimi retains its documented K3
+default of `high`; SpecRails never changes that default to `low`.
+
+### Normalize OpenSpec output in staging
+
+Core will invoke the pinned OpenSpec tool target and then normalize any
+generated `.kimi/skills/openspec-*` directories into `.kimi-code/skills`. The
+normalizer validates the complete source tree with `lstat` and canonical
+containment checks, accepts only real directories and regular files, rejects
+symlinks and special entries (including a symlinked artifact root or
+`SKILL.md`), and copies through an unpredictable same-filesystem staging
+directory. Replacement and rollback use unpredictable sibling backup paths,
+so pre-existing user directories with old predictable names are untouched.
+The copy is additive and atomic, removes only the generated legacy Kimi
+directory after success, and never moves user-authored content.
+
+### Use explicit Kimi branches and fail closed
+
+No unknown provider may fall through to Claude. Kimi gets explicit path, scaffold, settings, memory, manifest, and linked-subtree behavior. Provider lists, validation, help, and tests are updated together.
+
+### Keep profile schema backward compatible
+
+The existing v1 schema remains valid for Claude. It is extended in a
+backward-compatible manner with an optional provider and exact provider model
+identifiers, while preserving the baseline-role and routing rules. Kimi adds
+the same safe 128-character grammar enforced at spawn. Its defaults are
+explicit (`k3`), and role model selection is never inferred from
+`sonnet`/`opus`/`haiku`.
+
+## Risks / Trade-offs
+
+- **Kimi JSONL lacks Claude's terminal result envelope** → Expose a session ID
+  only from a valid, non-empty `session.resume_hint` in the terminal JSONL
+  record and only when the child exits successfully; earlier, malformed, or
+  failed-process hints are not resumable.
+- **A first-turn cancellation can occur before the session ID is emitted** → Treat cancellation as terminal and do not promise resume for that edge case.
+- **`${KIMI_SESSION_ID}` is not known before the first prompt** → Reject a
+  fresh helper invocation of a skill using that placeholder; allow it only
+  after a known `session.resume_hint` is passed with `--session`.
+- **Published OpenSpec Kimi layout is stale** → Normalize only generated `openspec-*` skills and cover both legacy and corrected upstream layouts.
+- **Pre-release SpecRails role layout is undiscoverable** → Rematerialize even
+  same-version Kimi frameworks that contain `skills/rails`; safely migrate
+  custom roles, regenerate managed roles, and diagnose collisions or unknown
+  nested content without deleting it.
+- **Claude-authored workflow prose may leak provider syntax** → Add inventory
+  tests rejecting `.claude`, `/specrails:`, `/skill:`, `subagent_type`, and
+  `Skill("opsx:` in generated Kimi skill bodies, while requiring native
+  `Skill(skill=..., args=...)` instructions for nested activation.
+- **Prompt materialization cannot emit private activation telemetry** → State
+  the limitation explicitly; do not synthesize `skill.activated`. Nested
+  in-session activations continue through Kimi's native `Skill` tool.
+- **Complete prompts can exceed Windows argv limits** → Preserve the full
+  workflow and use stdin only as transport into the official npm JavaScript
+  entry; never compact away phases or send prompt content through a shell.
+- **Native Kimi exposes the exact prompt in its process argv** → Document this
+  upstream CLI limitation honestly. Core protects the host-to-helper boundary,
+  but does not substitute a file/tool envelope that would alter the user turn;
+  sensitive secrets should not be placed in prompts.
+- **Persisted role state and copied overlays are locally editable** → Recompute
+  exact managed paths, worktree registration, exclude contents, and private-ref
+  identity before any stateful operation, and hash the complete copied
+  provider tree before reuse.
+- **Provider additions can regress existing installations** → Snapshot all providers and run standalone, relocated, framework, update, and multi-provider tests.
+- **Kimi evolves rapidly while pre-1** → Set a minimum tested version and keep parsing tolerant of unknown JSONL event types.
+
+## Migration Plan
+
+1. Release Core with Kimi scaffold/runtime contract but no automatic selection preference over existing providers.
+2. Existing projects opt in with `--provider kimi` or a Kimi install config.
+3. Update materializes `.kimi-code` alongside existing provider trees,
+   preserves user-owned skills/MCP, and migrates undiscoverable nested Kimi
+   roles to direct skill children when conflict-free.
+4. Desktop consumes the new Core version before exposing Kimi.
+5. Rollback removes only SpecRails-managed Kimi artifacts; other providers and user Kimi configuration remain intact.
+
+## Open Questions
+
+- Live Kimi contract fixtures cannot be captured in this environment unless a Kimi account/CLI is available; fixture schemas will therefore be derived from the official 0.27 contract and clearly versioned.

--- a/openspec/changes/add-kimi-provider/proposal.md
+++ b/openspec/changes/add-kimi-provider/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+SpecRails Core supports Claude Code, Codex, and Gemini CLI, but cannot install or run its complete workflow with Kimi Code even though Kimi provides a headless agentic CLI, project skills, MCP, sessions, and model selection. Adding Kimi as a first-class provider gives users another independent coding runtime without requiring Claude Code or a bundled daemon.
+
+## What Changes
+
+- Add `kimi` to provider detection, explicit selection, configuration validation, prerequisite reporting, and provider-aware diagnostics.
+- Target the current TypeScript Kimi Code CLI and execute unattended work
+  through a Core-managed, self-contained skill materializer which safely
+  launches external `kimi -p --output-format stream-json`.
+- Generate Kimi-native project artifacts under `.kimi-code/`, including `AGENTS.md`, SpecRails workflow skills, direct-child rail-role skills, rules, memory/state directories, and MCP-compatible layout.
+- Expose `/skill:<name>` only as interactive Kimi TUI syntax. Materialize the
+  initial skill for headless prompt mode, where slash text is otherwise
+  literal, and translate nested SpecRails/OpenSpec invocations to Kimi's native
+  `Skill` tool with explicit `skill` and `args` fields.
+- Compensate for Kimi subagents inheriting their parent model by allowing SpecRails-managed role invocations to select a Kimi model per headless process.
+- Make init, update, framework materialization, relocated workspaces, manifests, reserved paths, and cleanup aware of Kimi without changing other provider trees.
+- Install and manage `.kimi-code/specrails/run-skill.mjs` together with a
+  vendored `js-yaml` ESM distribution, license, and provenance notice so the
+  helper never depends on the consumer project's `node_modules`.
+- Safely migrate the pre-release nested `.kimi-code/skills/rails` role layout,
+  preserving user-authored custom roles and surfacing collisions instead of
+  overwriting either copy.
+- Normalize the current published OpenSpec Kimi output from legacy `.kimi/skills` into `.kimi-code/skills` until the corrected upstream layout is released.
+- Preserve a CLI-only integration: Core neither bundles Kimi nor installs or supervises `kimi server`.
+
+## Capabilities
+
+### New Capabilities
+
+- `kimi-provider`: First-class installation, rendering, headless execution contract, update behavior, and diagnostics for Kimi Code CLI.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Installer provider types, detection, authentication, configuration, scaffold, framework, update, doctor, manifests, paths, and tests.
+- New Kimi templates and generated `.kimi-code` artifacts.
+- OpenSpec initialization/post-processing for the Kimi tool target.
+- Profile/model validation and role invocation semantics.
+- Documentation, CLI help, integration contract, and cross-platform prerequisite guidance.

--- a/openspec/changes/add-kimi-provider/specs/kimi-provider/spec.md
+++ b/openspec/changes/add-kimi-provider/specs/kimi-provider/spec.md
@@ -1,0 +1,326 @@
+## ADDED Requirements
+
+### Requirement: Kimi provider selection and detection
+Core SHALL accept `kimi` anywhere an AI provider can be selected, detect the `kimi` executable cross-platform, retain the historical provider auto-selection priority, and never fall through to Claude rendering for Kimi.
+
+#### Scenario: Explicit Kimi selection
+- **WHEN** a user runs init with `--provider kimi`
+- **THEN** Core selects Kimi even when another provider executable is installed
+
+#### Scenario: Kimi-only environment
+- **WHEN** Kimi is the only supported provider executable detected
+- **THEN** Core selects Kimi and reports it in prerequisites
+
+#### Scenario: Multiple provider environment
+- **WHEN** Claude and Kimi are both installed and no provider is explicit
+- **THEN** Core preserves the historical Claude-first default
+
+### Requirement: Kimi prerequisites and authentication guidance
+Core SHALL report Kimi installation, version, and authentication status using bounded non-interactive probes and SHALL provide official installation and `kimi login` guidance without reading or copying credential secrets.
+
+#### Scenario: Missing Kimi executable
+- **WHEN** Kimi is explicitly selected but `kimi` is not executable
+- **THEN** init fails with an actionable official installation hint
+
+#### Scenario: Kimi authentication unavailable
+- **WHEN** Kimi is installed but its non-interactive auth probe reports that login is required
+- **THEN** init fails with a `kimi login` instruction unless prerequisite checks were explicitly skipped
+
+### Requirement: Kimi-native project layout
+Core SHALL render managed Kimi artifacts under `.kimi-code` using valid Kimi
+`AGENTS.md`, skill, MCP, state, and memory conventions and SHALL not generate
+Claude command or agent files inside that tree. Every invocable workflow and
+role SHALL be an immediate child of `.kimi-code/skills`, using disjoint
+`specrails-*`, `openspec-*`, `sr-*`, and `custom-*` namespaces, because Kimi's
+loader does not recurse into grouping directories.
+
+#### Scenario: Standalone Kimi scaffold
+- **WHEN** a project is initialized for Kimi
+- **THEN** `.kimi-code/AGENTS.md` and all selected SpecRails workflow and rail-role `SKILL.md` files exist
+
+#### Scenario: Skill validity
+- **WHEN** a generated Kimi directory-form skill is inspected
+- **THEN** its frontmatter contains non-empty `name` and `description`, nested
+  workflows use Kimi's built-in `Skill` tool with explicit `skill` and `args`
+  fields, and its body does not depend on interactive slash interception
+
+#### Scenario: Direct-child role discovery
+- **WHEN** selected managed or custom role skills are rendered
+- **THEN** each role exists at `.kimi-code/skills/<sr-*|custom-*>/SKILL.md` and no managed role depends on a nested `skills/rails` directory
+
+### Requirement: Complete workflow availability
+Core SHALL make every SpecRails workflow available to Kimi that is available to the selected installation tier for Claude, including implement, batch, retry, diagnostics, analysis commands, and selected custom roles.
+
+#### Scenario: Full-tier inventory
+- **WHEN** a full Kimi installation completes
+- **THEN** its managed skill inventory represents the same applicable workflow catalog and selected role catalog as a full Claude installation
+
+#### Scenario: Quick-tier inventory
+- **WHEN** a quick Kimi installation completes
+- **THEN** tier exclusions match the provider-neutral quick-tier rules rather than a Kimi-specific reduced catalog
+
+### Requirement: Kimi headless invocation contract
+Core SHALL install and test a self-contained managed Node helper which
+materializes Kimi 0.27's visible user-slash skill prompt before launching
+external Kimi in prompt mode with an explicit validated model and stream JSON
+output. `/skill:<name>` SHALL be documented as interactive TUI syntax only and
+SHALL NOT be passed as literal headless prompt text.
+
+#### Scenario: New headless invocation
+- **WHEN** a caller launches a Kimi workflow
+- **THEN** it executes `node .kimi-code/specrails/run-skill.mjs` with the skill,
+  model, and raw arguments, and the helper launches Kimi with `-p`,
+  `--output-format stream-json`, and the selected model without a shell
+
+#### Scenario: Exact plain-prompt transport
+- **WHEN** a provider host launches a plain Kimi turn through Core
+- **THEN** the host sends at most 1 MiB of non-empty UTF-8 prompt text to the
+  managed helper over stdin instead of host argv
+- **AND** the helper passes the exact turn to Kimi's native `-p` boundary,
+  documenting that native Kimi exposes it in its own process argv; it SHALL NOT
+  replace the turn with a prompt-file/read-tool envelope
+
+#### Scenario: Shell-free role wave
+- **WHEN** a generated workflow launches one role or a parallel role group
+  with arbitrary context
+- **THEN** it writes one exact `{run, roles[]}` object through the structured
+  WriteFile tool to `.specrails/kimi-role-wave.json` and runs one static
+  foreground helper command
+- **AND** each role entry contains exactly `key`, `skill`, `model`, `profile`,
+  `args`, and `workspace`, with `profile` set to `inherit` or a safe profile
+  stem and a safe `current` or `worktree:<id>` workspace
+- **AND** the helper rejects alternate paths, symlinks, extra keys, duplicate
+  ids/worktrees, unsafe identifiers, more than 32 roles, and files above
+  1 MiB, deletes the one-shot wave before setup, and never evaluates request
+  content as shell source
+
+#### Scenario: Parallel role isolation and aggregation
+- **WHEN** a role wave contains parallel current-repository and/or isolated
+  roles
+- **THEN** current roles receive unique execution directories and isolated
+  roles receive distinct reusable git worktrees created without a shell
+- **AND** every child receives `SPECRAILS_REPO_DIR` for its actual source
+  target, output is framed with the role key, all roles are awaited, and the
+  helper exits nonzero if any role fails
+
+#### Scenario: Worktree lifecycle
+- **WHEN** the first role for `worktree:<id>` is launched
+- **THEN** the helper creates a private synthetic commit from a temporary index
+  that snapshots dirty tracked and non-ignored untracked inputs while excluding
+  provider/run-state, exposes the managed Kimi artifacts, and
+  atomically persists the base/path mapping
+- **AND** later waves with the same run and worktree id reuse that path for
+  test/documentation roles and merge uses the recorded base commit
+- **AND** setup failures remove partial worktrees while role failures preserve
+  valid worktrees for retry and workflow-owned cleanup
+
+#### Scenario: Complete merge and retry lifecycle
+- **WHEN** an isolated role wave completes or a later phase is retried
+- **THEN** status emits complete committed/staged/unstaged/untracked A/M/D
+  inventories, structured merge actions apply safe copy/delete operations
+  without shell filename interpolation, and retry reuses the persisted run and
+  worktree mapping
+- **AND** successful cleanup removes worktrees, execution state, manifest, git
+  excludes, and the private synthetic ref, while failed/unmerged state remains
+
+#### Scenario: Tamper-resistant persisted wave
+- **WHEN** status, merge, retry, or cleanup reads a role-wave manifest
+- **THEN** Core recomputes every worktree, execution, and git-exclude path from
+  the canonical repository hash plus run/role/worktree ids and rejects any
+  different path, even if it names another registered worktree
+- **AND** the private baseline ref must still resolve to the exact recorded
+  base commit before any worktree operation
+
+#### Scenario: Wave cancellation
+- **WHEN** the helper receives SIGINT, SIGTERM, or SIGHUP during a wave
+- **THEN** it forwards the signal to every live Kimi child and retains the
+  aggregate completion/failure contract
+
+#### Scenario: Upstream-compatible materialization
+- **WHEN** the helper loads a direct-child `SKILL.md`
+- **THEN** it parses complete YAML frontmatter, strips the fences, applies
+  Kimi's named/indexed/raw argument and context placeholder semantics, XML
+  escaping, canonical skill-root `realpath`, and exact
+  `kimi-skill-loaded` wrapper before spawn
+
+#### Scenario: Literal slash backstop
+- **WHEN** a headless caller or generated workflow would otherwise pass an
+  interactive slash command as model text
+- **THEN** Core routes the initial call through the helper and nested calls
+  through Kimi's native `Skill` tool instead
+
+#### Scenario: Native nested skill
+- **WHEN** a materialized Kimi workflow invokes a SpecRails or OpenSpec
+  subworkflow
+- **THEN** its generated instructions call the built-in `Skill` tool using the
+  mapped direct-child `skill` id and raw `args`, preserving native nested
+  behavior and activation telemetry
+
+#### Scenario: Session resume
+- **WHEN** a completed Kimi stream produced a session resume hint
+- **THEN** a later invocation can include that session ID using Kimi's native
+  session flag only after the hint is the terminal non-empty record, passes the
+  session-id grammar, and the child exits successfully
+
+#### Scenario: Runtime project context
+- **WHEN** a generated Kimi role or workflow needs stack, CI, layer, persona,
+  backlog, or PR context
+- **THEN** it resolves explicit semantic markers at activation time from
+  `.kimi-code/project-context.md`, regular non-symlink persona files, and the
+  validated backlog configuration instead of relying on enrich-time mutation
+- **AND** backlog markers are never executed as shell command names and writes
+  fail closed for invalid, missing, or read-only configuration
+
+#### Scenario: Safe attachments
+- **WHEN** an attachment is supplied to a plain or skill invocation
+- **THEN** Core accepts only an absolute readable regular non-symlink file,
+  canonicalizes it, and exposes each unique parent through `--add-dir`
+
+#### Scenario: Fresh session placeholder
+- **WHEN** a skill body references `${KIMI_SESSION_ID}` before any session hint
+  is known
+- **THEN** the helper fails before spawn rather than substituting a false empty
+  identifier
+
+#### Scenario: Safe model boundary
+- **WHEN** a model id is empty, begins with `-`, contains whitespace or control
+  characters, or exceeds 128 characters
+- **THEN** Core rejects it before process spawn, while a safe configured alias
+  such as `company/Kimi-Custom:v2` remains byte-identical
+
+#### Scenario: Stable Kimi engine
+- **WHEN** the parent environment contains `KIMI_CODE_EXPERIMENTAL_FLAG` or a
+  caller supplies an unknown experimental runner option
+- **THEN** Core removes the environment opt-in and rejects the option before
+  launching Kimi, preserving the qualified stable v1 contract
+
+#### Scenario: Bounded child lifecycle
+- **WHEN** Core launches a managed Kimi child
+- **THEN** it forces `KIMI_DISABLE_CRON=1` and
+  `KIMI_CODE_NO_AUTO_UPDATE=1`, overriding case-insensitive inherited values
+- **AND** it does not disable print mode's normal foreground task drain or
+  steering lifecycle
+
+#### Scenario: Model-scoped thinking effort
+- **WHEN** the child environment contains `KIMI_MODEL_THINKING_EFFORT`
+- **THEN** only `low`, `high`, or `max` is preserved for normalized K3, while
+  non-K3 and invalid values are removed before spawn
+- **AND** when no effort is explicitly supplied, the variable remains unset so
+  Kimi uses its documented K3 default of `high`
+
+#### Scenario: Windows npm shim
+- **WHEN** `kimi` resolves to a standard npm `.cmd` or `.bat` shim on Windows
+- **THEN** the helper launches its JavaScript entry with Node and `shell: false`,
+  transports the full prompt over stdin to a fixed bootstrap which restores
+  the `-p` argv value, and rejects a non-standard shim instead of invoking
+  `cmd.exe`
+- **AND** the bootstrap replaces only the fixed marker immediately following
+  `-p`, never a marker-shaped value in another argument
+
+#### Scenario: Session option binding
+- **WHEN** a known resume id is passed to the external Kimi process
+- **THEN** Core emits one `--session=<id>` argv element so the id cannot be
+  reinterpreted as a separate Kimi option
+
+#### Scenario: Oversized native Windows command
+- **WHEN** a native Kimi executable would require more than 30,000 UTF-16 code
+  units in its command line
+- **THEN** Core fails before spawn with guidance to use the standard npm shim
+  instead of truncating or compacting the workflow
+
+#### Scenario: Initial activation telemetry boundary
+- **WHEN** the initial headless skill is materialized outside Kimi's private
+  `activateSkill` path
+- **THEN** Core reproduces the visible prompt but does not claim or synthesize
+  private `skill.activated` or activation-origin telemetry
+
+### Requirement: Profiles, roles, and models
+Core SHALL support Kimi model identifiers in provider-aware profiles and SHALL allow every selected baseline or custom role to be represented as a Kimi skill without interpreting Claude-only aliases as Kimi models.
+
+#### Scenario: Kimi profile model
+- **WHEN** a Kimi profile selects `k3` or another model reported by Kimi
+- **THEN** profile validation and rendering retain the exact safe identifier,
+  enforce the same 128-character process-boundary grammar, and only the three
+  documented official short ids gain `kimi-code/` at spawn
+
+#### Scenario: Custom role preservation
+- **WHEN** update encounters a user-managed Kimi `custom-*` role skill
+- **THEN** it preserves that role and its profile references
+
+### Requirement: OpenSpec Kimi normalization
+Core SHALL install the required OpenSpec workflow skills into `.kimi-code/skills` even when the pinned published OpenSpec release emits the legacy `.kimi/skills` layout.
+
+#### Scenario: Legacy upstream layout
+- **WHEN** OpenSpec generates `.kimi/skills/openspec-*`
+- **THEN** Core atomically installs those generated skills under `.kimi-code/skills` and leaves no generated legacy `.kimi` tree
+
+#### Scenario: Corrected upstream layout
+- **WHEN** OpenSpec already generates `.kimi-code/skills/openspec-*`
+- **THEN** Core accepts the corrected layout without double-copying or deleting it
+
+#### Scenario: Safe atomic normalization
+- **WHEN** Core normalizes a generated OpenSpec Kimi tree
+- **THEN** it rejects symlinked/special source and destination entries, copies
+  only contained regular files/directories, and uses unpredictable
+  same-filesystem temporary and backup paths without deleting collisions
+
+### Requirement: Framework, relocation, and update parity
+Kimi SHALL participate in versioned framework materialization, standalone and relocated workspace assembly, manifests, reserved paths, update, cleanup, and rollback under the same provider-neutral lifecycle guarantees as existing providers.
+
+#### Scenario: Relocated workspace
+- **WHEN** Desktop requests a relocated Kimi workspace
+- **THEN** the workspace receives usable `.kimi-code` managed artifacts while source and OpenSpec paths resolve through the existing relocation contract
+
+#### Scenario: Copied overlay integrity
+- **WHEN** Windows uses a copied Kimi provider overlay instead of a junction
+- **THEN** Core verifies a deterministic hash of the complete provider tree,
+  repairs an owned stale/corrupt copy, and never trusts the ownership marker
+  alone
+
+#### Scenario: Provider-preserving update
+- **WHEN** a multi-provider project containing Kimi is updated
+- **THEN** Core updates managed Kimi artifacts without pruning other provider trees or user-owned Kimi configuration
+
+#### Scenario: Legacy nested role migration
+- **WHEN** update encounters a pre-release `.kimi-code/skills/rails` layout
+- **THEN** managed `sr-*` roles are regenerated as direct children, an
+  unconflicted `custom-*` role is moved atomically to its direct-child path,
+  and unknown or conflicting user content is preserved for doctor to report
+
+#### Scenario: Same-version framework repair
+- **WHEN** the current Kimi framework stamp matches the package version but its
+  roles remain under `skills/rails` or any managed runner/vendor file is absent
+- **THEN** Core rematerializes that provider framework instead of taking the idempotent skip
+
+#### Scenario: Managed runner bundle lifecycle
+- **WHEN** Core scaffolds, relocates, updates, or manifests a Kimi provider tree
+- **THEN** `run-skill.mjs`, vendored `js-yaml`, its MIT license, and provenance
+  notice move together under `.kimi-code/specrails`, outside the skill scanner
+
+### Requirement: CLI-only ownership boundary
+Core SHALL require an externally installed Kimi CLI and SHALL NOT bundle Kimi, start Kimi Server, register an OS service, or persist Kimi credentials.
+
+#### Scenario: Kimi setup
+- **WHEN** Core initializes a Kimi project
+- **THEN** no Kimi binary, server process, service registration, or copied credential is created by Core
+
+### Requirement: Kimi diagnostics
+Doctor and manifests SHALL validate Kimi-specific paths, managed skill and
+runner-bundle presence, provider version, OpenSpec placement, and stale legacy
+output with provider-specific remediation.
+
+#### Scenario: Misplaced OpenSpec skills
+- **WHEN** OpenSpec skills exist only under `.kimi/skills`
+- **THEN** doctor reports the stale location and the update command that repairs it
+
+#### Scenario: Healthy Kimi installation
+- **WHEN** all managed Kimi artifacts and prerequisites are valid
+- **THEN** doctor reports Kimi healthy without requiring Claude
+
+#### Scenario: Incomplete headless runner bundle
+- **WHEN** the runner, parser, license, or provenance notice is missing
+- **THEN** doctor fails with a Kimi-specific update remediation
+
+#### Scenario: Undiscoverable nested Kimi roles
+- **WHEN** role directories remain below `.kimi-code/skills/rails`
+- **THEN** doctor fails with provider-specific remediation and does not silently treat the nested roles as installed

--- a/openspec/changes/add-kimi-provider/tasks.md
+++ b/openspec/changes/add-kimi-provider/tasks.md
@@ -1,0 +1,115 @@
+## 1. Provider contract and prerequisites
+
+- [x] 1.1 Add Kimi to the canonical provider types, install config, CLI flags, TUI choices, help text, and validation errors
+- [x] 1.2 Detect native/npm Kimi executables cross-platform and preserve the existing automatic provider priority
+- [x] 1.3 Add bounded Kimi version and authentication probes with official install and `kimi login` remediation
+- [x] 1.4 Extend prerequisite, init, and doctor tests for missing, explicit, authenticated, and multi-provider Kimi scenarios
+
+## 2. Kimi framework rendering
+
+- [x] 2.1 Define explicit Kimi paths, linked/static subtrees, mutable state, gitignore, manifest, and reserved-path behavior
+- [x] 2.2 Render `.kimi-code/AGENTS.md` and provider settings without writing or overwriting the root Codex `AGENTS.md`
+- [x] 2.3 Render every applicable SpecRails command as a valid directory-form Kimi skill
+- [x] 2.4 Render selected baseline and optional/custom agents as direct-child Kimi rail-role skills
+- [x] 2.5 Translate Claude/OpenSpec nested calls to Kimi's built-in `Skill`
+  tool with explicit `skill`/`args`, and translate provider paths/tool
+  terminology without relying on interactive slash text
+- [x] 2.6 Add Kimi-specific inventory and forbidden-syntax snapshot tests for full and quick tiers
+
+## 3. OpenSpec and profiles
+
+- [x] 3.1 Normalize generated legacy `.kimi/skills/openspec-*` output into `.kimi-code/skills` atomically
+- [x] 3.2 Preserve corrected upstream `.kimi-code` output and user-owned Kimi files during init and update
+- [x] 3.3 Ensure the complete required OpenSpec workflow skill set is installed and verified for Kimi
+- [x] 3.4 Extend profile/model contracts so Kimi identifiers are retained without silently mapping Claude aliases
+- [x] 3.5 Preserve and validate `custom-*` Kimi role skills and profile references across updates
+
+## 4. Lifecycle parity
+
+- [x] 4.1 Add Kimi to standalone scaffold, versioned framework materialization, current-link assembly, and relocated workspaces
+- [x] 4.2 Add Kimi to update, migration, cleanup, rollback, and stale-provider pruning safeguards
+- [x] 4.3 Add Kimi to multi-provider registry/manifest behavior without altering other provider trees
+- [x] 4.4 Add provider-specific doctor checks for Kimi framework, OpenSpec placement, roles, and stale `.kimi`
+- [x] 4.5 Repair same-version nested Kimi frameworks and safely migrate
+  pre-release `skills/rails` custom roles without destructive collision handling
+- [x] 4.6 Materialize, relocate, update, manifest, and diagnose the complete
+  `.kimi-code/specrails/` runner, vendored YAML parser, license, and provenance
+  bundle
+
+## 5. Headless execution contract
+
+- [x] 5.1 Define and test the canonical managed-helper-to-external-`kimi -p
+  --output-format stream-json` new-session argument contract
+- [x] 5.2 Define and test known-session resume, model, effort, attachment-path, and skill invocation arguments
+- [x] 5.3 Document CLI-only cancellation, session-hint, telemetry, image, and no-server ownership semantics
+- [x] 5.4 Reproduce Kimi 0.27 full YAML skill parsing, parameter expansion, XML
+  wrapper, and session/skill-directory placeholders in a self-contained Node
+  helper with vendored `js-yaml`
+- [x] 5.5 Launch external Kimi without a shell, validate spawn-boundary model
+  ids, normalize only official ids, and safely unwrap the standard npm Windows
+  `.cmd` shim
+- [x] 5.6 Execute every single/parallel role group through one validated
+  role-wave request; provide unique current-role execution directories,
+  reusable git worktrees with starting overlays and atomic base/path manifests,
+  attributed output, aggregate failure, and all-child signal forwarding
+- [x] 5.7 Treat persisted role manifests and copied provider overlays as
+  untrusted: recompute exact managed paths and private-ref identity before
+  stateful operations, and verify a complete deterministic content hash before
+  reusing a copied overlay
+
+## 6. Documentation and verification
+
+- [x] 6.1 Update README, integration contract, supported-provider documentation, examples, and upgrade guidance
+- [x] 6.2 Run formatting, typecheck, unit, installer integration, template inventory, relocation, and package tests
+- [x] 6.3 Verify the OpenSpec change against implementation and record any live-Kimi canary limitation
+- [x] 6.4 Replace false headless `/skill:` examples/contracts, use the native
+  nested `Skill` tool, and add YAML, security, Unicode, multiline, lifecycle,
+  migration, multi-provider doctor, stable-engine/model-effort environment
+  scrubbing, cron/auto-update child isolation, large-prompt stdin transport,
+  native command-line budgets, and Windows-shim coverage
+- [x] 6.5 Validate attachment canonicalization and safe directory grants,
+  terminal-success-only resume hints, activation-time runtime context,
+  symlink-safe atomic OpenSpec normalization, manifest tampering, private-ref
+  retargeting, and copied-overlay corruption recovery
+
+## Verification evidence
+
+- Final `npm test`: 34 test files and 499 tests passed, including the TypeScript
+  compile gate. Focused post-hardening suites also pass: Kimi runtime/runner
+  86/86, scaffold 42/42, Kimi OpenSpec/invocation 13/13,
+  framework/registry 62/62, profile/init 25/25, and doctor 18/18.
+- `npm run typecheck`, `npm run build`, `git diff --check`, JSON parsing, CLI syntax checks, and
+  `npm --cache /private/tmp/specrails-kimi-npm-cache pack --dry-run` passed.
+- `openspec validate add-kimi-provider --strict --no-interactive` passed.
+- Kimi inventory tests verify every generated direct child has `SKILL.md`,
+  nested workflows use Kimi's native `Skill` tool, external roles use one
+  bounded role-wave request plus a static foreground helper command, no
+  `skills/rails` or `skills/personas` directory is generated, and persona
+  references resolve to `.kimi-code/personas/`.
+- Runner tests cover full YAML, exact placeholder/XML behavior, Unicode and
+  multiline input, session/model grammars, shell-injection payloads, stable
+  engine/cron/auto-update environment isolation, signal and stdin failures,
+  upstream-compatible realpaths for relocated symlinks, npm shim precedence,
+  current-repo execution isolation, dirty/untracked worktree snapshots,
+  worktree reuse/manifests, manifest-path tampering and private-ref retargeting,
+  full copied-overlay content hashes and corruption recovery, attributed
+  parallel output, aggregate partial failure and cancellation, exact plain
+  prompt stdin transport, and native Windows command-line failure before
+  truncation.
+- OpenSpec normalization tests reject symlinked roots, skills, and nested
+  entries, preserve colliding user-owned predictable names, and verify atomic
+  same-filesystem staging and rollback. Attachment tests reject missing,
+  unreadable, directory, and symlink inputs while canonicalizing each accepted
+  file and granting only its unique parent directory.
+- End-to-end manual smoke passed on both Node 25.9.0 and the supported floor
+  Node 20.19.5: TUI config + Kimi init, 19 workflow inventory, profile
+  validation, 14-check doctor, headless enrich through a fake external
+  Kimi 0.27 executable, byte-exact Unicode/multiline plain-prompt transport,
+  user skill/MCP preservation on update, and relocated Claude+Kimi registry and
+  manifest coexistence.
+- A live authenticated Kimi canary was not run in this environment; the
+  daemon-free CLI, helper, generated inventories, and stream fixtures are
+  validated against Kimi Code 0.27 source/documentation. On Windows the
+  standard npm shim is required for complete workflows above the native
+  `CreateProcess` argv budget; native executables remain supported for bounded
+  prompts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package.json
+++ b/package.json
@@ -57,9 +57,9 @@
     "build": "tsc -p tsconfig.json",
     "build:watch": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.test.json --noEmit",
-    "test": "npm run typecheck && vitest run",
+    "test": "npm run build && npm run typecheck && vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage",
+    "test:coverage": "npm run build && vitest run --coverage",
     "dogfood": "npm run build && node bin/specrails-core.mjs init --yes",
     "prepack": "npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "specrails-core",
   "version": "4.11.3",
-  "description": "AI agent workflow system for Claude Code — installs 12 specialized agents, orchestration commands, and persona-driven product discovery into any repository",
+  "description": "Provider-independent AI agent workflow system for Claude Code, Codex, Gemini CLI, and Kimi Code",
   "type": "module",
   "bin": {
     "specrails-core": "bin/specrails-core.mjs"
@@ -17,7 +17,7 @@
     "pinned-versions.json"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.19.0"
   },
   "repository": {
     "type": "git",
@@ -30,6 +30,10 @@
     "workflow",
     "developer-tools",
     "anthropic",
+    "kimi",
+    "moonshot-ai",
+    "gemini",
+    "codex",
     "llm",
     "ai",
     "automation",

--- a/schemas/profile.v1.json
+++ b/schemas/profile.v1.json
@@ -23,14 +23,19 @@
       "maxLength": 512,
       "description": "Optional short summary of when to use this profile."
     },
+    "provider": {
+      "type": "string",
+      "enum": ["claude", "codex", "gemini", "kimi"],
+      "description": "Optional provider binding. Omitted profiles retain the legacy Claude model-alias contract. Provider-bound profiles retain exact model identifiers; Kimi additionally enforces its safe process-boundary grammar."
+    },
     "orchestrator": {
       "type": "object",
       "required": ["model"],
       "additionalProperties": false,
       "properties": {
         "model": {
-          "$ref": "#/$defs/modelAlias",
-          "description": "Model used to run the top-level implement orchestrator."
+          "$ref": "#/$defs/providerModelId",
+          "description": "Provider model identifier used to run the top-level implement orchestrator."
         }
       }
     },
@@ -73,11 +78,68 @@
       "items": { "$ref": "#/$defs/routingRule" }
     }
   },
+  "allOf": [
+    {
+      "if": {
+        "anyOf": [
+          { "not": { "required": ["provider"] } },
+          {
+            "required": ["provider"],
+            "properties": { "provider": { "const": "claude" } }
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "orchestrator": {
+            "properties": { "model": { "$ref": "#/$defs/modelAlias" } }
+          },
+          "agents": {
+            "items": {
+              "properties": { "model": { "$ref": "#/$defs/modelAlias" } }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["provider"],
+        "properties": { "provider": { "const": "kimi" } }
+      },
+      "then": {
+        "properties": {
+          "orchestrator": {
+            "properties": { "model": { "$ref": "#/$defs/kimiModelId" } }
+          },
+          "agents": {
+            "items": {
+              "properties": { "model": { "$ref": "#/$defs/kimiModelId" } }
+            }
+          }
+        }
+      }
+    }
+  ],
   "$defs": {
     "modelAlias": {
       "type": "string",
       "enum": ["sonnet", "opus", "haiku"],
       "description": "Accepted model alias. Resolved to the current concrete model ID by the pipeline."
+    },
+    "providerModelId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "pattern": "^\\S(?:.*\\S)?$",
+      "description": "Exact provider model identifier or user-configured alias. Core retains this value verbatim and applies documented provider-specific validation/normalization."
+    },
+    "kimiModelId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._/:-]*$",
+      "description": "Kimi model identifier accepted at the shell-free process boundary."
     },
     "agentEntry": {
       "type": "object",
@@ -87,11 +149,11 @@
         "id": {
           "type": "string",
           "pattern": "^(sr|custom)-[a-z0-9][a-z0-9-]*$",
-          "description": "Agent identifier. MUST correspond to a file at `.claude/agents/<id>.md`."
+          "description": "Agent identifier. MUST correspond to the selected provider's role artifact."
         },
         "model": {
-          "$ref": "#/$defs/modelAlias",
-          "description": "Model override for this agent when this profile is active. When omitted, the agent's frontmatter `model:` is used as a fallback."
+          "$ref": "#/$defs/providerModelId",
+          "description": "Exact provider model override for this agent. When omitted, the provider default is used."
         },
         "required": {
           "type": "boolean",

--- a/src/installer/cli.ts
+++ b/src/installer/cli.ts
@@ -85,7 +85,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
 function usageText(): string {
   return [
     '',
-    'specrails-core — AI agent workflow system',
+    'specrails-core — Provider-independent AI agent workflow system',
     '',
     'Usage:',
     '  specrails-core <command> [options]',

--- a/src/installer/commands/doctor.test.ts
+++ b/src/installer/commands/doctor.test.ts
@@ -1,24 +1,47 @@
-import { mkdtempSync, rmSync } from 'node:fs'
+import { chmodSync, mkdtempSync, rmSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { mkdirp, writeFileLf } from '../util/fs.js'
+import {
+  copyFile,
+  isFile,
+  mkdirp,
+  readTextFile,
+  writeFileLf,
+} from '../util/fs.js'
+import { runCommand } from '../util/exec.js'
 import { initRepo } from '../util/git.js'
-import { runDoctor } from './doctor.js'
+import {
+  buildManifest,
+  writeManifestFiles,
+} from '../phases/manifest.js'
+import { KIMI_REQUIRED_OPENSPEC_SKILLS } from './init.js'
+import {
+  KIMI_MANAGED_WORKFLOW_SKILLS,
+  runDoctor,
+} from './doctor.js'
 
 describe('runDoctor', () => {
   let tmpDir: string
   let prevCwd: string
+  let prevPath: string | undefined
+  let prevKimiHome: string | undefined
 
   beforeEach(() => {
     tmpDir = mkdtempSync(path.join(os.tmpdir(), 'specrails-doctor-test-'))
     prevCwd = process.cwd()
+    prevPath = process.env.PATH
+    prevKimiHome = process.env.KIMI_CODE_HOME
   })
 
   afterEach(() => {
     process.chdir(prevCwd)
+    if (prevPath === undefined) delete process.env.PATH
+    else process.env.PATH = prevPath
+    if (prevKimiHome === undefined) delete process.env.KIMI_CODE_HOME
+    else process.env.KIMI_CODE_HOME = prevKimiHome
     rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
   })
 
@@ -44,5 +67,444 @@ describe('runDoctor', () => {
     expect(passes).toContain('Git: initialized')
     expect(passes).toContain('CLAUDE.md: present')
     expect(passes).toMatch(/Agent files: 2 agent\(s\) found in \.claude\/agents/)
+  })
+
+  async function setupHealthyKimiRepo(
+    repoRoot = path.join(tmpDir, 'repo-kimi'),
+  ): Promise<string> {
+    const binDir = path.join(tmpDir, 'bin')
+    const kimiHome = path.join(tmpDir, 'kimi-home')
+    mkdirp(repoRoot)
+    mkdirp(binDir)
+    await initRepo(repoRoot)
+    const kimi = path.join(binDir, 'kimi')
+    writeFileLf(
+      kimi,
+      [
+        '#!/bin/sh',
+        'if [ "$1" = "--version" ]; then echo "kimi-code 0.27.0"; exit 0; fi',
+        'if [ "$1" = "doctor" ]; then exit 0; fi',
+        'exit 0',
+        '',
+      ].join('\n'),
+    )
+    chmodSync(kimi, 0o755)
+    process.env.PATH = `${binDir}${path.delimiter}${prevPath ?? ''}`
+    process.env.KIMI_CODE_HOME = kimiHome
+    writeFileLf(
+      path.join(kimiHome, 'credentials', 'kimi-code.json'),
+      '{"credential":"never-read"}\n',
+    )
+
+    writeFileLf(path.join(repoRoot, '.kimi-code', 'AGENTS.md'), '# Kimi')
+    writeFileLf(path.join(repoRoot, '.kimi-code', 'mcp.json'), '{"mcpServers":{}}\n')
+    for (const relative of [
+      'run-skill.mjs',
+      path.join('vendor', 'js-yaml', 'js-yaml.mjs'),
+      path.join('vendor', 'js-yaml', 'LICENSE'),
+      path.join('vendor', 'js-yaml', 'NOTICE.md'),
+    ]) {
+      copyFile(
+        path.join(process.cwd(), 'templates', 'kimi', 'specrails', relative),
+        path.join(repoRoot, '.kimi-code', 'specrails', relative),
+      )
+    }
+    for (const role of ['sr-architect', 'sr-developer', 'sr-reviewer']) {
+      writeFileLf(
+        path.join(repoRoot, '.kimi-code', 'skills', role, 'SKILL.md'),
+        `---\nname: ${role}\ndescription: role\n---\n`,
+      )
+    }
+    for (const workflow of KIMI_MANAGED_WORKFLOW_SKILLS) {
+      writeFileLf(
+        path.join(repoRoot, '.kimi-code', 'skills', workflow, 'SKILL.md'),
+        `---\nname: ${workflow}\ndescription: workflow\n---\n`,
+      )
+    }
+    for (const skill of KIMI_REQUIRED_OPENSPEC_SKILLS) {
+      writeFileLf(
+        path.join(repoRoot, '.kimi-code', 'skills', skill, 'SKILL.md'),
+        `---\nname: ${skill}\ndescription: openspec\n---\n`,
+      )
+    }
+    const packageJson = JSON.parse(
+      readTextFile(path.join(process.cwd(), 'package.json')),
+    ) as { version: string }
+    writeManifestFiles(
+      repoRoot,
+      buildManifest({
+        scriptDir: process.cwd(),
+        repoRoot,
+        version: packageJson.version,
+        installedAt: '2026-07-20T00:00:00Z',
+        providers: ['kimi'],
+        primaryProvider: 'kimi',
+      }),
+    )
+    return repoRoot
+  }
+
+  it.skipIf(process.platform === 'win32')(
+    'checks a healthy Kimi install without requiring Claude',
+    async () => {
+      const repoRoot = await setupHealthyKimiRepo()
+      const result = await runDoctor({ 'root-dir': repoRoot, provider: 'kimi' })
+      const messages = result.results.map((entry) => entry.message).join('\n')
+      expect(result.failed).toBe(0)
+      expect(messages).toContain('Kimi Code CLI: found')
+      expect(messages).toContain('Kimi Code version: kimi-code 0.27.0')
+      expect(messages).toContain('Kimi: authentication evidence found')
+      expect(messages).toContain('Role skills: 3 agent(s)')
+      expect(messages).toContain(
+        'Kimi headless skill runner: complete managed bundle integrity verified',
+      )
+      expect(messages).toContain(
+        `Kimi workflow skills: all ${KIMI_MANAGED_WORKFLOW_SKILLS.length} managed workflows present`,
+      )
+      expect(messages).toContain('Kimi OpenSpec skills: all 11 present')
+      expect(messages).toContain('.kimi-code/mcp.json: valid (0 server(s))')
+      expect(messages).toContain('SpecRails manifest: valid for Core')
+      expect(messages).not.toContain('Claude Code CLI')
+    },
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'honours the manifest primary provider in a mixed-provider workspace',
+    async () => {
+      const repoRoot = await setupHealthyKimiRepo()
+      writeFileLf(path.join(repoRoot, '.gemini', 'GEMINI.md'), '# Gemini')
+
+      const result = await runDoctor({ 'root-dir': repoRoot })
+      const messages = result.results.map((entry) => entry.message).join('\n')
+      expect(messages).toContain('Kimi Code CLI: found')
+      expect(messages).not.toContain('Gemini CLI')
+      expect(messages).not.toContain('Claude Code CLI')
+    },
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'preserves Gemini before Codex, Kimi, and Claude in directory fallback',
+    async () => {
+      const repoRoot = path.join(tmpDir, 'mixed-provider-repo')
+      const binDir = path.join(tmpDir, 'mixed-provider-bin')
+      mkdirp(binDir)
+      for (const providerDir of [
+        '.claude',
+        '.codex',
+        '.gemini',
+        '.kimi-code',
+      ]) {
+        mkdirp(path.join(repoRoot, providerDir))
+      }
+      const gemini = path.join(binDir, 'gemini')
+      writeFileLf(gemini, '#!/bin/sh\nexit 0\n')
+      chmodSync(gemini, 0o755)
+      process.env.PATH = `${binDir}${path.delimiter}${prevPath ?? ''}`
+
+      const result = await runDoctor({ 'root-dir': repoRoot })
+      const messages = result.results.map((entry) => entry.message).join('\n')
+      expect(messages).toContain('Gemini CLI: found')
+      expect(messages).not.toContain('Claude Code CLI')
+      expect(messages).not.toContain('Kimi Code CLI')
+    },
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'reports a missing managed Kimi headless skill runner',
+    async () => {
+      const repoRoot = await setupHealthyKimiRepo()
+      rmSync(
+        path.join(repoRoot, '.kimi-code', 'specrails', 'run-skill.mjs'),
+        { force: true },
+      )
+      const result = await runDoctor({ 'root-dir': repoRoot, provider: 'kimi' })
+      const missing = result.results.find((entry) =>
+        entry.message.includes('headless skill runner'),
+      )
+      expect(missing?.kind).toBe('fail')
+      expect(missing?.fix).toContain('update --provider kimi')
+    },
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'reports an incomplete managed Kimi runner vendor bundle',
+    async () => {
+      const repoRoot = await setupHealthyKimiRepo()
+      rmSync(
+        path.join(
+          repoRoot,
+          '.kimi-code',
+          'specrails',
+          'vendor',
+          'js-yaml',
+          'js-yaml.mjs',
+        ),
+        { force: true },
+      )
+      const result = await runDoctor({ 'root-dir': repoRoot, provider: 'kimi' })
+      const missing = result.results.find((entry) =>
+        entry.message.includes('headless skill runner'),
+      )
+      expect(missing?.kind).toBe('fail')
+      expect(missing?.message).toContain('vendor/js-yaml/js-yaml.mjs')
+      expect(missing?.fix).toContain('update --provider kimi')
+    },
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'reports a managed Kimi runner whose installed bytes were modified',
+    async () => {
+      const repoRoot = await setupHealthyKimiRepo()
+      writeFileLf(
+        path.join(repoRoot, '.kimi-code', 'specrails', 'run-skill.mjs'),
+        '// tampered managed runner\n',
+      )
+
+      const result = await runDoctor({ 'root-dir': repoRoot, provider: 'kimi' })
+      const mismatch = result.results.find((entry) =>
+        entry.message.includes('headless skill runner'),
+      )
+      expect(mismatch?.kind).toBe('fail')
+      expect(mismatch?.message).toContain('content mismatch')
+      expect(mismatch?.message).toContain('run-skill.mjs')
+      expect(mismatch?.fix).toContain('update --provider kimi')
+    },
+  )
+
+  it('rejects an explicit unsupported provider instead of auto-detecting', async () => {
+    await expect(
+      runDoctor({ 'root-dir': tmpDir, provider: 'unsupported' }),
+    ).rejects.toThrow(
+      "--provider value must be 'claude', 'codex', 'gemini', or 'kimi'",
+    )
+    await expect(
+      runDoctor({ 'root-dir': tmpDir, provider: true }),
+    ).rejects.toThrow(
+      "--provider value must be 'claude', 'codex', 'gemini', or 'kimi'",
+    )
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'reports stale legacy OpenSpec output with update remediation',
+    async () => {
+      const repoRoot = await setupHealthyKimiRepo()
+      writeFileLf(
+        path.join(repoRoot, '.kimi', 'skills', 'openspec-apply-change', 'SKILL.md'),
+        'legacy\n',
+      )
+      const result = await runDoctor({ 'root-dir': repoRoot, provider: 'kimi' })
+      const stale = result.results.find((entry) => entry.message.includes('stale generated'))
+      expect(stale?.kind).toBe('fail')
+      expect(stale?.fix).toContain('update --provider kimi')
+    },
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'reports nested Kimi roles that the direct-child skill loader cannot discover',
+    async () => {
+      const repoRoot = await setupHealthyKimiRepo()
+      writeFileLf(
+        path.join(
+          repoRoot,
+          '.kimi-code',
+          'skills',
+          'rails',
+          'custom-conflict',
+          'SKILL.md',
+        ),
+        'legacy nested role\n',
+      )
+      const result = await runDoctor({ 'root-dir': repoRoot, provider: 'kimi' })
+      const stale = result.results.find((entry) =>
+        entry.message.includes('stale nested skills/rails layout'),
+      )
+      expect(stale?.kind).toBe('fail')
+      expect(stale?.fix).toContain('update --provider kimi')
+    },
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'checks every managed Kimi workflow, not only the execution happy path',
+    async () => {
+      const repoRoot = await setupHealthyKimiRepo()
+      expect(KIMI_MANAGED_WORKFLOW_SKILLS.length).toBeGreaterThan(4)
+      const workflow = 'specrails-why'
+      expect(KIMI_MANAGED_WORKFLOW_SKILLS).toContain(workflow)
+      rmSync(
+        path.join(repoRoot, '.kimi-code', 'skills', workflow, 'SKILL.md'),
+        { force: true },
+      )
+
+      const result = await runDoctor({ 'root-dir': repoRoot, provider: 'kimi' })
+      const catalog = result.results.find((entry) =>
+        entry.message.includes('Kimi workflow skills'),
+      )
+      expect(catalog?.kind).toBe('fail')
+      expect(catalog?.message).toContain(workflow)
+    },
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'rejects malformed Kimi MCP JSON',
+    async () => {
+      const repoRoot = await setupHealthyKimiRepo()
+      writeFileLf(path.join(repoRoot, '.kimi-code', 'mcp.json'), '{not json}\n')
+
+      const result = await runDoctor({ 'root-dir': repoRoot, provider: 'kimi' })
+      const mcp = result.results.find((entry) =>
+        entry.message.includes('.kimi-code/mcp.json'),
+      )
+      expect(mcp?.kind).toBe('fail')
+      expect(mcp?.message).toContain('not valid JSON')
+    },
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'rejects invalid Kimi MCP container and server shapes',
+    async () => {
+      const repoRoot = await setupHealthyKimiRepo()
+      const mcpPath = path.join(repoRoot, '.kimi-code', 'mcp.json')
+      writeFileLf(mcpPath, '{"mcpServers":[]}\n')
+
+      let result = await runDoctor({ 'root-dir': repoRoot, provider: 'kimi' })
+      let mcp = result.results.find((entry) =>
+        entry.message.includes('.kimi-code/mcp.json'),
+      )
+      expect(mcp?.kind).toBe('fail')
+      expect(mcp?.message).toContain('mcpServers must be an object')
+
+      writeFileLf(
+        mcpPath,
+        '{"mcpServers":{"broken":{"transport":"stdio","command":"","args":[1]}}}\n',
+      )
+      result = await runDoctor({ 'root-dir': repoRoot, provider: 'kimi' })
+      mcp = result.results.find((entry) =>
+        entry.message.includes('.kimi-code/mcp.json'),
+      )
+      expect(mcp?.kind).toBe('fail')
+      expect(mcp?.message).toContain('command must be a non-empty string')
+      expect(mcp?.message).toContain('args must be an array of strings')
+    },
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'rejects a manifest whose version marker does not match',
+    async () => {
+      const repoRoot = await setupHealthyKimiRepo()
+      writeFileLf(
+        path.join(repoRoot, '.specrails', 'specrails-version'),
+        'different-version\n',
+      )
+
+      const result = await runDoctor({ 'root-dir': repoRoot, provider: 'kimi' })
+      const manifest = result.results.find((entry) =>
+        entry.message.includes('SpecRails manifest'),
+      )
+      expect(manifest?.kind).toBe('fail')
+      expect(manifest?.message).toContain(
+        'specrails-version marker does not match manifest version',
+      )
+    },
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'rejects a self-consistent manifest from a different Core version',
+    async () => {
+      const repoRoot = await setupHealthyKimiRepo()
+      const manifestPath = path.join(
+        repoRoot,
+        '.specrails',
+        'specrails-manifest.json',
+      )
+      const manifest = JSON.parse(readTextFile(manifestPath)) as {
+        version: string
+      }
+      manifest.version = '0.0.1'
+      writeFileLf(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+      writeFileLf(
+        path.join(repoRoot, '.specrails', 'specrails-version'),
+        '0.0.1\n',
+      )
+
+      const result = await runDoctor({ 'root-dir': repoRoot, provider: 'kimi' })
+      const validation = result.results.find((entry) =>
+        entry.message.includes('SpecRails manifest'),
+      )
+      expect(validation?.kind).toBe('fail')
+      expect(validation?.message).toContain(
+        'version 0.0.1 does not match running Core',
+      )
+    },
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'rejects tampered manifest checksums and inconsistent provider metadata',
+    async () => {
+      const repoRoot = await setupHealthyKimiRepo()
+      const manifestPath = path.join(
+        repoRoot,
+        '.specrails',
+        'specrails-manifest.json',
+      )
+      const manifest = JSON.parse(readTextFile(manifestPath)) as {
+        providers: string[]
+        primary_provider: string
+        artifacts: Record<string, string>
+      }
+      const firstArtifact = Object.keys(manifest.artifacts)[0]!
+      manifest.artifacts[firstArtifact] = `sha256:${'0'.repeat(64)}`
+      manifest.providers = ['kimi']
+      manifest.primary_provider = 'claude'
+      writeFileLf(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+
+      const result = await runDoctor({ 'root-dir': repoRoot, provider: 'kimi' })
+      const validation = result.results.find((entry) =>
+        entry.message.includes('SpecRails manifest'),
+      )
+      expect(validation?.kind).toBe('fail')
+      expect(validation?.message).toContain('artifacts checksum mismatch')
+      expect(validation?.message).toContain(
+        'primary_provider must also appear in providers',
+      )
+    },
+  )
+
+  it('recognizes a linked Git worktree whose .git entry is a file', async () => {
+    const mainRepo = path.join(tmpDir, 'main-repo')
+    const worktree = path.join(tmpDir, 'linked-worktree')
+    mkdirp(mainRepo)
+    await initRepo(mainRepo)
+    await runCommand(
+      'git',
+      [
+        '-c',
+        'user.name=SpecRails Test',
+        '-c',
+        'user.email=specrails@example.invalid',
+        'commit',
+        '--allow-empty',
+        '-m',
+        'initial',
+      ],
+      { cwd: mainRepo, inherit: false },
+    )
+    await runCommand(
+      'git',
+      ['worktree', 'add', '--detach', worktree],
+      { cwd: mainRepo, inherit: false },
+    )
+    expect(isFile(path.join(worktree, '.git'))).toBe(true)
+    writeFileLf(path.join(worktree, 'CLAUDE.md'), '# linked worktree')
+    writeFileLf(
+      path.join(worktree, '.claude', 'agents', 'sr-architect.md'),
+      'agent\n',
+    )
+
+    const result = await runDoctor({
+      'root-dir': worktree,
+      provider: 'claude',
+    })
+    const git = result.results.find((entry) => entry.message.startsWith('Git:'))
+    expect(git).toEqual({ kind: 'pass', message: 'Git: initialized' })
   })
 })

--- a/src/installer/commands/doctor.test.ts
+++ b/src/installer/commands/doctor.test.ts
@@ -50,7 +50,7 @@ describe('runDoctor', () => {
     expect(result.failed).toBeGreaterThan(0)
     // Must mention missing provider agents dir and missing CLAUDE.md.
     const messages = result.results.map((r) => r.message).join('\n')
-    expect(messages).toMatch(/\.claude\/agents directory not found/)
+    expect(messages).toMatch(/\.claude[\\/]agents directory not found/)
     expect(messages).toMatch(/CLAUDE\.md: missing/)
   })
 
@@ -66,7 +66,9 @@ describe('runDoctor', () => {
     const passes = result.results.filter((r) => r.kind === 'pass').map((r) => r.message).join('\n')
     expect(passes).toContain('Git: initialized')
     expect(passes).toContain('CLAUDE.md: present')
-    expect(passes).toMatch(/Agent files: 2 agent\(s\) found in \.claude\/agents/)
+    expect(passes).toMatch(
+      /Agent files: 2 agent\(s\) found in \.claude[\\/]agents/,
+    )
   })
 
   async function setupHealthyKimiRepo(

--- a/src/installer/commands/doctor.ts
+++ b/src/installer/commands/doctor.ts
@@ -1,14 +1,57 @@
-import { appendFileSync } from 'node:fs'
+import { appendFileSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import { info, ok, fail as logFail, rawOut } from '../util/logger.js'
 import { commandExists, runCommand } from '../util/exec.js'
-import { isDir, isFile, listDir, mkdirp } from '../util/fs.js'
+import {
+  isDir,
+  isFile,
+  listDir,
+  mkdirp,
+  readTextFile,
+} from '../util/fs.js'
+import { isGitRepo } from '../util/git.js'
 
-import { assertClaudeAuthenticated } from '../phases/provider-detect.js'
+import { buildManifest } from '../phases/manifest.js'
+import {
+  assertClaudeAuthenticated,
+  assertKimiAuthenticated,
+  isSupportedKimiVersion,
+  kimiVersion,
+  MIN_KIMI_VERSION,
+} from '../phases/provider-detect.js'
 import { derivedPaths, type Provider } from '../phases/provider-detect.js'
+import { ProviderError } from '../util/errors.js'
 import { resolveArtifacts } from '../util/registry.js'
+import { KIMI_REQUIRED_OPENSPEC_SKILLS } from './init.js'
+
+const CORE_PACKAGE_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '..',
+)
+
+/**
+ * Every canonical SpecRails command is materialized as a direct-child Kimi
+ * skill. Discover the list from the packaged source of truth so doctor cannot
+ * silently fall behind when the command catalog grows.
+ */
+export const KIMI_MANAGED_WORKFLOW_SKILLS = listDir(
+  path.join(CORE_PACKAGE_ROOT, 'templates', 'commands', 'specrails'),
+)
+  .filter(
+    (entry) =>
+      isFile(entry) &&
+      path.extname(entry) === '.md' &&
+      path.basename(entry) !== 'setup.md',
+  )
+  .map((entry) => `specrails-${path.basename(entry, '.md')}`)
+  .sort()
+
+const SHA256_DIGEST = /^sha256:[0-9a-f]{64}$/
 
 /**
  * `npx specrails-core doctor` — health check for a specrails install.
@@ -20,6 +63,7 @@ import { resolveArtifacts } from '../util/registry.js'
 
 export interface DoctorFlags {
   'root-dir'?: string | boolean
+  provider?: string | boolean
 }
 
 export interface DoctorResult {
@@ -51,19 +95,35 @@ export async function runDoctor(flags: DoctorFlags = {}): Promise<DoctorResult> 
   const addFail = (message: string, fix: string): void => {
     results.push({ kind: 'fail', message, fix })
   }
-  const provider = resolveInstalledProvider(artifactRoot)
+  const provider = resolveDoctorProvider(artifactRoot, flags.provider)
   const { providerDir, instructionsFile } = derivedPaths(provider)
 
-  // Check 1: Claude Code CLI
-  if (await commandExists('claude')) {
-    const path_ = await resolveCommandPath('claude')
-    addPass(`Claude Code CLI: found${path_ ? ` (${path_})` : ''}`)
+  // Check 1: selected provider CLI.
+  const cli = provider === 'claude' ? 'claude' : provider
+  const cliLabel =
+    provider === 'claude'
+      ? 'Claude Code'
+      : provider === 'kimi'
+        ? 'Kimi Code'
+        : provider === 'gemini'
+          ? 'Gemini'
+          : 'Codex'
+  const cliFound = await commandExists(cli)
+  if (cliFound) {
+    const path_ = await resolveCommandPath(cli)
+    addPass(`${cliLabel} CLI: found${path_ ? ` (${path_})` : ''}`)
   } else {
-    addFail('Claude Code CLI: not found', 'Install Claude Code: https://claude.ai/download')
+    const installFix =
+      provider === 'kimi'
+        ? 'Install Kimi Code: https://www.kimi.com/code/docs/en/kimi-code-cli/guides/getting-started.html'
+        : provider === 'claude'
+          ? 'Install Claude Code: https://claude.ai/download'
+          : `Install the ${cliLabel} CLI and retry`
+    addFail(`${cliLabel} CLI: not found`, installFix)
   }
 
-  // Check 2: Claude authentication (only meaningful if the CLI is installed)
-  if (await commandExists('claude')) {
+  // Check 2: provider version/authentication when a bounded probe exists.
+  if (cliFound && provider === 'claude') {
     try {
       await assertClaudeAuthenticated({ skipPrereqs: false })
       addPass('Claude: authenticated')
@@ -73,26 +133,66 @@ export async function runDoctor(flags: DoctorFlags = {}): Promise<DoctorResult> 
         'Option 1: claude config set api_key <your-key>  |  Option 2: claude auth login',
       )
     }
+  } else if (cliFound && provider === 'kimi') {
+    const version = await kimiVersion()
+    if (isSupportedKimiVersion(version)) {
+      addPass(`Kimi Code version: ${version}`)
+    } else {
+      addFail(
+        `Kimi Code version: unsupported (${version})`,
+        `Upgrade Kimi Code to ${MIN_KIMI_VERSION} or newer`,
+      )
+    }
+    try {
+      const auth = await assertKimiAuthenticated({ skipPrereqs: false })
+      if (auth === 'authenticated') {
+        addPass('Kimi: authentication evidence found')
+      } else {
+        // There is no non-billable readiness probe in 0.27. Unknown is healthy:
+        // doctor must not spend quota merely to prove login.
+        addPass('Kimi: authentication readiness unknown (non-billing check)')
+      }
+    } catch {
+      addFail('Kimi: not authenticated', 'Run: kimi login')
+    }
   }
 
-  // Check 3: Agent files present in the active provider directory.
-  const agentsDir = path.join(artifactRoot, providerDir, 'agents')
+  // Check 3: provider-native role artifacts.
+  const agentsDir =
+    provider === 'kimi'
+      ? path.join(artifactRoot, providerDir, 'skills')
+      : provider === 'codex'
+        ? path.join(artifactRoot, providerDir, 'skills', 'rails')
+      : path.join(artifactRoot, providerDir, 'agents')
   if (isDir(agentsDir)) {
     const agentFiles = findInstalledAgentFiles(agentsDir, provider)
     if (agentFiles.length >= 1) {
       const names = agentFiles
-        .map((f) => path.basename(f, path.extname(f)))
+        .map((f) =>
+          provider === 'kimi' || provider === 'codex'
+            ? path.basename(path.dirname(f))
+            : path.basename(f, path.extname(f)),
+        )
         .join(', ')
-      addPass(`Agent files: ${agentFiles.length} agent(s) found in ${providerDir}/agents (${names})`)
+      const relativeRoleDir =
+        provider === 'kimi'
+          ? `${providerDir}/skills`
+          : provider === 'codex'
+            ? `${providerDir}/skills/rails`
+          : `${providerDir}/agents`
+      const label = provider === 'kimi' ? 'Role skills' : 'Agent files'
+      addPass(`${label}: ${agentFiles.length} agent(s) found in ${relativeRoleDir} (${names})`)
     } else {
       addFail(
-        `Agent files: ${providerDir}/agents exists but no generated agent files were found`,
+        `${provider === 'kimi' ? 'Role skills' : 'Agent files'}: ` +
+          `${path.relative(artifactRoot, agentsDir)} exists but no generated role artifacts were found`,
         'Run specrails-core init to set up agents',
       )
     }
   } else {
     addFail(
-      `Agent files: ${providerDir}/agents directory not found`,
+      `${provider === 'kimi' ? 'Role skills' : 'Agent files'}: ` +
+        `${path.relative(artifactRoot, agentsDir)} directory not found`,
       'Run specrails-core init to set up agents',
     )
   }
@@ -109,8 +209,15 @@ export async function runDoctor(flags: DoctorFlags = {}): Promise<DoctorResult> 
     )
   }
 
-  // Check 5: Git initialized (in the repo — codeRoot, not the artifact root)
-  if (isDir(path.join(codeRoot, '.git'))) {
+  if (provider === 'kimi') {
+    checkKimiArtifacts({ artifactRoot, codeRoot, addPass, addFail })
+  }
+
+  // Check 5: Git initialized (in the repo — codeRoot, not the artifact root).
+  // `git rev-parse` supports normal repositories, linked worktrees (`.git` is a
+  // file there), subdirectories and repository layouts that do not expose a
+  // literal `.git/` directory.
+  if (await isGitRepo(codeRoot)) {
     addPass('Git: initialized')
   } else {
     addFail('Git: not a git repository', 'Initialize with: git init')
@@ -143,7 +250,11 @@ export async function runDoctor(flags: DoctorFlags = {}): Promise<DoctorResult> 
   rawOut('\n')
   if (failed === 0) {
     info(
-      `All ${passed + failed} checks passed. Run /specrails:get-backlog-specs to get started.`,
+      `All ${passed + failed} checks passed. Run ${
+        provider === 'kimi'
+          ? '/skill:specrails-get-backlog-specs'
+          : '/specrails:get-backlog-specs'
+      } to get started.`,
     )
   } else {
     rawOut(`${failed} check(s) failed.\n`)
@@ -166,21 +277,518 @@ async function resolveCommandPath(cmd: string): Promise<string | null> {
   }
 }
 
-function resolveInstalledProvider(projectRoot: string): Provider {
+function resolveDoctorProvider(
+  projectRoot: string,
+  explicit: string | boolean | undefined,
+): Provider {
+  if (
+    explicit === 'claude' ||
+    explicit === 'codex' ||
+    explicit === 'gemini' ||
+    explicit === 'kimi'
+  ) {
+    return explicit
+  }
+  if (explicit !== undefined) {
+    throw new ProviderError(
+      `--provider value must be 'claude', 'codex', 'gemini', or 'kimi', got: ${String(explicit)}`,
+    )
+  }
+
+  const manifestPath = path.join(
+    projectRoot,
+    '.specrails',
+    'specrails-manifest.json',
+  )
+  if (isFile(manifestPath)) {
+    try {
+      const manifest = JSON.parse(readTextFile(manifestPath)) as {
+        primary_provider?: unknown
+        providers?: unknown
+      }
+      if (isProvider(manifest.primary_provider)) return manifest.primary_provider
+      if (Array.isArray(manifest.providers)) {
+        const recorded = manifest.providers.filter(isProvider)
+        if (recorded.length === 1) return recorded[0]
+      }
+    } catch {
+      // The manifest itself is diagnosed later. Preserve legacy directory
+      // fallback here so doctor still reports every actionable problem.
+    }
+  }
+
+  // Preserve the established multi-tree fallback: Gemini and Codex predate
+  // Claude-first resolution. Kimi slots ahead of Claude without changing
+  // existing Gemini/Codex behavior.
   if (isDir(path.join(projectRoot, '.gemini'))) return 'gemini'
   if (isDir(path.join(projectRoot, '.codex'))) return 'codex'
+  if (isDir(path.join(projectRoot, '.kimi-code'))) return 'kimi'
+  if (isDir(path.join(projectRoot, '.claude'))) return 'claude'
   return 'claude'
+}
+
+function isProvider(value: unknown): value is Provider {
+  return (
+    value === 'claude' ||
+    value === 'codex' ||
+    value === 'gemini' ||
+    value === 'kimi'
+  )
 }
 
 function findInstalledAgentFiles(root: string, provider: Provider): string[] {
   if (!isDir(root)) return []
-  const matcher =
-    provider === 'codex'
-      ? /^(custom-|sr-).+\.toml$/
-      : /^(custom-|sr-).+\.md$/
+  if (provider === 'kimi') {
+    return listDir(root)
+      .filter((entry) => {
+        const id = path.basename(entry)
+        return (
+          isDir(entry) &&
+          /^(?:sr|custom)-[a-z0-9-]+$/.test(id) &&
+          isFile(path.join(entry, 'SKILL.md'))
+        )
+      })
+      .map((entry) => path.join(entry, 'SKILL.md'))
+      .sort()
+  }
+  if (provider === 'codex') {
+    return listDir(root)
+      .filter((entry) => isDir(entry) && isFile(path.join(entry, 'SKILL.md')))
+      .map((entry) => path.join(entry, 'SKILL.md'))
+      .sort()
+  }
+  const matcher = /^(custom-|sr-).+\.md$/
   return listDir(root)
     .filter((entry) => isFile(entry) && matcher.test(path.basename(entry)))
     .sort()
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function validateStringRecord(value: unknown, field: string): string[] {
+  if (!isRecord(value)) return [`${field} must be an object of string values`]
+  return Object.entries(value)
+    .filter(([, item]) => typeof item !== 'string')
+    .map(([key]) => `${field}.${key} must be a string`)
+}
+
+function validateStringArray(value: unknown, field: string): string[] {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    return [`${field} must be an array of strings`]
+  }
+  return []
+}
+
+function validateKimiMcpServer(name: string, value: unknown): string[] {
+  const field = `mcpServers.${name}`
+  if (!isRecord(value)) return [`${field} must be an object`]
+
+  const errors: string[] = []
+  let transport = value.transport
+  if (transport === undefined) {
+    if (typeof value.command === 'string') transport = 'stdio'
+    else if (typeof value.url === 'string') transport = 'http'
+  }
+
+  if (transport !== 'stdio' && transport !== 'http' && transport !== 'sse') {
+    return [`${field} must declare a command, a URL, or a supported transport`]
+  }
+
+  if (transport === 'stdio') {
+    if (typeof value.command !== 'string' || value.command.length === 0) {
+      errors.push(`${field}.command must be a non-empty string`)
+    }
+    if (value.args !== undefined) {
+      errors.push(...validateStringArray(value.args, `${field}.args`))
+    }
+    if (value.env !== undefined) {
+      errors.push(...validateStringRecord(value.env, `${field}.env`))
+    }
+    if (value.cwd !== undefined && typeof value.cwd !== 'string') {
+      errors.push(`${field}.cwd must be a string`)
+    }
+    if (
+      value.executor !== undefined &&
+      value.executor !== 'local' &&
+      value.executor !== 'kaos'
+    ) {
+      errors.push(`${field}.executor must be "local" or "kaos"`)
+    }
+  } else {
+    if (typeof value.url !== 'string') {
+      errors.push(`${field}.url must be a valid URL`)
+    } else {
+      try {
+        new URL(value.url)
+      } catch {
+        errors.push(`${field}.url must be a valid URL`)
+      }
+    }
+    if (value.headers !== undefined) {
+      errors.push(...validateStringRecord(value.headers, `${field}.headers`))
+    }
+    if (value.auth !== undefined && value.auth !== 'oauth') {
+      errors.push(`${field}.auth must be "oauth"`)
+    }
+    if (
+      value.bearerTokenEnvVar !== undefined &&
+      (typeof value.bearerTokenEnvVar !== 'string' ||
+        value.bearerTokenEnvVar.length === 0)
+    ) {
+      errors.push(`${field}.bearerTokenEnvVar must be a non-empty string`)
+    }
+  }
+
+  if (value.enabled !== undefined && typeof value.enabled !== 'boolean') {
+    errors.push(`${field}.enabled must be a boolean`)
+  }
+  for (const timeoutField of ['startupTimeoutMs', 'toolTimeoutMs'] as const) {
+    const timeout = value[timeoutField]
+    if (
+      timeout !== undefined &&
+      (typeof timeout !== 'number' ||
+        !Number.isInteger(timeout) ||
+        timeout < 1)
+    ) {
+      errors.push(`${field}.${timeoutField} must be a positive integer`)
+    }
+  }
+  for (const toolsField of ['enabledTools', 'disabledTools'] as const) {
+    if (value[toolsField] !== undefined) {
+      errors.push(
+        ...validateStringArray(value[toolsField], `${field}.${toolsField}`),
+      )
+    }
+  }
+  return errors
+}
+
+function inspectKimiMcpConfig(filePath: string): {
+  errors: string[]
+  serverCount: number
+} {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(readTextFile(filePath))
+  } catch {
+    return { errors: ['file is not valid JSON'], serverCount: 0 }
+  }
+  if (!isRecord(parsed)) {
+    return { errors: ['root must be a JSON object'], serverCount: 0 }
+  }
+
+  // Kimi defaults a missing mcpServers field to an empty object, so `{}` is a
+  // valid upstream config. When present, every entry must match Kimi 0.27's
+  // stdio/HTTP/SSE schema.
+  const serversValue = parsed.mcpServers ?? {}
+  if (!isRecord(serversValue)) {
+    return {
+      errors: ['mcpServers must be an object keyed by server name'],
+      serverCount: 0,
+    }
+  }
+
+  const errors = Object.entries(serversValue).flatMap(([name, value]) =>
+    validateKimiMcpServer(name, value),
+  )
+  return { errors, serverCount: Object.keys(serversValue).length }
+}
+
+function summarizePaths(paths: string[]): string {
+  const shown = paths.slice(0, 3).join(', ')
+  return paths.length <= 3 ? shown : `${shown} (+${paths.length - 3} more)`
+}
+
+function readCorePackageVersion(): string | null {
+  try {
+    const parsed = JSON.parse(
+      readTextFile(path.join(CORE_PACKAGE_ROOT, 'package.json')),
+    ) as { version?: unknown }
+    return typeof parsed.version === 'string' && parsed.version.trim().length > 0
+      ? parsed.version.trim()
+      : null
+  } catch {
+    return null
+  }
+}
+
+function inspectKimiManifest(
+  artifactRoot: string,
+  manifestPath: string,
+): {
+  errors: string[]
+  version: string | null
+  artifactCount: number
+} {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(readTextFile(manifestPath))
+  } catch {
+    return { errors: ['file is not valid JSON'], version: null, artifactCount: 0 }
+  }
+  if (!isRecord(parsed)) {
+    return {
+      errors: ['root must be a JSON object'],
+      version: null,
+      artifactCount: 0,
+    }
+  }
+
+  const errors: string[] = []
+  const version =
+    typeof parsed.version === 'string' && parsed.version.trim().length > 0
+      ? parsed.version.trim()
+      : null
+  if (!version) errors.push('version must be a non-empty string')
+
+  const currentVersion = readCorePackageVersion()
+  if (!currentVersion) {
+    errors.push('running Core package version could not be read')
+  } else if (version && version !== currentVersion) {
+    errors.push(
+      `version ${version} does not match running Core ${currentVersion}`,
+    )
+  }
+
+  const markerPath = path.join(artifactRoot, '.specrails', 'specrails-version')
+  if (!isFile(markerPath)) {
+    errors.push('specrails-version marker is missing')
+  } else if (version && readTextFile(markerPath).trim() !== version) {
+    errors.push('specrails-version marker does not match manifest version')
+  }
+
+  if (
+    typeof parsed.installed_at !== 'string' ||
+    !Number.isFinite(Date.parse(parsed.installed_at))
+  ) {
+    errors.push('installed_at must be a valid timestamp')
+  }
+
+  const providers = Array.isArray(parsed.providers)
+    ? parsed.providers.filter(isProvider)
+    : []
+  if (
+    !Array.isArray(parsed.providers) ||
+    providers.length !== parsed.providers.length ||
+    providers.length === 0
+  ) {
+    errors.push('providers must be a non-empty array of supported providers')
+  } else {
+    if (new Set(providers).size !== providers.length) {
+      errors.push('providers must not contain duplicates')
+    }
+    if (!providers.includes('kimi')) {
+      errors.push('providers does not record kimi')
+    }
+  }
+
+  if (!isProvider(parsed.primary_provider)) {
+    errors.push('primary_provider must be a supported provider')
+  } else if (!providers.includes(parsed.primary_provider)) {
+    errors.push('primary_provider must also appear in providers')
+  }
+
+  if (!isRecord(parsed.artifacts) || Object.keys(parsed.artifacts).length === 0) {
+    errors.push('artifacts must be a non-empty checksum object')
+    return { errors, version, artifactCount: 0 }
+  }
+
+  const actualArtifacts = parsed.artifacts
+  const malformedDigests = Object.entries(actualArtifacts)
+    .filter(([, digest]) => typeof digest !== 'string' || !SHA256_DIGEST.test(digest))
+    .map(([artifact]) => artifact)
+  if (malformedDigests.length > 0) {
+    errors.push(
+      `artifacts contains invalid sha256 digests: ${summarizePaths(malformedDigests)}`,
+    )
+  }
+
+  try {
+    const expectedArtifacts = buildManifest({
+      scriptDir: CORE_PACKAGE_ROOT,
+      repoRoot: artifactRoot,
+      version: currentVersion ?? version ?? 'unknown',
+      installedAt: '1970-01-01T00:00:00Z',
+    }).artifacts
+    const actualKeys = Object.keys(actualArtifacts)
+    const expectedKeys = Object.keys(expectedArtifacts)
+    const missing = expectedKeys.filter((key) => !(key in actualArtifacts))
+    const unexpected = actualKeys.filter((key) => !(key in expectedArtifacts))
+    const changed = expectedKeys.filter(
+      (key) =>
+        key in actualArtifacts && actualArtifacts[key] !== expectedArtifacts[key],
+    )
+    if (missing.length > 0) {
+      errors.push(`artifacts is missing: ${summarizePaths(missing)}`)
+    }
+    if (unexpected.length > 0) {
+      errors.push(`artifacts has unknown entries: ${summarizePaths(unexpected)}`)
+    }
+    if (changed.length > 0) {
+      errors.push(`artifacts checksum mismatch: ${summarizePaths(changed)}`)
+    }
+  } catch {
+    errors.push('packaged Core artifact checksums could not be computed')
+  }
+
+  return {
+    errors,
+    version,
+    artifactCount: Object.keys(actualArtifacts).length,
+  }
+}
+
+function checkKimiArtifacts(args: {
+  artifactRoot: string
+  codeRoot: string
+  addPass: (message: string) => void
+  addFail: (message: string, fix: string) => void
+}): void {
+  const skillRoot = path.join(args.artifactRoot, '.kimi-code', 'skills')
+  const legacyRoleRoot = path.join(skillRoot, 'rails')
+  const staleNestedRoles = listDir(legacyRoleRoot).filter((entry) => isDir(entry))
+  if (staleNestedRoles.length > 0) {
+    args.addFail(
+      `Kimi role skills: stale nested skills/rails layout contains ` +
+        staleNestedRoles.map((entry) => path.basename(entry)).join(', '),
+      'Run: npx specrails-core update --provider kimi; resolve any reported custom-role conflict manually',
+    )
+  } else {
+    args.addPass('Kimi role layout: all roles are direct children of .kimi-code/skills')
+  }
+  const runnerRoot = path.join(args.artifactRoot, '.kimi-code', 'specrails')
+  const requiredRunnerFiles = [
+    'run-skill.mjs',
+    path.join('vendor', 'js-yaml', 'js-yaml.mjs'),
+    path.join('vendor', 'js-yaml', 'LICENSE'),
+    path.join('vendor', 'js-yaml', 'NOTICE.md'),
+  ]
+  const missingRunnerFiles = requiredRunnerFiles.filter(
+    (relative) => !isFile(path.join(runnerRoot, relative)),
+  )
+  const mismatchedRunnerFiles =
+    missingRunnerFiles.length === 0
+      ? requiredRunnerFiles.filter((relative) => {
+          const installed = path.join(runnerRoot, relative)
+          const packaged = path.join(
+            CORE_PACKAGE_ROOT,
+            'templates',
+            'kimi',
+            'specrails',
+            relative,
+          )
+          try {
+            return !readFileSync(installed).equals(readFileSync(packaged))
+          } catch {
+            return true
+          }
+        })
+      : []
+  if (
+    missingRunnerFiles.length === 0 &&
+    mismatchedRunnerFiles.length === 0
+  ) {
+    args.addPass(
+      'Kimi headless skill runner: complete managed bundle integrity verified outside the skill scanner',
+    )
+  } else if (missingRunnerFiles.length > 0) {
+    args.addFail(
+      `Kimi headless skill runner: missing ${missingRunnerFiles.join(', ')} ` +
+        'under .kimi-code/specrails',
+      'Run: npx specrails-core update --provider kimi',
+    )
+  } else {
+    args.addFail(
+      `Kimi headless skill runner: managed content mismatch in ` +
+        mismatchedRunnerFiles.join(', '),
+      'Run: npx specrails-core update --provider kimi',
+    )
+  }
+  const missingSpecrails = KIMI_MANAGED_WORKFLOW_SKILLS.filter(
+    (name) => !isFile(path.join(skillRoot, name, 'SKILL.md')),
+  )
+  if (KIMI_MANAGED_WORKFLOW_SKILLS.length === 0) {
+    args.addFail(
+      'Kimi workflow skills: packaged managed catalog is unavailable',
+      'Reinstall specrails-core, then run: npx specrails-core update --provider kimi',
+    )
+  } else if (missingSpecrails.length === 0) {
+    args.addPass(
+      `Kimi workflow skills: all ${KIMI_MANAGED_WORKFLOW_SKILLS.length} managed workflows present`,
+    )
+  } else {
+    args.addFail(
+      `Kimi workflow skills: missing ${missingSpecrails.join(', ')}`,
+      'Run: npx specrails-core update --provider kimi',
+    )
+  }
+
+  const missingOpenSpec = KIMI_REQUIRED_OPENSPEC_SKILLS.filter(
+    (name) => !isFile(path.join(skillRoot, name, 'SKILL.md')),
+  )
+  if (missingOpenSpec.length === 0) {
+    args.addPass(`Kimi OpenSpec skills: all ${KIMI_REQUIRED_OPENSPEC_SKILLS.length} present`)
+  } else {
+    args.addFail(
+      `Kimi OpenSpec skills: missing ${missingOpenSpec.join(', ')}`,
+      'Run: npx specrails-core update --provider kimi',
+    )
+  }
+
+  const legacyRoot = path.join(args.codeRoot, '.kimi', 'skills')
+  const staleLegacy = listDir(legacyRoot).filter(
+    (entry) => isDir(entry) && path.basename(entry).startsWith('openspec-'),
+  )
+  if (staleLegacy.length > 0) {
+    args.addFail(
+      `Kimi OpenSpec skills: stale generated .kimi/skills output found`,
+      'Run: npx specrails-core update --provider kimi',
+    )
+  } else {
+    args.addPass('Kimi OpenSpec layout: no stale .kimi/skills output')
+  }
+
+  const mcpPath = path.join(args.artifactRoot, '.kimi-code', 'mcp.json')
+  if (isFile(mcpPath)) {
+    const mcp = inspectKimiMcpConfig(mcpPath)
+    if (mcp.errors.length === 0) {
+      args.addPass(
+        `.kimi-code/mcp.json: valid (${mcp.serverCount} server(s))`,
+      )
+    } else {
+      args.addFail(
+        `.kimi-code/mcp.json: invalid (${mcp.errors.join('; ')})`,
+        'Fix the JSON using `kimi` → `/mcp-config`, or restore a valid config and retry',
+      )
+    }
+  } else {
+    args.addFail(
+      '.kimi-code/mcp.json: missing',
+      'Run: npx specrails-core update --provider kimi',
+    )
+  }
+  const manifestPath = path.join(args.artifactRoot, '.specrails', 'specrails-manifest.json')
+  if (isFile(manifestPath)) {
+    const manifest = inspectKimiManifest(args.artifactRoot, manifestPath)
+    if (manifest.errors.length === 0) {
+      args.addPass(
+        `SpecRails manifest: valid for Core ${manifest.version} ` +
+          `(${manifest.artifactCount} packaged source checksums verified; records kimi)`,
+      )
+    } else {
+      args.addFail(
+        `SpecRails manifest: invalid (${manifest.errors.join('; ')})`,
+        'Run: npx specrails-core update --provider kimi',
+      )
+    }
+  } else {
+    args.addFail(
+      'SpecRails manifest: missing',
+      'Run: npx specrails-core update --provider kimi',
+    )
+  }
 }
 
 function appendDoctorLog(passed: number, failed: number): void {

--- a/src/installer/commands/framework.test.ts
+++ b/src/installer/commands/framework.test.ts
@@ -33,6 +33,46 @@ function setupFakeScriptDir(scriptDir: string): void {
     path.join(scriptDir, 'templates', 'commands', 'specrails', 'implement.md'),
     '/specrails:implement\n',
   )
+  writeFileLf(
+    path.join(scriptDir, 'templates', 'kimi', 'specrails', 'run-skill.mjs'),
+    '// managed Kimi runner fixture\n',
+  )
+  writeFileLf(
+    path.join(
+      scriptDir,
+      'templates',
+      'kimi',
+      'specrails',
+      'vendor',
+      'js-yaml',
+      'js-yaml.mjs',
+    ),
+    '// vendored js-yaml fixture\n',
+  )
+  writeFileLf(
+    path.join(
+      scriptDir,
+      'templates',
+      'kimi',
+      'specrails',
+      'vendor',
+      'js-yaml',
+      'LICENSE',
+    ),
+    'fixture license\n',
+  )
+  writeFileLf(
+    path.join(
+      scriptDir,
+      'templates',
+      'kimi',
+      'specrails',
+      'vendor',
+      'js-yaml',
+      'NOTICE.md',
+    ),
+    'fixture notice\n',
+  )
   writeFileLf(path.join(scriptDir, 'commands', 'enrich.md'), 'enrich')
   writeFileLf(path.join(scriptDir, 'commands', 'doctor.md'), 'doctor')
 }
@@ -106,6 +146,37 @@ describe('framework subcommands (install-framework / assemble)', () => {
         runInstallFramework({ 'framework-dir': fwDir, provider: 'bogus', version: '5.0.0' }),
       ).rejects.toThrow(/provider value must be/)
     })
+
+    it.each([
+      ['dot segment', '.'],
+      ['parent dot segment', '..'],
+      ['traversal', '../victim'],
+      ['POSIX separator', '5.0.0/child'],
+      ['Windows separator', '5.0.0\\child'],
+      ['NUL', '5.0.0\0child'],
+    ])('rejects an unsafe --version (%s)', async (label, version) => {
+      await expect(
+        runInstallFramework({
+          'framework-dir': fwDir,
+          provider: 'claude',
+          version,
+        }),
+      ).rejects.toThrow(/safe framework version identifier/)
+      if (label === 'traversal') {
+        expect(pathExists(path.join(tmpDir, 'victim'))).toBe(false)
+      }
+    })
+
+    it('accepts a safe semver prerelease with build metadata', async () => {
+      const version = '5.0.0-beta.1+build.7'
+      const out = await runInstallFramework({
+        'framework-dir': fwDir,
+        provider: 'claude',
+        version,
+      })
+      expect(out.version).toBe(version)
+      expect(isDir(path.join(fwDir, version, '.claude', 'agents'))).toBe(true)
+    })
   })
 
   describe('runAssemble', () => {
@@ -167,6 +238,18 @@ describe('framework subcommands (install-framework / assemble)', () => {
         runAssemble({ 'framework-dir': fwDir, provider: 'claude', version: '5.0.0', 'code-root': tmpDir }),
       ).rejects.toThrow(/workspace is required/)
     })
+
+    it('rejects an unsafe --version before resolving framework content', async () => {
+      await expect(
+        runAssemble({
+          workspace: path.join(tmpDir, 'ws-unsafe-version'),
+          'framework-dir': fwDir,
+          provider: 'claude',
+          version: '../victim',
+          'code-root': tmpDir,
+        }),
+      ).rejects.toThrow(/safe framework version identifier/)
+    })
   })
 
   describe('--no-swap + swap-current (multi-provider materialize-all-then-swap-once)', () => {
@@ -197,6 +280,74 @@ describe('framework subcommands (install-framework / assemble)', () => {
 
     it('swap-current rejects a missing --framework-dir', async () => {
       await expect(runSwapCurrent({ version: '5.0.0' })).rejects.toThrow(/framework-dir is required/)
+    })
+
+    it('swap-current rejects an unsafe --version before registry resolution', async () => {
+      await expect(
+        runSwapCurrent({ 'framework-dir': fwDir, version: '..\\victim' }),
+      ).rejects.toThrow(/safe framework version identifier/)
+    })
+
+    it('swap-current rejects a nonexistent version without moving current', async () => {
+      await runInstallFramework({
+        'framework-dir': fwDir,
+        provider: 'claude',
+        version: '5.0.0',
+      })
+      const before = realpathSafe(path.join(fwDir, 'current'))
+
+      await expect(
+        runSwapCurrent({ 'framework-dir': fwDir, version: 'does-not-exist' }),
+      ).rejects.toThrow(/is not materialized/)
+      expect(realpathSafe(path.join(fwDir, 'current'))).toBe(before)
+    })
+
+    it('swap-current rejects a target missing a provider served by current', async () => {
+      await runInstallFramework({
+        'framework-dir': fwDir,
+        provider: 'claude',
+        version: '4.11.0',
+      })
+      const before = realpathSafe(path.join(fwDir, 'current'))
+
+      // Only Kimi is present in the destination. The current Claude framework
+      // still has live consumers, so exposing this target would break them.
+      await runInstallFramework({
+        'framework-dir': fwDir,
+        provider: 'kimi',
+        version: '4.12.0',
+        'no-swap': true,
+      })
+      await expect(
+        runSwapCurrent({
+          'framework-dir': fwDir,
+          version: '4.12.0',
+          providers: 'claude,kimi',
+        }),
+      ).rejects.toThrow(/incomplete.*claude: missing \.claude\//)
+      expect(realpathSafe(path.join(fwDir, 'current'))).toBe(before)
+    })
+
+    it('swap-current rejects corrupt managed content even when the stamp exists', async () => {
+      await runInstallFramework({
+        'framework-dir': fwDir,
+        provider: 'claude',
+        version: '4.12.0',
+        'no-swap': true,
+      })
+      writeFileLf(
+        path.join(fwDir, '4.12.0', '.claude', 'agents', 'sr-architect.md'),
+        'corrupt after materialize\n',
+      )
+
+      await expect(
+        runSwapCurrent({
+          'framework-dir': fwDir,
+          version: '4.12.0',
+          providers: 'claude',
+        }),
+      ).rejects.toThrow(/managed content does not match stamp/)
+      expect(pathExists(path.join(fwDir, 'current'))).toBe(false)
     })
   })
 

--- a/src/installer/commands/framework.ts
+++ b/src/installer/commands/framework.ts
@@ -7,6 +7,10 @@ import { pathExists, readTextFile } from '../util/fs.js'
 
 import { type Provider } from '../phases/provider-detect.js'
 import { derivedPaths } from '../phases/provider-detect.js'
+import {
+  assertFrameworkVersionComplete,
+  resolveRequiredFrameworkProviders,
+} from '../phases/framework-lifecycle.js'
 import { assembleProjectWorkspace, ensureCurrentSymlink } from '../phases/scaffold.js'
 import { ensureFramework } from './init.js'
 
@@ -38,6 +42,11 @@ export interface InstallFrameworkFlags {
 export interface SwapCurrentFlags {
   'framework-dir'?: string | boolean
   version?: string | boolean
+  /**
+   * Comma-separated provider set the caller materialized for this transition.
+   * The swap validator unions it with globally registered/current providers.
+   */
+  providers?: string | boolean
 }
 
 export interface AssembleFlags {
@@ -62,6 +71,8 @@ export interface InstallFrameworkOutcome {
 export interface SwapCurrentOutcome {
   frameworkDir: string
   version: string
+  /** Complete provider set validated before the pointer was moved. */
+  providers: Provider[]
 }
 
 export interface AssembleOutcome {
@@ -80,12 +91,55 @@ function requireString(value: string | boolean | undefined, flagName: string): s
   return value
 }
 
+const SAFE_FRAMEWORK_VERSION = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$/
+
+/**
+ * Framework versions become directory names under the shared framework store.
+ * Keep this deliberately narrower than an arbitrary path segment so a version
+ * accepted on POSIX remains safe when the same registry/store is consumed on
+ * Windows. It accepts normal semver, prerelease, and build identifiers while
+ * rejecting separators, dot segments, controls, and traversal payloads.
+ */
+function parseFrameworkVersion(value: string | boolean | undefined): string {
+  const version = requireString(value, 'version')
+  if (
+    version === '.' ||
+    version === '..' ||
+    version.includes('\0') ||
+    !SAFE_FRAMEWORK_VERSION.test(version)
+  ) {
+    throw new InstallerError(
+      `--version must be a safe framework version identifier, got: ${JSON.stringify(version)}`,
+      40,
+    )
+  }
+  return version
+}
+
 function parseProvider(value: string | boolean | undefined): Provider {
   const v = requireString(value, 'provider')
-  if (v !== 'claude' && v !== 'codex' && v !== 'gemini') {
-    throw new InstallerError(`--provider value must be 'claude', 'codex', or 'gemini', got: ${v}`, 40)
+  if (v !== 'claude' && v !== 'codex' && v !== 'gemini' && v !== 'kimi') {
+    throw new InstallerError(
+      `--provider value must be 'claude', 'codex', 'gemini', or 'kimi', got: ${v}`,
+      40,
+    )
   }
   return v
+}
+
+function parseProviders(value: string | boolean | undefined): Provider[] {
+  if (value === undefined) return []
+  const raw = requireString(value, 'providers')
+  const providers: Provider[] = []
+  for (const item of raw.split(',')) {
+    const provider = item.trim()
+    if (provider.length === 0) continue
+    providers.push(parseProvider(provider))
+  }
+  if (providers.length === 0) {
+    throw new InstallerError('--providers must contain at least one provider', 40)
+  }
+  return [...new Set(providers)]
 }
 
 /**
@@ -113,7 +167,7 @@ export async function runInstallFramework(
   const scriptDir = resolveScriptDir()
   const frameworkDir = path.resolve(requireString(flags['framework-dir'], 'framework-dir'))
   const provider = parseProvider(flags.provider)
-  const version = requireString(flags.version, 'version')
+  const version = parseFrameworkVersion(flags.version)
   const { providerDir } = derivedPaths(provider)
 
   const swapCurrent = flags['no-swap'] !== true
@@ -143,11 +197,18 @@ export async function runInstallFramework(
  */
 export async function runSwapCurrent(flags: SwapCurrentFlags): Promise<SwapCurrentOutcome> {
   const frameworkDir = path.resolve(requireString(flags['framework-dir'], 'framework-dir'))
-  const version = requireString(flags.version, 'version')
+  const version = parseFrameworkVersion(flags.version)
+  const requested = parseProviders(flags.providers)
+  const required = resolveRequiredFrameworkProviders({
+    frameworkDir,
+    requested,
+    registryHome: process.env.SPECRAILS_REGISTRY_HOME,
+  })
   step(`Swapping framework current → ${version} (${frameworkDir})`)
+  const providers = assertFrameworkVersionComplete(frameworkDir, version, required)
   ensureCurrentSymlink(frameworkDir, version)
-  ok(`current → ${version}`)
-  return { frameworkDir, version }
+  ok(`current → ${version} (${providers.join(', ')})`)
+  return { frameworkDir, version, providers }
 }
 
 /**
@@ -160,7 +221,7 @@ export async function runAssemble(flags: AssembleFlags): Promise<AssembleOutcome
   const workspace = path.resolve(requireString(flags.workspace, 'workspace'))
   const frameworkDir = path.resolve(requireString(flags['framework-dir'], 'framework-dir'))
   const provider = parseProvider(flags.provider)
-  const version = requireString(flags.version, 'version')
+  const version = parseFrameworkVersion(flags.version)
   const codeRoot = path.resolve(requireString(flags['code-root'], 'code-root'))
   const { providerDir } = derivedPaths(provider)
 

--- a/src/installer/commands/init.test.ts
+++ b/src/installer/commands/init.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { isDir, isSymlink, mkdirp, pathExists, readTextFile, writeFileLf } from '../util/fs.js'
 import { initRepo } from '../util/git.js'
 import { frameworkRoot, resolveArtifacts } from '../util/registry.js'
-import { runInit } from './init.js'
+import { KIMI_REQUIRED_OPENSPEC_SKILLS, runInit } from './init.js'
 
 /**
  * Integration-style tests for `runInit`. Uses a real filesystem
@@ -24,13 +24,56 @@ import { runInit } from './init.js'
 
 const IS_WIN = process.platform === 'win32'
 
-async function setupFakeScriptDir(scriptDir: string): Promise<void> {
-  writeFileLf(path.join(scriptDir, 'package.json'), `${JSON.stringify({ version: '4.2.0' })}\n`)
-  writeFileLf(path.join(scriptDir, 'templates', 'agents', 'sr-architect.md'), 'arch')
-  writeFileLf(path.join(scriptDir, 'templates', 'agents', 'sr-developer.md'), 'dev')
-  writeFileLf(path.join(scriptDir, 'templates', 'agents', 'sr-reviewer.md'), 'reviewer')
+async function setupFakeScriptDir(
+  scriptDir: string,
+  version = '4.2.0',
+): Promise<void> {
+  writeFileLf(path.join(scriptDir, 'package.json'), `${JSON.stringify({ version })}\n`)
+  writeFileLf(path.join(scriptDir, 'templates', 'agents', 'sr-architect.md'), `${version}-arch`)
+  writeFileLf(path.join(scriptDir, 'templates', 'agents', 'sr-developer.md'), `${version}-dev`)
+  writeFileLf(path.join(scriptDir, 'templates', 'agents', 'sr-reviewer.md'), `${version}-reviewer`)
   writeFileLf(path.join(scriptDir, 'templates', 'agents', 'sr-merge-resolver.md'), 'merge')
   writeFileLf(path.join(scriptDir, 'templates', 'rules', 'general.md'), 'rules')
+  writeFileLf(
+    path.join(scriptDir, 'templates', 'kimi', 'specrails', 'run-skill.mjs'),
+    '// managed Kimi runner fixture\n',
+  )
+  writeFileLf(
+    path.join(
+      scriptDir,
+      'templates',
+      'kimi',
+      'specrails',
+      'vendor',
+      'js-yaml',
+      'js-yaml.mjs',
+    ),
+    '// vendored js-yaml fixture\n',
+  )
+  writeFileLf(
+    path.join(
+      scriptDir,
+      'templates',
+      'kimi',
+      'specrails',
+      'vendor',
+      'js-yaml',
+      'LICENSE',
+    ),
+    'js-yaml fixture license\n',
+  )
+  writeFileLf(
+    path.join(
+      scriptDir,
+      'templates',
+      'kimi',
+      'specrails',
+      'vendor',
+      'js-yaml',
+      'NOTICE.md',
+    ),
+    'js-yaml fixture notice\n',
+  )
   writeFileLf(path.join(scriptDir, 'commands', 'enrich.md'), 'enrich')
   writeFileLf(path.join(scriptDir, 'commands', 'doctor.md'), 'doctor')
 }
@@ -102,6 +145,7 @@ describe('runInit', () => {
       '.claude',
       '.codex',
       '.gemini',
+      '.kimi-code',
       'CLAUDE.md',
       'AGENTS.md',
       'GEMINI.md',
@@ -173,7 +217,27 @@ describe('runInit', () => {
     assertRepoHasNoSpecrailsArtifacts(repoRoot)
   })
 
-  it('reads provider + tier from install-config.yaml when --from-config is passed', async () => {
+  it('treats -y exactly like --yes and initializes a fresh non-git directory', async () => {
+    const scriptDir = path.join(tmpDir, 'core-short-y')
+    const repoRoot = path.join(tmpDir, 'repo-short-y')
+    mkdirp(repoRoot)
+    await setupFakeScriptDir(scriptDir)
+    process.env.SPECRAILS_CORE_SCRIPT_DIR = scriptDir
+
+    const result = await runInit({
+      'root-dir': repoRoot,
+      y: true,
+      provider: 'claude',
+      quick: true,
+      relocate: true,
+    })
+
+    expect(result.provider).toBe('claude')
+    expect(pathExists(path.join(repoRoot, '.git'))).toBe(true)
+    assertRepoHasNoSpecrailsArtifacts(repoRoot)
+  })
+
+  it('accepts matching --provider + --from-config from the TUI re-entry flow', async () => {
     const scriptDir = path.join(tmpDir, 'core')
     const repoRoot = path.join(tmpDir, 'repo')
     mkdirp(repoRoot)
@@ -196,6 +260,7 @@ describe('runInit', () => {
     const result = await runInit({
       'root-dir': repoRoot,
       yes: true,
+      provider: 'claude',
       'from-config': true,
       relocate: true,
     })
@@ -214,11 +279,18 @@ describe('runInit', () => {
     expect(pathExists(path.join(repoRoot, '.specrails', 'setup-templates'))).toBe(false)
   })
 
-  it('accepts --provider codex and produces a codex install (.codex/ + AGENTS.md)', async () => {
+  it('uses explicit --provider as fallback when --from-config does not exist', async () => {
     const repoRoot = path.join(tmpDir, 'repo-codex')
     mkdirp(repoRoot)
     await initRepo(repoRoot)
-    const result = await runInit({ 'root-dir': repoRoot, yes: true, provider: 'codex', quick: true, relocate: true })
+    const result = await runInit({
+      'root-dir': repoRoot,
+      yes: true,
+      provider: 'codex',
+      'from-config': true,
+      quick: true,
+      relocate: true,
+    })
     expect(result.provider).toBe('codex')
     const ws = workspaceFor(repoRoot)
     // Provider-derived layout: .codex/ + AGENTS.md — under the workspace.
@@ -234,13 +306,54 @@ describe('runInit', () => {
     assertRepoHasNoSpecrailsArtifacts(repoRoot)
   })
 
-  it('rejects --provider with an unknown value', async () => {
+  it('rejects invalid --provider values even when --from-config is present', async () => {
     const repoRoot = path.join(tmpDir, 'repo-unknown')
     mkdirp(repoRoot)
     await initRepo(repoRoot)
     await expect(
-      runInit({ 'root-dir': repoRoot, yes: true, provider: 'turbofake' as never }),
-    ).rejects.toThrow(/must be 'claude', 'codex', or 'gemini'/)
+      runInit({
+        'root-dir': repoRoot,
+        yes: true,
+        provider: 'turbofake',
+        'from-config': true,
+      }),
+    ).rejects.toThrow(/must be 'claude', 'codex', 'gemini', or 'kimi'/)
+    await expect(
+      runInit({
+        'root-dir': repoRoot,
+        yes: true,
+        provider: true,
+        'from-config': true,
+      }),
+    ).rejects.toThrow(/must be 'claude', 'codex', 'gemini', or 'kimi'/)
+  })
+
+  it('rejects conflicting --provider + --from-config instead of silently overriding', async () => {
+    const repoRoot = path.join(tmpDir, 'repo-provider-conflict')
+    mkdirp(repoRoot)
+    await initRepo(repoRoot)
+    writeFileLf(
+      path.join(repoRoot, '.specrails', 'install-config.yaml'),
+      [
+        'version: 1',
+        'provider: kimi',
+        'tier: quick',
+        'agents:',
+        '  selected: [sr-architect]',
+        '',
+      ].join('\n'),
+    )
+
+    await expect(
+      runInit({
+        'root-dir': repoRoot,
+        yes: true,
+        provider: 'claude',
+        'from-config': true,
+      }),
+    ).rejects.toThrow(
+      /--provider 'claude' conflicts with provider 'kimi' in .*install-config\.yaml/,
+    )
   })
 
   it('installs IN-REPO by default (no --relocate, no pre-existing registry entry): real files, not symlinks', async () => {
@@ -315,6 +428,78 @@ describe('runInit', () => {
     expect(ws).not.toBe(repoRoot)
     expect(pathExists(path.join(ws, '.claude', 'agents', 'sr-architect.md'))).toBe(true)
     expect(pathExists(path.join(ws, '.specrails', 'specrails-version'))).toBe(true)
+  })
+
+  it('carries Claude 4.11 forward when a relocated project adds Kimi on 4.12', async () => {
+    const scriptDir = path.join(tmpDir, 'core-cross-version')
+    const repoRoot = path.join(tmpDir, 'repo-cross-version')
+    mkdirp(repoRoot)
+    await setupFakeScriptDir(scriptDir, '4.11.0')
+    await initRepo(repoRoot)
+    process.env.SPECRAILS_CORE_SCRIPT_DIR = scriptDir
+
+    await runInit({
+      'root-dir': repoRoot,
+      yes: true,
+      provider: 'claude',
+      quick: true,
+      relocate: true,
+    })
+
+    const ws = workspaceFor(repoRoot)
+    const fw = frameworkFor()
+    const claudeCommands = path.join(ws, '.claude', 'commands')
+    const claudeArchitect = path.join(ws, '.claude', 'agents', 'sr-architect.md')
+    writeFileLf(
+      path.join(ws, '.claude', 'agents', 'custom-owner.md'),
+      'user-owned-claude-agent\n',
+    )
+    expect(realpathSync(claudeCommands)).toBe(
+      realpathSync(path.join(fw, '4.11.0', '.claude', 'commands')),
+    )
+    expect(readTextFile(claudeArchitect)).toBe('4.11.0-arch')
+
+    // Simulate installing the next Core release while selecting Kimi. Because
+    // `current` is global, the 4.12 target must be complete for BOTH providers
+    // before one swap makes it visible.
+    await setupFakeScriptDir(scriptDir, '4.12.0')
+    await runInit({
+      'root-dir': repoRoot,
+      yes: true,
+      provider: 'kimi',
+      quick: true,
+      relocate: true,
+    })
+
+    expect(realpathSync(path.join(fw, 'current'))).toBe(
+      realpathSync(path.join(fw, '4.12.0')),
+    )
+    expect(isDir(path.join(fw, '4.12.0', '.claude'))).toBe(true)
+    expect(isDir(path.join(fw, '4.12.0', '.kimi-code'))).toBe(true)
+
+    // Existing Claude links remain live and now resolve through the complete
+    // 4.12 target; user-owned files in the workspace are byte-preserved.
+    expect(realpathSync(claudeCommands)).toBe(
+      realpathSync(path.join(fw, '4.12.0', '.claude', 'commands')),
+    )
+    expect(readTextFile(claudeArchitect)).toBe('4.12.0-arch')
+    expect(
+      readTextFile(path.join(ws, '.claude', 'agents', 'custom-owner.md')),
+    ).toBe('user-owned-claude-agent\n')
+
+    // The newly selected provider is assembled from the same destination
+    // version, while the previous version remains available for rollback.
+    expect(
+      pathExists(path.join(ws, '.kimi-code', 'skills', 'sr-architect', 'SKILL.md')),
+    ).toBe(true)
+    expect(pathExists(path.join(ws, '.kimi-code', 'specrails', 'run-skill.mjs'))).toBe(true)
+    expect(isDir(path.join(fw, '4.11.0', '.claude'))).toBe(true)
+
+    const manifest = JSON.parse(
+      readTextFile(path.join(ws, '.specrails', 'specrails-manifest.json')),
+    ) as { providers: string[]; primary_provider: string }
+    expect(manifest.providers).toEqual(['claude', 'kimi'])
+    expect(manifest.primary_provider).toBe('claude')
   })
 
   it('relocates when SPECRAILS_RELOCATE=1 is set (env opt-in)', async () => {
@@ -394,4 +579,77 @@ describe('runInit', () => {
       pathExists(path.join(repoRoot, '.claude', 'skills', 'openspec-propose', 'SKILL.md')),
     ).toBe(true)
   })
+
+  it.skipIf(process.platform === 'win32')(
+    'initializes Kimi in-repo and normalizes all OpenSpec skills',
+    async () => {
+      const scriptDir = path.join(tmpDir, 'core-kimi')
+      const repoRoot = path.join(tmpDir, 'repo-kimi')
+      const binDir = path.join(tmpDir, 'bin-kimi')
+      mkdirp(repoRoot)
+      mkdirp(binDir)
+      await setupFakeScriptDir(scriptDir)
+      for (const command of ['implement', 'batch-implement', 'retry', 'doctor']) {
+        writeFileLf(
+          path.join(scriptDir, 'templates', 'commands', 'specrails', `${command}.md`),
+          `/specrails:${command}\n`,
+        )
+      }
+      await initRepo(repoRoot)
+      process.env.SPECRAILS_CORE_SCRIPT_DIR = scriptDir
+      process.env.SPECRAILS_SKIP_OPENSPEC_INIT = '0'
+
+      const fakeOpenSpec = path.join(binDir, 'openspec')
+      writeFileLf(
+        fakeOpenSpec,
+        [
+          '#!/bin/sh',
+          'if [ "$1" = "init" ]; then',
+          '  [ "$2" = "--tools" ] && [ "$3" = "kimi" ] || exit 31',
+          '  [ "$4" = "--profile" ] && [ "$5" = "custom" ] || exit 32',
+          '  [ -f "$XDG_CONFIG_HOME/openspec/config.json" ] || exit 33',
+          '  repo="$6"',
+          '  mkdir -p "$repo/openspec/changes/archive" "$repo/openspec/specs"',
+          `  for skill in ${KIMI_REQUIRED_OPENSPEC_SKILLS.join(' ')}; do`,
+          '    mkdir -p "$repo/.kimi/skills/$skill"',
+          '    printf "%s\\n" "---" "name: $skill" "description: generated" "---" > "$repo/.kimi/skills/$skill/SKILL.md"',
+          '  done',
+          '  exit 0',
+          'fi',
+          'exit 0',
+          '',
+        ].join('\n'),
+      )
+      chmodSync(fakeOpenSpec, 0o755)
+      process.env.SPECRAILS_OPENSPEC_BIN = fakeOpenSpec
+
+      const result = await runInit({
+        'root-dir': repoRoot,
+        yes: true,
+        provider: 'kimi',
+        quick: true,
+      })
+
+      expect(result.provider).toBe('kimi')
+      expect(pathExists(path.join(repoRoot, '.kimi-code', 'AGENTS.md'))).toBe(true)
+      expect(pathExists(path.join(repoRoot, '.kimi-code', 'mcp.json'))).toBe(true)
+      expect(pathExists(path.join(repoRoot, 'AGENTS.md'))).toBe(false)
+      expect(
+        pathExists(
+          path.join(repoRoot, '.kimi-code', 'skills', 'specrails-implement', 'SKILL.md'),
+        ),
+      ).toBe(true)
+      for (const skill of KIMI_REQUIRED_OPENSPEC_SKILLS) {
+        expect(
+          pathExists(path.join(repoRoot, '.kimi-code', 'skills', skill, 'SKILL.md')),
+        ).toBe(true)
+      }
+      expect(pathExists(path.join(repoRoot, '.kimi'))).toBe(false)
+      const manifest = JSON.parse(
+        readTextFile(path.join(repoRoot, '.specrails', 'specrails-manifest.json')),
+      ) as { providers: string[]; primary_provider: string }
+      expect(manifest.providers).toEqual(['kimi'])
+      expect(manifest.primary_provider).toBe('kimi')
+    },
+  )
 })

--- a/src/installer/commands/init.ts
+++ b/src/installer/commands/init.ts
@@ -1,10 +1,28 @@
+import {
+  copyFileSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+} from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { InstallerError } from '../util/errors.js'
 import { runCommand } from '../util/exec.js'
 import { info, ok, step } from '../util/logger.js'
-import { readTextFile, pathExists } from '../util/fs.js'
+import {
+  isDir,
+  listDir,
+  pathExists,
+  readTextFile,
+  removePath,
+  writeFileLf,
+} from '../util/fs.js'
 
 import {
   type Provider,
@@ -14,9 +32,9 @@ import {
 } from '../phases/install-config.js'
 import { checkPrerequisites } from '../phases/prereqs.js'
 import { derivedPaths } from '../phases/provider-detect.js'
+import { materializeFrameworkVersion } from '../phases/framework-lifecycle.js'
 import {
   assembleProjectWorkspace,
-  ensureCurrentSymlink,
   installFramework,
 } from '../phases/scaffold.js'
 import { frameworkRoot, resolveArtifacts } from '../util/registry.js'
@@ -28,13 +46,13 @@ import { frameworkRoot, resolveArtifacts } from '../util/registry.js'
  * bin/specrails-core.cjs until Phase 5):
  *   --root-dir <path>     Target repo (default: cwd)
  *   --yes / -y            Non-interactive; auto-init git + accept defaults
- *   --provider <claude>   Force provider (only `claude` accepted in v1)
+ *   --provider <name>     Force provider (claude, codex, gemini, or kimi)
  *   --from-config [<p>]   Read provider + tier from install-config.yaml
  *   --quick               Quick tier (direct template placement, skip enrich)
  *   --relocate            Relocate artifacts to the $HOME workspace (symlinked
  *                         from the bundled framework) instead of installing them
  *                         IN-REPO. Default is in-repo so a standalone user's
- *                         `claude`/`codex`/`gemini` finds the agents/commands in
+ *                         `claude`/`codex`/`gemini`/`kimi` finds its artifacts in
  *                         their own repo. specrails-desktop pre-creates a registry
  *                         entry (so it always relocates regardless of this flag);
  *                         standalone users opt in with `--relocate` or
@@ -44,6 +62,7 @@ import { frameworkRoot, resolveArtifacts } from '../util/registry.js'
 export interface InitFlags {
   'root-dir'?: string | boolean
   yes?: boolean
+  y?: boolean
   provider?: string | boolean
   'from-config'?: string | boolean
   quick?: boolean
@@ -69,12 +88,32 @@ export async function runInit(flags: InitFlags): Promise<InitResult> {
   const repoRoot = path.resolve(
     typeof flags['root-dir'] === 'string' ? flags['root-dir'] : process.cwd(),
   )
-  const autoYes = flags.yes === true
+  const autoYes = flags.yes === true || flags.y === true
   const skipPrereqs = process.env.SPECRAILS_SKIP_PREREQS === '1'
+
+  // Validate an explicit provider before consulting --from-config. The TUI
+  // intentionally re-enters init with BOTH flags; accepting that flow is safe
+  // only when the generated config agrees with the original explicit choice.
+  let explicitProvider: Provider | undefined
+  if (flags.provider !== undefined) {
+    if (
+      typeof flags.provider !== 'string' ||
+      (flags.provider !== 'claude' &&
+        flags.provider !== 'codex' &&
+        flags.provider !== 'gemini' &&
+        flags.provider !== 'kimi')
+    ) {
+      throw new InstallerError(
+        `--provider value must be 'claude', 'codex', 'gemini', or 'kimi', got: ${String(flags.provider)}`,
+        40,
+      )
+    }
+    explicitProvider = flags.provider
+  }
 
   // --from-config: read provider + tier from yaml.
   const fromConfigFlag = flags['from-config']
-  let providerHint: Provider | undefined
+  let providerHint: Provider | undefined = explicitProvider
   let tierHint: Tier | undefined
   let selectedAgentsHint: string[] | undefined
 
@@ -83,21 +122,23 @@ export async function runInit(flags: InitFlags): Promise<InitResult> {
     const resolved = resolveConfigPath(repoRoot, explicitPath)
     const config = loadInstallConfig(resolved)
     if (config) {
+      if (explicitProvider && explicitProvider !== config.provider) {
+        throw new InstallerError(
+          `--provider '${explicitProvider}' conflicts with provider '${config.provider}' in ${resolved}`,
+          40,
+        )
+      }
       providerHint = config.provider
       tierHint = config.tier
       selectedAgentsHint = config.agents.selected
       info(`Loaded install config from ${resolved}`)
     } else {
-      info(`install-config.yaml not found at ${resolved} — falling back to auto-detection`)
-    }
-  } else if (typeof flags.provider === 'string') {
-    if (flags.provider !== 'claude' && flags.provider !== 'codex' && flags.provider !== 'gemini') {
-      throw new InstallerError(
-        `--provider value must be 'claude', 'codex', or 'gemini', got: ${flags.provider}`,
-        40,
+      info(
+        `install-config.yaml not found at ${resolved} — falling back to ${
+          explicitProvider ? `explicit provider '${explicitProvider}'` : 'auto-detection'
+        }`,
       )
     }
-    providerHint = flags.provider as Provider
   }
 
   if (flags.quick === true) {
@@ -132,6 +173,18 @@ export async function runInit(flags: InitFlags): Promise<InitResult> {
     providers: [prereqs.provider],
     coreVersion: version,
   })
+  // An existing Core-owned relocated entry is also the durable provider
+  // inventory. Merge this install's provider without reallocating legacy
+  // in-repo installs; Desktop-owned entries remain read-only in the resolver.
+  if (artifactRoot !== codeRoot) {
+    resolveArtifacts(repoRoot, {
+      allocate: true,
+      allocator: 'core-standalone',
+      home: process.env.SPECRAILS_REGISTRY_HOME,
+      providers: [prereqs.provider],
+      coreVersion: version,
+    })
+  }
   // In-repo when the resolution did NOT relocate the artifacts out of the repo.
   const inRepo = artifactRoot === codeRoot
 
@@ -174,12 +227,14 @@ export async function runInit(flags: InitFlags): Promise<InitResult> {
   }
 
   // openspec STAYS in the repo (codeRoot) — unchanged behaviour.
-  await installOpenSpecProject(codeRoot, prereqs.provider)
+  await installOpenSpecProject(codeRoot, prereqs.provider, artifactRoot)
 
   const tier: Tier = tierHint ?? 'full'
   if (tier === 'full') {
     step('Next steps')
-    info('Run `/specrails:enrich` inside Claude Code to complete your setup.')
+    const enrichCommand =
+      prereqs.provider === 'kimi' ? '/skill:specrails-enrich' : '/specrails:enrich'
+    info(`Run \`${enrichCommand}\` inside your selected provider to complete your setup.`)
   } else {
     step('Installation complete')
     info('Quick tier: agents + rules were placed directly; enrich not required.')
@@ -205,6 +260,13 @@ export interface EnsureFrameworkInput {
   version: string
   selectedAgents?: string[]
   /**
+   * Additional providers that must remain available through the global
+   * `framework/current` pointer after this version transition.
+   */
+  requiredProviders?: Provider[]
+  /** Registry home override used while computing the global provider union. */
+  registryHome?: string
+  /**
    * When false, MATERIALIZE the provider subtree but do NOT swap
    * `<frameworkDir>/current` to point at `<version>`. The caller is responsible
    * for the single `ensureCurrentSymlink(frameworkDir, version)` swap AFTER all
@@ -229,17 +291,29 @@ export interface EnsureFrameworkInput {
  *   ensureCurrentSymlink(frameworkDir, version) // single atomic swap at the end
  */
 export function ensureFramework(input: EnsureFrameworkInput): void {
-  installFramework({
+  if (input.swapCurrent === false) {
+    installFramework({
+      scriptDir: input.scriptDir,
+      frameworkDir: input.frameworkDir,
+      provider: input.provider,
+      providerDir: input.providerDir,
+      version: input.version,
+      selectedAgents: input.selectedAgents,
+    })
+    return
+  }
+
+  // `current` is global, not scoped to this project/provider. Carry forward the
+  // requested provider, every globally registered provider, and every provider
+  // represented by the old current version; materialize all without swapping,
+  // validate the complete destination, then move the pointer exactly once.
+  materializeFrameworkVersion({
     scriptDir: input.scriptDir,
     frameworkDir: input.frameworkDir,
-    provider: input.provider,
-    providerDir: input.providerDir,
     version: input.version,
-    selectedAgents: input.selectedAgents,
+    requested: [input.provider, ...(input.requiredProviders ?? [])],
+    registryHome: input.registryHome,
   })
-  if (input.swapCurrent !== false) {
-    ensureCurrentSymlink(input.frameworkDir, input.version)
-  }
 }
 
 /**
@@ -310,7 +384,10 @@ export function buildOpenSpecInvocation(
 ): { bin: string; args: string[] } {
   const bin = env.SPECRAILS_OPENSPEC_BIN
   const node = env.SPECRAILS_OPENSPEC_NODE
-  const initArgs = ['init', '--tools', provider, repoRoot]
+  const initArgs =
+    provider === 'kimi'
+      ? ['init', '--tools', provider, '--profile', 'custom', repoRoot]
+      : ['init', '--tools', provider, repoRoot]
 
   if (bin && node) {
     // Form 1: bundled offline — run the node CLI through the given node exe.
@@ -334,25 +411,365 @@ export function buildOpenSpecInvocation(
   }
 }
 
-async function installOpenSpecProject(repoRoot: string, provider: Provider): Promise<void> {
+export const KIMI_REQUIRED_OPENSPEC_SKILLS = [
+  'openspec-propose',
+  'openspec-explore',
+  'openspec-new-change',
+  'openspec-continue-change',
+  'openspec-apply-change',
+  'openspec-ff-change',
+  'openspec-sync-specs',
+  'openspec-archive-change',
+  'openspec-bulk-archive-change',
+  'openspec-verify-change',
+  'openspec-onboard',
+] as const
+
+const OPENSPEC_ALL_WORKFLOWS = [
+  'propose',
+  'explore',
+  'new',
+  'continue',
+  'apply',
+  'ff',
+  'sync',
+  'archive',
+  'bulk-archive',
+  'verify',
+  'onboard',
+]
+
+/**
+ * Move only OpenSpec-owned Kimi workflow directories from either upstream
+ * location into the artifact workspace. Every destination is copied to a
+ * sibling temporary directory and renamed, so readers never observe a partial
+ * skill. A distinct newly generated source refreshes the managed destination;
+ * an in-place corrected destination is retained as-is.
+ */
+export function normalizeKimiOpenSpecSkills(repoRoot: string, artifactRoot: string): string[] {
+  const canonicalRepoRoot = realpathSync(repoRoot)
+  const canonicalArtifactRoot = ensureRealDirectoryPath(artifactRoot)
+  const destinationRoot = ensureRealDirectoryPath(
+    path.join(canonicalArtifactRoot, '.kimi-code', 'skills'),
+  )
+  const correctedSourceRoot = path.join(canonicalRepoRoot, '.kimi-code', 'skills')
+  const legacySourceRoot = path.join(canonicalRepoRoot, '.kimi', 'skills')
+  const correctedIsDestination =
+    path.resolve(correctedSourceRoot) === path.resolve(destinationRoot)
+  const installed: string[] = []
+  const sources = new Map<string, string | null>()
+
+  // Validate the full inventory before mutating either tree.
+  for (const skillName of KIMI_REQUIRED_OPENSPEC_SKILLS) {
+    const destination = path.join(destinationRoot, skillName)
+    const correctedSource = path.join(correctedSourceRoot, skillName)
+    const legacySource = path.join(legacySourceRoot, skillName)
+    const sourceCandidate =
+      !correctedIsDestination && pathExists(path.join(correctedSource, 'SKILL.md'))
+        ? correctedSource
+        : pathExists(path.join(legacySource, 'SKILL.md'))
+          ? legacySource
+          : null
+    const source =
+      sourceCandidate === null
+        ? null
+        : validateSafeSkillTree(sourceCandidate, skillName)
+    sources.set(skillName, source)
+    if (source) {
+      validateReplaceableDestination(destination, skillName)
+      continue
+    }
+    if (lstatExists(destination)) {
+      validateSafeSkillTree(destination, skillName)
+      continue
+    }
+    if (pathExists(destination)) {
+      throw new InstallerError(
+        `Kimi OpenSpec skill ${skillName} exists without SKILL.md; refusing to overwrite it`,
+        50,
+      )
+    }
+    throw new InstallerError(
+      `OpenSpec did not generate required Kimi skill ${skillName}; ` +
+        'retry `npx specrails-core update --provider kimi`',
+      50,
+    )
+  }
+
+  for (const skillName of KIMI_REQUIRED_OPENSPEC_SKILLS) {
+    const destination = path.join(destinationRoot, skillName)
+    const source = sources.get(skillName) ?? null
+
+    if (source) {
+      const temporary = mkdtempSync(
+        path.join(destinationRoot, `.${skillName}.specrails-tmp-`),
+      )
+      const backupContainer = mkdtempSync(
+        path.join(destinationRoot, `.${skillName}.specrails-backup-`),
+      )
+      const backup = path.join(backupContainer, 'previous')
+      copyValidatedSkillTree(source, temporary)
+      try {
+        validateSafeSkillTree(temporary, skillName)
+      } catch (error) {
+        removePath(temporary)
+        removePath(backupContainer)
+        throw error
+      }
+      const hadDestination = lstatExists(destination)
+      try {
+        if (hadDestination) renameSync(destination, backup)
+        renameSync(temporary, destination)
+        removePath(backupContainer)
+      } catch (err) {
+        removePath(temporary)
+        if (!lstatExists(destination) && lstatExists(backup)) {
+          renameSync(backup, destination)
+        }
+        removePath(backupContainer)
+        throw err
+      }
+    }
+    installed.push(skillName)
+  }
+
+  // Remove only the generated, known workflow directories after every
+  // destination has been validated. Unknown/user content keeps both trees.
+  for (const skillName of KIMI_REQUIRED_OPENSPEC_SKILLS) {
+    const legacy = path.join(legacySourceRoot, skillName)
+    if (path.resolve(legacy) !== path.resolve(path.join(destinationRoot, skillName))) {
+      removePath(legacy)
+    }
+    if (path.resolve(correctedSourceRoot) !== path.resolve(destinationRoot)) {
+      removePath(path.join(correctedSourceRoot, skillName))
+    }
+  }
+  removeDirectoryIfEmpty(legacySourceRoot)
+  removeDirectoryIfEmpty(path.dirname(legacySourceRoot))
+  if (path.resolve(correctedSourceRoot) !== path.resolve(destinationRoot)) {
+    removeDirectoryIfEmpty(correctedSourceRoot)
+    removeDirectoryIfEmpty(path.dirname(correctedSourceRoot))
+  }
+  return installed
+}
+
+function lstatExists(target: string): boolean {
+  try {
+    lstatSync(target)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Create a directory tree without ever traversing a caller-controlled symlink.
+ * Existing ancestor aliases (for example macOS `/var` → `/private/var`) are
+ * canonicalized once; every newly appended component must then be a real dir.
+ */
+function ensureRealDirectoryPath(directory: string): string {
+  const absolute = path.resolve(directory)
+  const missing: string[] = []
+  let anchor = absolute
+  while (!lstatExists(anchor)) {
+    const parent = path.dirname(anchor)
+    if (parent === anchor) {
+      throw new InstallerError(`cannot resolve directory root for ${absolute}`, 50)
+    }
+    missing.unshift(path.basename(anchor))
+    anchor = parent
+  }
+  const anchorMetadata = lstatSync(anchor)
+  if (
+    !anchorMetadata.isDirectory() ||
+    anchorMetadata.isSymbolicLink()
+  ) {
+    throw new InstallerError(
+      `Kimi OpenSpec destination must be a real directory: ${absolute}`,
+      50,
+    )
+  }
+  let cursor = realpathSync(anchor)
+  for (const component of missing) {
+    cursor = path.join(cursor, component)
+    if (!lstatExists(cursor)) mkdirSync(cursor, { mode: 0o700 })
+    const metadata = lstatSync(cursor)
+    if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+      throw new InstallerError(
+        `Kimi OpenSpec destination parent must not be a symlink: ${cursor}`,
+        50,
+      )
+    }
+  }
+  return cursor
+}
+
+function validateReplaceableDestination(
+  destination: string,
+  skillName: string,
+): void {
+  if (!lstatExists(destination)) return
+  const metadata = lstatSync(destination)
+  if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+    throw new InstallerError(
+      `Kimi OpenSpec destination ${skillName} must be a real directory`,
+      50,
+    )
+  }
+}
+
+function validateSafeSkillTree(source: string, skillName: string): string {
+  let canonicalRoot: string
+  try {
+    const rootMetadata = lstatSync(source)
+    if (!rootMetadata.isDirectory() || rootMetadata.isSymbolicLink()) {
+      throw new Error('skill root is not a real directory')
+    }
+    canonicalRoot = realpathSync(source)
+  } catch (error) {
+    throw new InstallerError(
+      `unsafe Kimi OpenSpec skill ${skillName}: ${(error as Error).message}`,
+      50,
+    )
+  }
+
+  const walk = (directory: string): void => {
+    for (const name of readdirSync(directory)) {
+      const entry = path.join(directory, name)
+      const metadata = lstatSync(entry)
+      if (metadata.isSymbolicLink()) {
+        throw new InstallerError(
+          `unsafe Kimi OpenSpec skill ${skillName}: symlink ${entry}`,
+          50,
+        )
+      }
+      const relative = path.relative(canonicalRoot, realpathSync(entry))
+      if (
+        relative === '..' ||
+        relative.startsWith(`..${path.sep}`) ||
+        path.isAbsolute(relative)
+      ) {
+        throw new InstallerError(
+          `unsafe Kimi OpenSpec skill ${skillName}: path escapes source`,
+          50,
+        )
+      }
+      if (metadata.isDirectory()) {
+        walk(entry)
+      } else if (!metadata.isFile()) {
+        throw new InstallerError(
+          `unsafe Kimi OpenSpec skill ${skillName}: unsupported file type ${entry}`,
+          50,
+        )
+      }
+    }
+  }
+  walk(canonicalRoot)
+  const skillFile = path.join(canonicalRoot, 'SKILL.md')
+  if (!lstatExists(skillFile)) {
+    throw new InstallerError(
+      `generated Kimi skill ${skillName} is missing SKILL.md`,
+      50,
+    )
+  }
+  const skillMetadata = lstatSync(skillFile)
+  if (!skillMetadata.isFile() || skillMetadata.isSymbolicLink()) {
+    throw new InstallerError(
+      `generated Kimi skill ${skillName} has unsafe SKILL.md`,
+      50,
+    )
+  }
+  return canonicalRoot
+}
+
+function copyValidatedSkillTree(source: string, destination: string): void {
+  for (const name of readdirSync(source)) {
+    const from = path.join(source, name)
+    const to = path.join(destination, name)
+    const metadata = lstatSync(from)
+    if (metadata.isSymbolicLink()) {
+      throw new InstallerError(`refusing to copy Kimi OpenSpec symlink ${from}`, 50)
+    }
+    if (metadata.isDirectory()) {
+      mkdirSync(to, { mode: 0o700 })
+      copyValidatedSkillTree(from, to)
+    } else if (metadata.isFile()) {
+      copyFileSync(from, to)
+    } else {
+      throw new InstallerError(
+        `refusing to copy unsupported Kimi OpenSpec file ${from}`,
+        50,
+      )
+    }
+  }
+}
+
+function removeDirectoryIfEmpty(dir: string): void {
+  if (isDir(dir) && listDir(dir).length === 0) removePath(dir)
+}
+
+export async function installOpenSpecProject(
+  repoRoot: string,
+  provider: Provider,
+  artifactRoot: string = repoRoot,
+): Promise<void> {
   if (process.env.SPECRAILS_SKIP_OPENSPEC_INIT === '1') {
+    if (provider === 'kimi') {
+      const generatedRoots = [
+        path.join(repoRoot, '.kimi', 'skills'),
+        path.join(repoRoot, '.kimi-code', 'skills'),
+      ]
+      const hasGeneratedOutput = generatedRoots.some((root) =>
+        listDir(root).some(
+          (entry) => isDir(entry) && path.basename(entry).startsWith('openspec-'),
+        ),
+      )
+      if (hasGeneratedOutput) normalizeKimiOpenSpecSkills(repoRoot, artifactRoot)
+    }
     info('Skipping OpenSpec project init (SPECRAILS_SKIP_OPENSPEC_INIT=1)')
     return
   }
 
   const { bin, args } = buildOpenSpecInvocation(repoRoot, provider)
+  let temporaryConfigHome: string | null = null
+  let commandEnv: NodeJS.ProcessEnv | undefined
+  if (provider === 'kimi') {
+    temporaryConfigHome = mkdtempSync(path.join(os.tmpdir(), 'specrails-openspec-kimi-'))
+    writeFileLf(
+      path.join(temporaryConfigHome, 'openspec', 'config.json'),
+      `${JSON.stringify(
+        {
+          profile: 'custom',
+          delivery: 'skills',
+          workflows: OPENSPEC_ALL_WORKFLOWS,
+          featureFlags: {},
+        },
+        null,
+        2,
+      )}\n`,
+    )
+    commandEnv = { ...process.env, XDG_CONFIG_HOME: temporaryConfigHome }
+  }
 
   step('Phase 3c: Installing OpenSpec')
   try {
     await runCommand(bin, args, {
       cwd: repoRoot,
       timeoutMs: 180000,
+      env: commandEnv,
     })
+    if (provider === 'kimi') {
+      normalizeKimiOpenSpecSkills(repoRoot, artifactRoot)
+    }
     ok(`OpenSpec project files installed (${provider})`)
   } catch (err) {
     throw new InstallerError(
       `OpenSpec init failed: ${(err as Error).message}`,
       50,
     )
+  } finally {
+    if (temporaryConfigHome) {
+      rmSync(temporaryConfigHome, { recursive: true, force: true })
+    }
   }
 }

--- a/src/installer/commands/init.ts
+++ b/src/installer/commands/init.ts
@@ -17,6 +17,7 @@ import { runCommand } from '../util/exec.js'
 import { info, ok, step } from '../util/logger.js'
 import {
   isDir,
+  isSymlink,
   listDir,
   pathExists,
   readTextFile,
@@ -74,6 +75,135 @@ export interface InitResult {
   repoRoot: string
   provider: Provider
   tier: Tier
+}
+
+const WORKSPACE_PROVIDER_ORDER: readonly Provider[] = [
+  'claude',
+  'codex',
+  'gemini',
+  'kimi',
+]
+
+export type WorkspaceProviderSelections = Partial<
+  Record<Provider, string[]>
+>
+
+/**
+ * Snapshot the provider/role inventory exposed by one live workspace before a
+ * global framework version swap. This matters on Windows: directory junctions
+ * resolve their target when they are created, so a workspace link made through
+ * `framework/current` must be recreated after `current` moves. Keeping the
+ * exact visible `sr-*` set also avoids widening or narrowing a project's
+ * optional role selection during that refresh.
+ */
+export function snapshotWorkspaceProviderSelections(
+  workspace: string,
+): WorkspaceProviderSelections {
+  const selections: WorkspaceProviderSelections = {}
+  for (const provider of WORKSPACE_PROVIDER_ORDER) {
+    const { providerDir } = derivedPaths(provider)
+    const providerRoot = path.join(workspace, providerDir)
+    if (
+      !pathExists(providerRoot) ||
+      !workspaceHasManagedProviderLink(providerRoot, provider)
+    ) {
+      continue
+    }
+
+    const roleRoot =
+      provider === 'codex'
+        ? path.join(workspace, providerDir, 'skills', 'rails')
+        : provider === 'kimi'
+          ? path.join(workspace, providerDir, 'skills')
+          : path.join(workspace, providerDir, 'agents')
+    const ids = listDir(roleRoot)
+      .filter((entry) =>
+        provider === 'claude' || provider === 'gemini'
+          ? path.basename(entry).endsWith('.md')
+          : isDir(entry),
+      )
+      .map((entry) => {
+        const name = path.basename(entry)
+        return name.endsWith('.md') ? name.slice(0, -3) : name
+      })
+      .filter((id) => /^sr-[a-z0-9-]+$/.test(id))
+    selections[provider] = [...new Set(ids)].sort()
+  }
+  return selections
+}
+
+function workspaceHasManagedProviderLink(
+  providerRoot: string,
+  provider: Provider,
+): boolean {
+  const directoryLinks =
+    provider === 'claude'
+      ? ['commands', 'skills', 'rules']
+      : provider === 'codex'
+        ? ['skills']
+        : provider === 'gemini'
+          ? ['commands']
+          : ['rules', 'specrails']
+  if (
+    directoryLinks.some((relative) =>
+      isSymlink(path.join(providerRoot, relative)),
+    )
+  ) {
+    return true
+  }
+
+  const granularRoot =
+    provider === 'kimi'
+      ? path.join(providerRoot, 'skills')
+      : path.join(providerRoot, 'agents')
+  return listDir(granularRoot).some((entry) => isSymlink(entry))
+}
+
+interface ReassembleWorkspaceProvidersInput {
+  workspace: string
+  frameworkDir: string
+  version: string
+  codeRoot: string
+  scriptDir: string
+  selectedProvider: Provider
+  selectedAgents?: string[]
+  previousSelections: WorkspaceProviderSelections
+  copyStatics: boolean
+}
+
+/**
+ * Refresh every provider already represented in the project plus the provider
+ * selected by the current operation. POSIX symlinks continue to follow
+ * `framework/current`; Windows junctions do not reliably preserve that
+ * indirection, so rebuilding all live links is required for true
+ * multi-provider version parity.
+ */
+export function reassembleWorkspaceProviders(
+  input: ReassembleWorkspaceProvidersInput,
+): Provider[] {
+  const providers = WORKSPACE_PROVIDER_ORDER.filter(
+    (provider) =>
+      provider === input.selectedProvider ||
+      Object.prototype.hasOwnProperty.call(input.previousSelections, provider),
+  )
+  for (const provider of providers) {
+    const { providerDir } = derivedPaths(provider)
+    assembleProjectWorkspace({
+      workspace: input.workspace,
+      frameworkDir: input.frameworkDir,
+      provider,
+      providerDir,
+      version: input.version,
+      codeRoot: input.codeRoot,
+      scriptDir: input.scriptDir,
+      selectedAgents:
+        provider === input.selectedProvider
+          ? input.selectedAgents ?? input.previousSelections[provider]
+          : input.previousSelections[provider],
+      copyStatics: input.copyStatics,
+    })
+  }
+  return providers
 }
 
 /**
@@ -187,6 +317,8 @@ export async function runInit(flags: InitFlags): Promise<InitResult> {
   }
   // In-repo when the resolution did NOT relocate the artifacts out of the repo.
   const inRepo = artifactRoot === codeRoot
+  const previousSelections =
+    snapshotWorkspaceProviderSelections(artifactRoot)
 
   // ─── Phase 2 + 3 ──────────────────────────────────────────────────────
   // Bundled-framework flow: materialize the provider-INVARIANT framework ONCE
@@ -207,15 +339,15 @@ export async function runInit(flags: InitFlags): Promise<InitResult> {
     selectedAgents: selectedAgentsHint,
   })
 
-  assembleProjectWorkspace({
+  reassembleWorkspaceProviders({
     workspace: artifactRoot,
     frameworkDir: fwDir,
-    provider: prereqs.provider,
-    providerDir,
     version,
     codeRoot,
     scriptDir,
+    selectedProvider: prereqs.provider,
     selectedAgents: selectedAgentsHint,
+    previousSelections,
     // In-repo: COPY the framework statics as real, committable files. Relocated:
     // symlink from the framework store (O(1) update on a version swap).
     copyStatics: inRepo,

--- a/src/installer/commands/kimi-openspec.test.ts
+++ b/src/installer/commands/kimi-openspec.test.ts
@@ -1,0 +1,202 @@
+import {
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+} from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { pathExists, readTextFile, writeFileLf } from '../util/fs.js'
+import {
+  KIMI_REQUIRED_OPENSPEC_SKILLS,
+  normalizeKimiOpenSpecSkills,
+} from './init.js'
+
+describe('normalizeKimiOpenSpecSkills', () => {
+  let tmpDir: string
+  let repoRoot: string
+  let artifactRoot: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'specrails-kimi-openspec-'))
+    repoRoot = path.join(tmpDir, 'repo')
+    artifactRoot = path.join(tmpDir, 'workspace')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+  })
+
+  function seedAll(base: string, marker = 'generated'): void {
+    for (const skill of KIMI_REQUIRED_OPENSPEC_SKILLS) {
+      writeFileLf(path.join(base, skill, 'SKILL.md'), `${marker}:${skill}\n`)
+    }
+  }
+
+  it('atomically normalizes the complete legacy output and prunes only managed directories', () => {
+    const legacyRoot = path.join(repoRoot, '.kimi', 'skills')
+    seedAll(legacyRoot)
+    writeFileLf(path.join(legacyRoot, 'user-skill', 'SKILL.md'), 'user-byte-content\n')
+
+    expect(normalizeKimiOpenSpecSkills(repoRoot, artifactRoot)).toEqual([
+      ...KIMI_REQUIRED_OPENSPEC_SKILLS,
+    ])
+
+    for (const skill of KIMI_REQUIRED_OPENSPEC_SKILLS) {
+      expect(
+        readTextFile(path.join(artifactRoot, '.kimi-code', 'skills', skill, 'SKILL.md')),
+      ).toBe(`generated:${skill}\n`)
+      expect(pathExists(path.join(legacyRoot, skill))).toBe(false)
+    }
+    expect(readTextFile(path.join(legacyRoot, 'user-skill', 'SKILL.md'))).toBe(
+      'user-byte-content\n',
+    )
+  })
+
+  it('accepts corrected upstream output, refreshes managed destinations, and preserves user files', () => {
+    const correctedRoot = path.join(repoRoot, '.kimi-code', 'skills')
+    seedAll(correctedRoot, 'corrected')
+    const first = KIMI_REQUIRED_OPENSPEC_SKILLS[0]
+    writeFileLf(
+      path.join(artifactRoot, '.kimi-code', 'skills', first, 'SKILL.md'),
+      'existing-destination-byte-content\n',
+    )
+    writeFileLf(path.join(repoRoot, '.kimi-code', 'user.json'), '{"keep":true}\n')
+
+    normalizeKimiOpenSpecSkills(repoRoot, artifactRoot)
+
+    expect(
+      readTextFile(path.join(artifactRoot, '.kimi-code', 'skills', first, 'SKILL.md')),
+    ).toBe(`corrected:${first}\n`)
+    expect(readTextFile(path.join(repoRoot, '.kimi-code', 'user.json'))).toBe('{"keep":true}\n')
+    expect(pathExists(path.join(correctedRoot, KIMI_REQUIRED_OPENSPEC_SKILLS[1]))).toBe(
+      false,
+    )
+  })
+
+  it('refreshes every managed skill on a relocated second update', () => {
+    const legacyRoot = path.join(repoRoot, '.kimi', 'skills')
+    seedAll(legacyRoot, 'first-release')
+    normalizeKimiOpenSpecSkills(repoRoot, artifactRoot)
+
+    const correctedRoot = path.join(repoRoot, '.kimi-code', 'skills')
+    seedAll(correctedRoot, 'second-release')
+    writeFileLf(
+      path.join(artifactRoot, '.kimi-code', 'skills', 'custom-user', 'SKILL.md'),
+      'keep-user-skill\n',
+    )
+
+    normalizeKimiOpenSpecSkills(repoRoot, artifactRoot)
+
+    for (const skill of KIMI_REQUIRED_OPENSPEC_SKILLS) {
+      expect(
+        readTextFile(path.join(artifactRoot, '.kimi-code', 'skills', skill, 'SKILL.md')),
+      ).toBe(`second-release:${skill}\n`)
+    }
+    expect(
+      readTextFile(
+        path.join(artifactRoot, '.kimi-code', 'skills', 'custom-user', 'SKILL.md'),
+      ),
+    ).toBe('keep-user-skill\n')
+  })
+
+  it('fails closed when any required workflow is missing', () => {
+    const legacyRoot = path.join(repoRoot, '.kimi', 'skills')
+    seedAll(legacyRoot)
+    rmSync(path.join(legacyRoot, 'openspec-verify-change'), {
+      recursive: true,
+      force: true,
+    })
+    expect(() => normalizeKimiOpenSpecSkills(repoRoot, artifactRoot)).toThrow(
+      /required Kimi skill openspec-verify-change/,
+    )
+    // The cleanup phase runs only after the complete inventory validates.
+    expect(pathExists(path.join(legacyRoot, 'openspec-apply-change'))).toBe(true)
+  })
+
+  it('rejects a generated SKILL.md symlink without reading or deleting its target', () => {
+    if (process.platform === 'win32') return
+    const legacyRoot = path.join(repoRoot, '.kimi', 'skills')
+    seedAll(legacyRoot)
+    const first = KIMI_REQUIRED_OPENSPEC_SKILLS[0]
+    const outside = path.join(tmpDir, 'outside-skill.md')
+    writeFileLf(outside, 'outside-byte-content\n')
+    rmSync(path.join(legacyRoot, first, 'SKILL.md'))
+    symlinkSync(outside, path.join(legacyRoot, first, 'SKILL.md'))
+
+    expect(() => normalizeKimiOpenSpecSkills(repoRoot, artifactRoot)).toThrow(
+      /unsafe Kimi OpenSpec skill.*symlink/,
+    )
+    expect(readTextFile(outside)).toBe('outside-byte-content\n')
+    expect(pathExists(path.join(legacyRoot, first))).toBe(true)
+  })
+
+  it('rejects nested source symlinks before mutating any managed destination', () => {
+    if (process.platform === 'win32') return
+    const legacyRoot = path.join(repoRoot, '.kimi', 'skills')
+    seedAll(legacyRoot)
+    const first = KIMI_REQUIRED_OPENSPEC_SKILLS[0]
+    const outside = path.join(tmpDir, 'outside-reference.txt')
+    writeFileLf(outside, 'outside\n')
+    symlinkSync(outside, path.join(legacyRoot, first, 'reference.txt'))
+
+    expect(() => normalizeKimiOpenSpecSkills(repoRoot, artifactRoot)).toThrow(
+      /unsafe Kimi OpenSpec skill.*symlink/,
+    )
+    expect(
+      pathExists(
+        path.join(artifactRoot, '.kimi-code', 'skills', first, 'SKILL.md'),
+      ),
+    ).toBe(false)
+  })
+
+  it('rejects a symlinked artifact root instead of copying outside it', () => {
+    if (process.platform === 'win32') return
+    const legacyRoot = path.join(repoRoot, '.kimi', 'skills')
+    seedAll(legacyRoot)
+    const outside = path.join(tmpDir, 'outside-workspace')
+    writeFileLf(path.join(outside, 'sentinel.txt'), 'keep\n')
+    symlinkSync(outside, artifactRoot)
+
+    expect(() => normalizeKimiOpenSpecSkills(repoRoot, artifactRoot)).toThrow(
+      /destination must be a real directory/,
+    )
+    expect(readTextFile(path.join(outside, 'sentinel.txt'))).toBe('keep\n')
+    expect(pathExists(path.join(outside, '.kimi-code'))).toBe(false)
+  })
+
+  it('uses unpredictable sibling temp names and preserves colliding user paths', () => {
+    const legacyRoot = path.join(repoRoot, '.kimi', 'skills')
+    seedAll(legacyRoot)
+    const destinationRoot = path.join(artifactRoot, '.kimi-code', 'skills')
+    const first = KIMI_REQUIRED_OPENSPEC_SKILLS[0]
+    const oldPredictableTemp = path.join(
+      destinationRoot,
+      `.${first}.specrails-tmp-${process.pid}`,
+    )
+    const oldPredictableBackup = path.join(
+      destinationRoot,
+      `.${first}.specrails-backup-${process.pid}`,
+    )
+    writeFileLf(path.join(oldPredictableTemp, 'keep.txt'), 'temp-user\n')
+    writeFileLf(path.join(oldPredictableBackup, 'keep.txt'), 'backup-user\n')
+
+    normalizeKimiOpenSpecSkills(repoRoot, artifactRoot)
+
+    expect(readTextFile(path.join(oldPredictableTemp, 'keep.txt'))).toBe(
+      'temp-user\n',
+    )
+    expect(readTextFile(path.join(oldPredictableBackup, 'keep.txt'))).toBe(
+      'backup-user\n',
+    )
+    const unexpectedManagedTemps = readdirSync(destinationRoot).filter(
+      (entry) =>
+        entry.startsWith(`.${first}.specrails-tmp-`) &&
+        entry !== path.basename(oldPredictableTemp),
+    )
+    expect(unexpectedManagedTemps).toEqual([])
+  })
+})

--- a/src/installer/commands/openspec-invocation.test.ts
+++ b/src/installer/commands/openspec-invocation.test.ts
@@ -61,4 +61,22 @@ describe('buildOpenSpecInvocation', () => {
     expect(bin).toBe('npx')
     expect(args).toContain(`@fission-ai/openspec@${pinned}`)
   })
+
+  it('Kimi requests the isolated custom workflow profile', () => {
+    const { bin, args } = buildOpenSpecInvocation(
+      repoRoot,
+      'kimi',
+      { SPECRAILS_OPENSPEC_BIN: '/usr/local/bin/openspec' },
+      pinned,
+    )
+    expect(bin).toBe('/usr/local/bin/openspec')
+    expect(args).toEqual([
+      'init',
+      '--tools',
+      'kimi',
+      '--profile',
+      'custom',
+      repoRoot,
+    ])
+  })
 })

--- a/src/installer/commands/update.test.ts
+++ b/src/installer/commands/update.test.ts
@@ -5,17 +5,68 @@ import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { PrerequisiteError } from '../util/errors.js'
-import { mkdirp, pathExists, readTextFile, writeFileLf } from '../util/fs.js'
+import { isDir, mkdirp, pathExists, readTextFile, writeFileLf } from '../util/fs.js'
 import { initRepo } from '../util/git.js'
-import { resolveArtifacts } from '../util/registry.js'
+import { frameworkRoot, resolveArtifacts } from '../util/registry.js'
+import {
+  assembleProjectWorkspace,
+  ensureCurrentSymlink,
+  installFramework,
+} from '../phases/scaffold.js'
+import { KIMI_REQUIRED_OPENSPEC_SKILLS } from './init.js'
 import { runUpdate } from './update.js'
 
 async function setupFakeScriptDir(scriptDir: string, version: string): Promise<void> {
   writeFileLf(path.join(scriptDir, 'package.json'), `${JSON.stringify({ version })}\n`)
-  writeFileLf(path.join(scriptDir, 'templates', 'agents', 'sr-architect.md'), 'v2-arch')
-  writeFileLf(path.join(scriptDir, 'templates', 'rules', 'general.md'), 'v2-rules')
+  writeFileLf(path.join(scriptDir, 'templates', 'agents', 'sr-architect.md'), `${version}-arch`)
+  writeFileLf(path.join(scriptDir, 'templates', 'agents', 'sr-developer.md'), `${version}-dev`)
+  writeFileLf(path.join(scriptDir, 'templates', 'agents', 'sr-reviewer.md'), `${version}-review`)
+  writeFileLf(path.join(scriptDir, 'templates', 'rules', 'general.md'), `${version}-rules`)
+  writeFileLf(
+    path.join(scriptDir, 'templates', 'kimi', 'specrails', 'run-skill.mjs'),
+    '// managed Kimi runner fixture\n',
+  )
+  writeFileLf(
+    path.join(
+      scriptDir,
+      'templates',
+      'kimi',
+      'specrails',
+      'vendor',
+      'js-yaml',
+      'js-yaml.mjs',
+    ),
+    '// vendored js-yaml fixture\n',
+  )
+  writeFileLf(
+    path.join(
+      scriptDir,
+      'templates',
+      'kimi',
+      'specrails',
+      'vendor',
+      'js-yaml',
+      'LICENSE',
+    ),
+    'js-yaml fixture license\n',
+  )
+  writeFileLf(
+    path.join(
+      scriptDir,
+      'templates',
+      'kimi',
+      'specrails',
+      'vendor',
+      'js-yaml',
+      'NOTICE.md',
+    ),
+    'js-yaml fixture notice\n',
+  )
   writeFileLf(path.join(scriptDir, 'commands', 'enrich.md'), 'enrich')
   writeFileLf(path.join(scriptDir, 'commands', 'doctor.md'), 'doctor')
+  writeFileLf(path.join(scriptDir, 'commands', 'implement.md'), 'implement')
+  writeFileLf(path.join(scriptDir, 'commands', 'batch-implement.md'), 'batch')
+  writeFileLf(path.join(scriptDir, 'commands', 'retry.md'), 'retry')
 }
 
 describe('runUpdate', () => {
@@ -24,6 +75,7 @@ describe('runUpdate', () => {
   let prevCwd: string
   let prevScriptDirOverride: string | undefined
   let prevRegistryHome: string | undefined
+  let prevSkipOpenSpec: string | undefined
 
   /** Resolve the relocated artifact workspace for a repo (allocate so update finds it). */
   function workspaceFor(repoRoot: string): string {
@@ -56,6 +108,7 @@ describe('runUpdate', () => {
     prevCwd = process.cwd()
     prevScriptDirOverride = process.env.SPECRAILS_CORE_SCRIPT_DIR
     prevRegistryHome = process.env.SPECRAILS_REGISTRY_HOME
+    prevSkipOpenSpec = process.env.SPECRAILS_SKIP_OPENSPEC_INIT
     process.env.SPECRAILS_REGISTRY_HOME = registryHome
   })
 
@@ -65,6 +118,8 @@ describe('runUpdate', () => {
     else process.env.SPECRAILS_CORE_SCRIPT_DIR = prevScriptDirOverride
     if (prevRegistryHome === undefined) delete process.env.SPECRAILS_REGISTRY_HOME
     else process.env.SPECRAILS_REGISTRY_HOME = prevRegistryHome
+    if (prevSkipOpenSpec === undefined) delete process.env.SPECRAILS_SKIP_OPENSPEC_INIT
+    else process.env.SPECRAILS_SKIP_OPENSPEC_INIT = prevSkipOpenSpec
     rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
     rmSync(registryHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
   })
@@ -194,6 +249,169 @@ describe('runUpdate', () => {
       expect(result.provider).toBe('gemini')
     })
 
+    it('adds and refreshes Kimi without altering another provider or user-owned Kimi files', async () => {
+      const scriptDir = path.join(tmpDir, 'core')
+      const repoRoot = path.join(tmpDir, 'repo')
+      await setupFakeScriptDir(scriptDir, '5.0.0')
+      await simulateExistingInstall(repoRoot, '4.2.0')
+      const ws = workspaceFor(repoRoot)
+      writeFileLf(
+        path.join(ws, '.specrails', 'specrails-manifest.json'),
+        `${JSON.stringify(
+          {
+            version: '4.2.0',
+            installed_at: '2026-01-01T00:00:00Z',
+            providers: ['claude'],
+            primary_provider: 'claude',
+            artifacts: {},
+          },
+          null,
+          2,
+        )}\n`,
+      )
+      writeFileLf(
+        path.join(ws, '.claude', 'commands', 'specrails', 'user-byte.md'),
+        'claude-user-byte-content\n',
+      )
+      writeFileLf(
+        path.join(ws, '.kimi-code', 'mcp.json'),
+        '{"mcpServers":{"user-owned":{"command":"keep"}}}\n',
+      )
+      writeFileLf(
+        path.join(
+          ws,
+          '.kimi-code',
+          'skills',
+          'rails',
+          'custom-auditor',
+          'SKILL.md',
+        ),
+        'custom-kimi-role-byte-content\n',
+      )
+      for (const skill of KIMI_REQUIRED_OPENSPEC_SKILLS) {
+        writeFileLf(
+          path.join(repoRoot, '.kimi', 'skills', skill, 'SKILL.md'),
+          `fresh:${skill}\n`,
+        )
+      }
+      writeFileLf(
+        path.join(repoRoot, '.kimi', 'skills', 'user-skill', 'SKILL.md'),
+        'repo-user-skill\n',
+      )
+      process.env.SPECRAILS_CORE_SCRIPT_DIR = scriptDir
+      process.env.SPECRAILS_SKIP_OPENSPEC_INIT = '1'
+
+      const result = await runUpdate({ 'root-dir': repoRoot, provider: 'kimi' })
+      expect(result.provider).toBe('kimi')
+      expect(
+        readTextFile(
+          path.join(ws, '.claude', 'commands', 'specrails', 'user-byte.md'),
+        ),
+      ).toBe('claude-user-byte-content\n')
+      expect(readTextFile(path.join(ws, '.kimi-code', 'mcp.json'))).toBe(
+        '{"mcpServers":{"user-owned":{"command":"keep"}}}\n',
+      )
+      expect(
+        readTextFile(
+          path.join(
+            ws,
+            '.kimi-code',
+            'skills',
+            'custom-auditor',
+            'SKILL.md',
+          ),
+        ),
+      ).toBe('custom-kimi-role-byte-content\n')
+      for (const skill of KIMI_REQUIRED_OPENSPEC_SKILLS) {
+        expect(
+          readTextFile(path.join(ws, '.kimi-code', 'skills', skill, 'SKILL.md')),
+        ).toBe(`fresh:${skill}\n`)
+      }
+      expect(
+        readTextFile(
+          path.join(repoRoot, '.kimi', 'skills', 'user-skill', 'SKILL.md'),
+        ),
+      ).toBe('repo-user-skill\n')
+      const manifest = JSON.parse(
+        readTextFile(path.join(ws, '.specrails', 'specrails-manifest.json')),
+      ) as { providers: string[]; primary_provider: string }
+      expect(manifest.providers).toEqual(['claude', 'kimi'])
+      expect(manifest.primary_provider).toBe('claude')
+      const registryResolution = resolveArtifacts(repoRoot, { home: registryHome })
+      expect(registryResolution.providers).toEqual(['claude', 'kimi'])
+      expect(registryResolution.primaryProvider).toBe('claude')
+    })
+
+    it('updates to Kimi 4.12 without breaking a Claude workspace linked through 4.11 current', async () => {
+      const scriptDir = path.join(tmpDir, 'core-cross-version')
+      const repoRoot = path.join(tmpDir, 'repo-cross-version')
+      await setupFakeScriptDir(scriptDir, '4.11.0')
+      await simulateExistingInstall(repoRoot, '4.11.0')
+      const ws = workspaceFor(repoRoot)
+      const fwDir = frameworkRoot(registryHome)
+
+      // Build the actual 4.11 Claude framework/workspace link topology that the
+      // update must preserve (the generic update fixture otherwise only writes
+      // an installation marker).
+      installFramework({
+        scriptDir,
+        frameworkDir: fwDir,
+        provider: 'claude',
+        providerDir: '.claude',
+        version: '4.11.0',
+      })
+      ensureCurrentSymlink(fwDir, '4.11.0')
+      assembleProjectWorkspace({
+        workspace: ws,
+        frameworkDir: fwDir,
+        provider: 'claude',
+        providerDir: '.claude',
+        version: '4.11.0',
+        codeRoot: repoRoot,
+        scriptDir,
+      })
+      writeFileLf(
+        path.join(ws, '.claude', 'agents', 'custom-owner.md'),
+        'user-owned-claude-agent\n',
+      )
+      expect(readTextFile(path.join(ws, '.claude', 'agents', 'sr-architect.md'))).toBe(
+        '4.11.0-arch',
+      )
+
+      await setupFakeScriptDir(scriptDir, '4.12.0')
+      process.env.SPECRAILS_CORE_SCRIPT_DIR = scriptDir
+      process.env.SPECRAILS_SKIP_OPENSPEC_INIT = '1'
+      const result = await runUpdate({
+        'root-dir': repoRoot,
+        provider: 'kimi',
+      })
+
+      expect(result.previousVersion).toBe('4.11.0')
+      expect(result.currentVersion).toBe('4.12.0')
+      expect(result.provider).toBe('kimi')
+      expect(isDir(path.join(fwDir, '4.12.0', '.claude'))).toBe(true)
+      expect(isDir(path.join(fwDir, '4.12.0', '.kimi-code'))).toBe(true)
+
+      // The pre-existing Claude symlink follows the one global pointer into a
+      // destination that still contains Claude, and user-owned files survive.
+      expect(readTextFile(path.join(ws, '.claude', 'agents', 'sr-architect.md'))).toBe(
+        '4.12.0-arch',
+      )
+      expect(
+        readTextFile(path.join(ws, '.claude', 'agents', 'custom-owner.md')),
+      ).toBe('user-owned-claude-agent\n')
+      expect(
+        pathExists(path.join(ws, '.kimi-code', 'skills', 'sr-architect', 'SKILL.md')),
+      ).toBe(true)
+      expect(pathExists(path.join(ws, '.kimi-code', 'specrails', 'run-skill.mjs'))).toBe(true)
+
+      const manifest = JSON.parse(
+        readTextFile(path.join(ws, '.specrails', 'specrails-manifest.json')),
+      ) as { providers: string[]; primary_provider: string }
+      expect(manifest.providers).toEqual(['claude', 'kimi'])
+      expect(manifest.primary_provider).toBe('claude')
+    })
+
     it('auto-detects (claude first) when --provider is omitted — backward compatible', async () => {
       const scriptDir = path.join(tmpDir, 'core')
       const repoRoot = path.join(tmpDir, 'repo')
@@ -215,7 +433,7 @@ describe('runUpdate', () => {
 
       await expect(
         runUpdate({ 'root-dir': repoRoot, provider: 'bogus' }),
-      ).rejects.toThrow(/--provider value must be 'claude', 'codex', or 'gemini'/)
+      ).rejects.toThrow(/--provider value must be 'claude', 'codex', 'gemini', or 'kimi'/)
     })
   })
 
@@ -260,6 +478,28 @@ describe('runUpdate', () => {
       const result = await runUpdate({ 'root-dir': repoRoot, only: 'agents' })
       expect(result.scope).toBe('agents')
       expect(pathExists(path.join(workspaceFor(repoRoot), '.specrails', 'setup-templates', 'agents', 'sr-architect.md'))).toBe(true)
+    })
+
+    it('fails closed for partial Kimi refreshes before bumping manifest/version', async () => {
+      const scriptDir = path.join(tmpDir, 'core')
+      const repoRoot = path.join(tmpDir, 'repo')
+      await setupFakeScriptDir(scriptDir, '5.0.0')
+      await simulateExistingInstall(repoRoot, '4.2.0')
+      process.env.SPECRAILS_CORE_SCRIPT_DIR = scriptDir
+      const versionPath = path.join(
+        workspaceFor(repoRoot),
+        '.specrails',
+        'specrails-version',
+      )
+
+      await expect(
+        runUpdate({
+          'root-dir': repoRoot,
+          provider: 'kimi',
+          only: 'rules',
+        }),
+      ).rejects.toThrow(/cannot safely refresh Kimi/)
+      expect(readTextFile(versionPath).trim()).toBe('4.2.0')
     })
 
     it('--only=web-manager warns and exits without writing (deprecated)', async () => {

--- a/src/installer/commands/update.ts
+++ b/src/installer/commands/update.ts
@@ -11,7 +11,7 @@ import { derivedPaths, detectAvailability, resolveProvider, type Provider } from
 import { assembleProjectWorkspace } from '../phases/scaffold.js'
 import { frameworkRoot, resolveArtifacts } from '../util/registry.js'
 
-import { ensureFramework } from './init.js'
+import { ensureFramework, installOpenSpecProject } from './init.js'
 
 /**
  * Components recognised by the `--only <component>` flag. Mirrors the
@@ -52,8 +52,8 @@ export interface UpdateFlags {
   yes?: boolean
   /**
    * Force the provider to update. Without it, the provider is auto-detected
-   * from the existing install (`.claude` > `.codex` > `.gemini`), which on a
-   * MULTI-PROVIDER workspace always picks `.claude` first — so codex/gemini
+   * from the existing install (`.claude` > `.codex` > `.gemini` > `.kimi-code`), which on a
+   * MULTI-PROVIDER workspace always picks `.claude` first — so codex/gemini/kimi
    * could never be updated. specrails-desktop (and standalone users) pass
    * `--provider <name>` to update one specific provider. Mirrors `init`.
    */
@@ -124,13 +124,18 @@ export async function runUpdate(flags: UpdateFlags): Promise<UpdateResult> {
 
   // Provider can be FORCED via --provider (e.g. specrails-desktop updating one
   // provider on a multi-provider workspace, where auto-detection would always
-  // resolve `.claude` first and never reach codex/gemini). Absent ⇒ auto-detect
+  // resolve `.claude` first and never reach codex/gemini/kimi). Absent ⇒ auto-detect
   // from the existing install — byte-identical single-provider behaviour.
   let provider: Provider
   if (typeof flags.provider === 'string') {
-    if (flags.provider !== 'claude' && flags.provider !== 'codex' && flags.provider !== 'gemini') {
+    if (
+      flags.provider !== 'claude' &&
+      flags.provider !== 'codex' &&
+      flags.provider !== 'gemini' &&
+      flags.provider !== 'kimi'
+    ) {
       throw new InstallerError(
-        `--provider value must be 'claude', 'codex', or 'gemini', got: ${flags.provider}`,
+        `--provider value must be 'claude', 'codex', 'gemini', or 'kimi', got: ${flags.provider}`,
         40,
       )
     }
@@ -142,6 +147,15 @@ export async function runUpdate(flags: UpdateFlags): Promise<UpdateResult> {
   }
   const { providerDir } = derivedPaths(provider)
   ok(`Detected provider: ${provider} (${providerDir})`)
+  if (artifactRoot !== codeRoot) {
+    resolveArtifacts(repoRoot, {
+      allocate: true,
+      allocator: 'core-standalone',
+      home: process.env.SPECRAILS_REGISTRY_HOME,
+      providers: [provider],
+      coreVersion: currentVersion,
+    })
+  }
 
   // ─── Resolve --only scope ────────────────────────────────────────
   const scope = resolveScope(flags.only)
@@ -151,6 +165,17 @@ export async function runUpdate(flags: UpdateFlags): Promise<UpdateResult> {
         'specrails-desktop is the supported dashboard. Skipping with no changes.',
     )
     return { repoRoot, previousVersion, currentVersion, provider, dryRun, scope, tier }
+  }
+  if (
+    provider === 'kimi' &&
+    (scope === 'rules' || scope === 'agents')
+  ) {
+    throw new InstallerError(
+      `--only=${scope} cannot safely refresh Kimi's linked direct-child skill ` +
+        'catalogue in isolation. Run `npx specrails-core update --provider kimi` ' +
+        'without --only so framework, live workspace, and manifest advance together.',
+      40,
+    )
   }
 
   if (config) {
@@ -193,6 +218,9 @@ export async function runUpdate(flags: UpdateFlags): Promise<UpdateResult> {
       // In-repo updates COPY real files; relocated workspaces symlink.
       copyStatics: artifactRoot === codeRoot,
     })
+    if (provider === 'kimi') {
+      await installOpenSpecProject(codeRoot, provider, artifactRoot)
+    }
     ok(`Re-linked ${providerDir}/ at framework ${currentVersion} + rewrote manifest`)
   } else if (scope === 'rules' || scope === 'agents') {
     rescaffoldComponent(scope, { scriptDir, artifactRoot })
@@ -202,6 +230,8 @@ export async function runUpdate(flags: UpdateFlags): Promise<UpdateResult> {
       scriptDir,
       repoRoot: artifactRoot,
       version: currentVersion,
+      providers: [provider],
+      primaryProvider: provider,
     })
     const { manifestPath, versionPath } = writeManifestFiles(artifactRoot, manifest)
     ok(`Wrote ${path.relative(artifactRoot, manifestPath)}`)
@@ -257,6 +287,7 @@ async function resolveExistingProvider(artifactRoot: string): Promise<Provider> 
   if (pathExists(path.join(artifactRoot, '.claude'))) return 'claude'
   if (pathExists(path.join(artifactRoot, '.codex'))) return 'codex'
   if (pathExists(path.join(artifactRoot, '.gemini'))) return 'gemini'
+  if (pathExists(path.join(artifactRoot, '.kimi-code'))) return 'kimi'
   // None present — fall back to resolving via CLI availability.
   const avail = await detectAvailability()
   try {

--- a/src/installer/commands/update.ts
+++ b/src/installer/commands/update.ts
@@ -8,10 +8,14 @@ import { copyDir, isDir, pathExists, readTextFile } from '../util/fs.js'
 import { loadInstallConfig, resolveConfigPath, type Tier } from '../phases/install-config.js'
 import { buildManifest, writeManifestFiles, type SpecrailsManifest } from '../phases/manifest.js'
 import { derivedPaths, detectAvailability, resolveProvider, type Provider } from '../phases/provider-detect.js'
-import { assembleProjectWorkspace } from '../phases/scaffold.js'
 import { frameworkRoot, resolveArtifacts } from '../util/registry.js'
 
-import { ensureFramework, installOpenSpecProject } from './init.js'
+import {
+  ensureFramework,
+  installOpenSpecProject,
+  reassembleWorkspaceProviders,
+  snapshotWorkspaceProviderSelections,
+} from './init.js'
 
 /**
  * Components recognised by the `--only <component>` flag. Mirrors the
@@ -121,6 +125,8 @@ export async function runUpdate(flags: UpdateFlags): Promise<UpdateResult> {
     )
   }
   const previousVersion = readExistingVersion(artifactRoot)
+  const previousSelections =
+    snapshotWorkspaceProviderSelections(artifactRoot)
 
   // Provider can be FORCED via --provider (e.g. specrails-desktop updating one
   // provider on a multi-provider workspace, where auto-detection would always
@@ -206,15 +212,18 @@ export async function runUpdate(flags: UpdateFlags): Promise<UpdateResult> {
       version: currentVersion,
       selectedAgents,
     })
-    assembleProjectWorkspace({
+    reassembleWorkspaceProviders({
       workspace: artifactRoot,
       frameworkDir: fwDir,
-      provider,
-      providerDir,
       version: currentVersion,
       codeRoot,
       scriptDir,
-      selectedAgents,
+      selectedProvider: provider,
+      selectedAgents:
+        config?.provider === provider
+          ? selectedAgents
+          : previousSelections[provider] ?? selectedAgents,
+      previousSelections,
       // In-repo updates COPY real files; relocated workspaces symlink.
       copyStatics: artifactRoot === codeRoot,
     })

--- a/src/installer/dispatcher-enrich.test.ts
+++ b/src/installer/dispatcher-enrich.test.ts
@@ -1,0 +1,195 @@
+import { spawnSync } from 'node:child_process'
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const dispatcher = path.resolve(here, '..', '..', 'bin', 'specrails-core.mjs')
+
+describe('specrails-core Kimi enrich launcher', () => {
+  let root: string
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(os.tmpdir(), 'specrails-enrich-launch-'))
+  })
+
+  afterEach(() => {
+    rmSync(root, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 100,
+    })
+  })
+
+  it('resolves a relocated runner/cwd and applies CLI > active profile > config model precedence', () => {
+    const home = path.join(root, 'home')
+    const repo = path.join(root, 'repo')
+    // Registry rows are untrusted and accepted only at the immutable
+    // `<home>/.specrails/projects/<slug>/workspace` location. Keep this
+    // integration fixture on the real cross-repo layout so a stricter compiled
+    // registry cannot silently make enrich fall back to the in-repo provider.
+    const workspace = path.join(
+      home,
+      '.specrails',
+      'projects',
+      'repo',
+      'workspace',
+    )
+    const capture = path.join(root, 'capture.jsonl')
+    mkdirSync(path.join(repo, '.specrails', 'profiles'), { recursive: true })
+    mkdirSync(path.join(workspace, '.specrails'), { recursive: true })
+    mkdirSync(path.join(workspace, '.kimi-code', 'specrails'), {
+      recursive: true,
+    })
+    writeFileSync(
+      path.join(repo, '.specrails', 'profiles', 'active.json'),
+      '{"orchestrator":{"model":"profile/model-v2"}}\n',
+    )
+    writeFileSync(
+      path.join(workspace, '.specrails', 'install-config.yaml'),
+      [
+        'version: 1',
+        'provider: kimi',
+        'models:',
+        '  preset: balanced',
+        '  defaults: { model: config/model-v1 }',
+        '  overrides: {}',
+        '',
+      ].join('\n'),
+    )
+    writeFileSync(
+      path.join(workspace, '.kimi-code', 'specrails', 'run-skill.mjs'),
+      [
+        "import { appendFileSync } from 'node:fs'",
+        "appendFileSync(process.env.CAPTURE_FILE, JSON.stringify({args:process.argv.slice(2),cwd:process.cwd(),repo:process.env.SPECRAILS_REPO_DIR})+'\\n')",
+        '',
+      ].join('\n'),
+    )
+
+    const canonicalRepo = realpathSync(repo)
+    const key =
+      process.platform === 'darwin' || process.platform === 'win32'
+        ? canonicalRepo.toLowerCase()
+        : canonicalRepo
+    const registryDir = path.join(home, '.specrails')
+    mkdirSync(registryDir, { recursive: true })
+    writeFileSync(
+      path.join(registryDir, 'registry.json'),
+      `${JSON.stringify({
+        schemaVersion: 1,
+        projects: {
+          [key]: {
+            repoPath: canonicalRepo,
+            slug: 'repo',
+            workspaceDir: workspace,
+            artifactRoot: workspace,
+            codeRoot: canonicalRepo,
+            stateDir: path.join(workspace, '.kimi-code'),
+            ticketsPath: path.join(workspace, '.specrails', 'local-tickets.json'),
+            backlogConfigPath: path.join(
+              workspace,
+              '.specrails',
+              'backlog-config.json',
+            ),
+            profilesDir: path.join(workspace, '.specrails', 'profiles'),
+            pluginsStateDir: path.join(workspace, '.specrails', 'plugins'),
+            fileSummariesDir: path.join(
+              workspace,
+              '.specrails',
+              'file-summaries',
+            ),
+            providers: ['kimi'],
+            primaryProvider: 'kimi',
+            source: 'desktop',
+          },
+        },
+      })}\n`,
+    )
+
+    const launch = (
+      args: string[],
+      extraEnv: Record<string, string | undefined> = {},
+    ) =>
+      spawnSync(process.execPath, [dispatcher, 'enrich', ...args], {
+        cwd: repo,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          SPECRAILS_REGISTRY_HOME: home,
+          CAPTURE_FILE: capture,
+          ...extraEnv,
+        },
+      })
+
+    const expectLaunchSuccess = (result: ReturnType<typeof launch>) => {
+      expect(
+        result.status,
+        `stdout:\n${result.stdout ?? ''}\nstderr:\n${result.stderr ?? ''}`,
+      ).toBe(0)
+    }
+
+    expectLaunchSuccess(launch([], {
+      SPECRAILS_PROFILE_PATH: '.specrails/profiles/active.json',
+    }))
+    expectLaunchSuccess(
+      launch([], { SPECRAILS_PROFILE_PATH: undefined }),
+    )
+    expectLaunchSuccess(launch(['--model', 'cli/model-v3'], {
+      SPECRAILS_PROFILE_PATH: undefined,
+    }))
+
+    const records = readFileSync(capture, 'utf8')
+      .trim()
+      .split('\n')
+      .map(
+        (line) =>
+          JSON.parse(line) as {
+            args: string[]
+            cwd: string
+            repo: string
+          },
+      )
+    expect(records).toHaveLength(3)
+    expect(records.map((record) => record.args)).toEqual([
+      [
+        '--skill',
+        'specrails-enrich',
+        '--model',
+        'profile/model-v2',
+        '--add-dir',
+        canonicalRepo,
+      ],
+      [
+        '--skill',
+        'specrails-enrich',
+        '--model',
+        'config/model-v1',
+        '--add-dir',
+        canonicalRepo,
+      ],
+      [
+        '--skill',
+        'specrails-enrich',
+        '--model',
+        'cli/model-v3',
+        '--add-dir',
+        canonicalRepo,
+      ],
+    ])
+    for (const record of records) {
+      expect(record.cwd).toBe(realpathSync(workspace))
+      expect(record.repo).toBe(canonicalRepo)
+    }
+  })
+})

--- a/src/installer/dispatcher-help.test.ts
+++ b/src/installer/dispatcher-help.test.ts
@@ -1,0 +1,83 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const dispatcher = path.resolve(here, '..', '..', 'bin', 'specrails-core.mjs')
+const distCli = path.resolve(here, '..', '..', 'dist', 'installer', 'cli.js')
+const distFramework = path.resolve(
+  here,
+  '..',
+  '..',
+  'dist',
+  'installer',
+  'commands',
+  'framework.js',
+)
+const hasCurrentDist =
+  existsSync(distCli) &&
+  existsSync(distFramework) &&
+  readFileSync(distFramework, 'utf8').includes('assertFrameworkVersionComplete')
+
+describe('specrails-core dispatcher help', () => {
+  it('describes all supported providers without a Claude-only enrich claim', () => {
+    const result = spawnSync(process.execPath, [dispatcher, 'help'], {
+      encoding: 'utf8',
+    })
+
+    expect(result.status).toBe(0)
+    expect(result.stderr).toBe('')
+    expect(result.stdout).toContain(
+      'Provider-independent AI agent workflow system',
+    )
+    expect(result.stdout).toContain('claude, codex, gemini, or kimi')
+    expect(result.stdout).toContain(
+      "Run the configured provider's enrich workflow",
+    )
+    expect(result.stdout).toContain('swap-current')
+    expect(result.stdout).not.toContain('via Claude CLI')
+  })
+
+  it('allowlists swap-current in the public dispatcher', () => {
+    const source = readFileSync(dispatcher, 'utf8')
+    expect(source).toMatch(
+      /const KNOWN_SUBCOMMANDS = new Set\(\[[\s\S]*?'swap-current'/,
+    )
+    expect(source).toContain(
+      'Available commands: init, update, doctor, install-framework, swap-current, assemble',
+    )
+  })
+
+  it.skipIf(!hasCurrentDist)(
+    'routes swap-current to the installer and rejects a nonexistent target',
+    () => {
+      const tmp = mkdtempSync(path.join(os.tmpdir(), 'specrails-dispatch-swap-'))
+      try {
+        const result = spawnSync(
+          process.execPath,
+          [
+            dispatcher,
+            'swap-current',
+            '--framework-dir',
+            path.join(tmp, 'framework'),
+            '--version',
+            'missing',
+            '--providers',
+            'claude',
+          ],
+          { encoding: 'utf8' },
+        )
+
+        expect(result.status).toBe(41)
+        expect(result.stderr).not.toContain('Unknown command')
+        expect(result.stderr).toContain('is not materialized')
+      } finally {
+        rmSync(tmp, { recursive: true, force: true })
+      }
+    },
+  )
+})

--- a/src/installer/phases/framework-lifecycle.ts
+++ b/src/installer/phases/framework-lifecycle.ts
@@ -1,0 +1,195 @@
+import path from 'node:path'
+
+import { InstallerError } from '../util/errors.js'
+import { isDir, pathExists } from '../util/fs.js'
+import { readRegistryOrEmpty } from '../util/registry.js'
+
+import {
+  derivedPaths,
+  type Provider,
+} from './provider-detect.js'
+import {
+  ensureCurrentSymlink,
+  frameworkMaterializationProblem,
+  frameworkStampPath,
+  installFramework,
+} from './scaffold.js'
+
+/**
+ * Stable provider order for the global framework store. `framework/current` is
+ * shared by every relocated workspace, so a version transition must carry
+ * forward every provider that can still have live links through that pointer.
+ */
+export const FRAMEWORK_PROVIDERS: readonly Provider[] = [
+  'claude',
+  'codex',
+  'gemini',
+  'kimi',
+]
+
+export interface ResolveRequiredFrameworkProvidersInput {
+  frameworkDir: string
+  /** Providers requested by the lifecycle operation that is about to swap. */
+  requested?: readonly Provider[]
+  /** Registry home. Defaults to SPECRAILS_REGISTRY_HOME / the normal home. */
+  registryHome?: string
+}
+
+export interface MaterializeFrameworkVersionInput
+  extends ResolveRequiredFrameworkProvidersInput {
+  scriptDir: string
+  version: string
+}
+
+function isProvider(value: unknown): value is Provider {
+  return (
+    value === 'claude' ||
+    value === 'codex' ||
+    value === 'gemini' ||
+    value === 'kimi'
+  )
+}
+
+function stableProviders(values: Iterable<Provider>): Provider[] {
+  const wanted = new Set(values)
+  return FRAMEWORK_PROVIDERS.filter((provider) => wanted.has(provider))
+}
+
+/**
+ * Discover providers represented by a framework version.
+ *
+ * A provider is included when either its subtree or its stamp exists. For the
+ * current version this is deliberately conservative: an interrupted/legacy
+ * materialization without a stamp may still have live workspace symlinks, so
+ * the next version must carry that provider forward rather than dropping it.
+ */
+export function discoverFrameworkProviders(
+  frameworkDir: string,
+  version: string,
+): Provider[] {
+  const versionDir = path.join(frameworkDir, version)
+  return FRAMEWORK_PROVIDERS.filter((provider) => {
+    const { providerDir } = derivedPaths(provider)
+    return (
+      pathExists(path.join(versionDir, providerDir)) ||
+      pathExists(frameworkStampPath(versionDir, providerDir))
+    )
+  })
+}
+
+/**
+ * Compute the provider set that MUST exist in a destination version before the
+ * process may move the global `current` pointer:
+ *
+ *  1. providers requested by this operation;
+ *  2. every supported provider recorded by any project in registry.json;
+ *  3. every provider represented by the version currently serving workspaces.
+ *
+ * Taking the global registry union (not just the active project) is essential:
+ * `framework/current` is global, while provider inventories are per project.
+ */
+export function resolveRequiredFrameworkProviders(
+  input: ResolveRequiredFrameworkProvidersInput,
+): Provider[] {
+  const required = new Set<Provider>(input.requested ?? [])
+
+  const registry = readRegistryOrEmpty(input.registryHome)
+  for (const entry of Object.values(registry.projects)) {
+    for (const provider of entry.providers ?? []) {
+      if (isProvider(provider)) required.add(provider)
+    }
+    if (isProvider(entry.primaryProvider)) required.add(entry.primaryProvider)
+  }
+
+  for (const provider of discoverFrameworkProviders(input.frameworkDir, 'current')) {
+    required.add(provider)
+  }
+
+  return stableProviders(required)
+}
+
+/**
+ * Fail closed when a destination version is missing or only partially
+ * materialized. A valid provider requires BOTH its provider subtree and the
+ * final stamp written after scaffold completion, with matching version/provider
+ * fields. The caller may supply an empty requirement only for a first install;
+ * in that case at least one complete provider must be discoverable in target.
+ */
+export function assertFrameworkVersionComplete(
+  frameworkDir: string,
+  version: string,
+  requiredProviders: readonly Provider[],
+): Provider[] {
+  const versionDir = path.join(frameworkDir, version)
+  if (!isDir(versionDir)) {
+    throw new InstallerError(
+      `framework version ${version} is not materialized at ${versionDir}`,
+      41,
+    )
+  }
+
+  const required =
+    requiredProviders.length > 0
+      ? stableProviders(requiredProviders)
+      : discoverFrameworkProviders(frameworkDir, version)
+
+  if (required.length === 0) {
+    throw new InstallerError(
+      `framework version ${version} is incomplete: no provider was materialized`,
+      41,
+    )
+  }
+
+  const problems: string[] = []
+  for (const provider of required) {
+    const { providerDir } = derivedPaths(provider)
+    const problem = frameworkMaterializationProblem(
+      versionDir,
+      version,
+      provider,
+      providerDir,
+    )
+    if (problem) problems.push(`${provider}: ${problem}`)
+  }
+
+  if (problems.length > 0) {
+    throw new InstallerError(
+      `framework version ${version} is incomplete; refusing to move current: ` +
+        problems.join('; '),
+      41,
+    )
+  }
+
+  return required
+}
+
+/**
+ * Materialize a complete destination version and expose it with ONE atomic
+ * pointer swap. No call in the provider loop can move `current`; if any provider
+ * fails, existing workspaces continue resolving through the previous version.
+ */
+export function materializeFrameworkVersion(
+  input: MaterializeFrameworkVersionInput,
+): Provider[] {
+  const required = resolveRequiredFrameworkProviders(input)
+  if (required.length === 0) {
+    throw new InstallerError(
+      `framework version ${input.version} has no requested or registered provider`,
+      41,
+    )
+  }
+
+  for (const provider of required) {
+    installFramework({
+      scriptDir: input.scriptDir,
+      frameworkDir: input.frameworkDir,
+      provider,
+      providerDir: derivedPaths(provider).providerDir,
+      version: input.version,
+    })
+  }
+
+  assertFrameworkVersionComplete(input.frameworkDir, input.version, required)
+  ensureCurrentSymlink(input.frameworkDir, input.version)
+  return required
+}

--- a/src/installer/phases/framework.test.ts
+++ b/src/installer/phases/framework.test.ts
@@ -8,6 +8,7 @@ import { isDir, isSymlink, pathExists, readTextFile, removePath, writeFileLf } f
 import {
   assembleProjectWorkspace,
   ensureCurrentSymlink,
+  frameworkStampPath,
   installFramework,
 } from './scaffold.js'
 
@@ -97,7 +98,7 @@ describe('bundled framework — installFramework / ensureCurrentSymlink / assemb
       expect(pathExists(path.join(fwDir, '5.0.0', 'CLAUDE.md'))).toBe(false)
     })
 
-    it('is idempotent — a second call with a matching stamp does NOT re-materialize', () => {
+    it('is idempotent with a deterministic stamp and repairs same-version corruption', () => {
       const scriptDir = path.join(tmpDir, 'core')
       const fwDir = path.join(tmpDir, 'framework')
       setupFakeScriptDir(scriptDir)
@@ -107,15 +108,54 @@ describe('bundled framework — installFramework / ensureCurrentSymlink / assemb
       })
       expect(first.materialized).toBe(true)
 
-      // Tamper with a materialized file; an idempotent skip leaves it as-is.
       const archPath = path.join(fwDir, '5.0.0', '.claude', 'agents', 'sr-architect.md')
-      writeFileLf(archPath, 'TAMPERED')
+      const stampPath = frameworkStampPath(path.join(fwDir, '5.0.0'), '.claude')
+      const firstStamp = readTextFile(stampPath)
 
-      const second = installFramework({
+      // An unchanged retry is a true no-op and the stamp is byte-deterministic
+      // (there is no install timestamp churn).
+      const unchanged = installFramework({
         scriptDir, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude', version: '5.0.0',
       })
-      expect(second.materialized).toBe(false)
-      expect(readTextFile(archPath)).toBe('TAMPERED') // proof it was skipped
+      expect(unchanged.materialized).toBe(false)
+      expect(readTextFile(stampPath)).toBe(firstStamp)
+
+      // Corrupt a managed byte at the SAME version. The content hash must force
+      // a clean repair, restoring both output and the original deterministic
+      // stamp rather than trusting stamp existence alone.
+      writeFileLf(archPath, 'TAMPERED')
+
+      const repaired = installFramework({
+        scriptDir, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude', version: '5.0.0',
+      })
+      expect(repaired.materialized).toBe(true)
+      expect(readTextFile(archPath)).toContain('# arch')
+      expect(readTextFile(stampPath)).toBe(firstStamp)
+    })
+
+    it('repairs a missing managed file at the same version', () => {
+      const scriptDir = path.join(tmpDir, 'core')
+      const fwDir = path.join(tmpDir, 'framework')
+      setupFakeScriptDir(scriptDir)
+
+      installFramework({
+        scriptDir, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude', version: '5.0.0',
+      })
+      const reviewerPath = path.join(
+        fwDir,
+        '5.0.0',
+        '.claude',
+        'agents',
+        'sr-reviewer.md',
+      )
+      rmSync(reviewerPath)
+      expect(pathExists(reviewerPath)).toBe(false)
+
+      const repaired = installFramework({
+        scriptDir, frameworkDir: fwDir, provider: 'claude', providerDir: '.claude', version: '5.0.0',
+      })
+      expect(repaired.materialized).toBe(true)
+      expect(readTextFile(reviewerPath)).toContain('# reviewer')
     })
 
     it('materializes a codex framework with config.toml but no project-named AGENTS.md', () => {

--- a/src/installer/phases/install-config.test.ts
+++ b/src/installer/phases/install-config.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
@@ -9,6 +9,7 @@ import {
   CONFIG_RELATIVE_PATH,
   InvalidConfigError,
   loadInstallConfig,
+  resolveProviderModelConfig,
   resolveConfigPath,
   validateInstallConfig,
   writeInstallConfig,
@@ -60,6 +61,152 @@ describe('install-config', () => {
       expect(result.provider).toBe('gemini')
     })
 
+    it('accepts kimi as a valid provider', () => {
+      const result = validateInstallConfig({
+        version: 1,
+        provider: 'kimi',
+        agents: { selected: ['sr-architect'] },
+      })
+      expect(result.provider).toBe('kimi')
+      expect(result.models).toEqual({
+        preset: 'balanced',
+        defaults: { model: 'k3' },
+        overrides: {},
+      })
+    })
+
+    it.each(['balanced', 'budget', 'max'] as const)(
+      'resolves the %s preset to an explicit Kimi model id',
+      (preset) => {
+        expect(resolveProviderModelConfig('kimi', preset)).toEqual({
+          preset,
+          defaults: { model: 'k3' },
+          overrides: {},
+        })
+      },
+    )
+
+    it('retains exact custom Kimi aliases without Claude interpretation', () => {
+      const result = validateInstallConfig({
+        version: 1,
+        provider: 'kimi',
+        agents: { selected: ['sr-architect'] },
+        models: {
+          preset: 'max',
+          defaults: { model: 'sonnet' },
+          overrides: { 'sr-architect': 'company/custom-kimi' },
+        },
+      })
+      expect(result.models).toEqual({
+        preset: 'max',
+        defaults: { model: 'sonnet' },
+        overrides: { 'sr-architect': 'company/custom-kimi' },
+      })
+    })
+
+    it.each([
+      '--yolo',
+      'team model',
+      ' team/model',
+      'team/model ',
+      'team/model\n--yolo',
+      `a${'b'.repeat(128)}`,
+    ])('rejects unsafe Kimi model id %j before installation', (model) => {
+      expect(() =>
+        validateInstallConfig({
+          version: 1,
+          provider: 'kimi',
+          agents: { selected: ['sr-architect'] },
+          models: {
+            preset: 'balanced',
+            defaults: { model },
+            overrides: { 'sr-reviewer': model },
+          },
+        }),
+      ).toThrow(/safe Kimi model id/)
+    })
+
+    it('rejects blank Kimi model identifiers', () => {
+      expect(() =>
+        validateInstallConfig({
+          version: 1,
+          provider: 'kimi',
+          agents: { selected: ['sr-architect'] },
+          models: {
+            preset: 'balanced',
+            defaults: { model: '  ' },
+            overrides: {},
+          },
+        }),
+      ).toThrow(/safe Kimi model id/)
+    })
+
+    it('validates every selected and excluded agent id', () => {
+      try {
+        validateInstallConfig({
+          version: 1,
+          provider: 'kimi',
+          agents: {
+            selected: ['sr-architect', '../escape', 42, '-leading'],
+            excluded: ['sr-reviewer', 'UPPERCASE', 'x'.repeat(65)],
+          },
+        })
+        throw new Error('expected config validation to fail')
+      } catch (err) {
+        expect(err).toBeInstanceOf(InvalidConfigError)
+        expect((err as InvalidConfigError).errors).toEqual(
+          expect.arrayContaining([
+            expect.stringContaining(`'agents.selected[1]'`),
+            expect.stringContaining(`'agents.selected[2]'`),
+            expect.stringContaining(`'agents.selected[3]'`),
+            expect.stringContaining(`'agents.excluded[1]'`),
+            expect.stringContaining(`'agents.excluded[2]'`),
+          ]),
+        )
+      }
+    })
+
+    it('rejects duplicate and overlapping selected/excluded agents', () => {
+      try {
+        validateInstallConfig({
+          version: 1,
+          provider: 'kimi',
+          agents: {
+            selected: ['sr-architect', 'sr-architect', 'sr-reviewer'],
+            excluded: ['sr-reviewer', 'sr-reviewer'],
+          },
+        })
+        throw new Error('expected config validation to fail')
+      } catch (err) {
+        expect(err).toBeInstanceOf(InvalidConfigError)
+        const messages = (err as InvalidConfigError).errors.join('\n')
+        expect(messages).toContain(
+          `'agents.selected' must not contain duplicate agent id 'sr-architect'`,
+        )
+        expect(messages).toContain(
+          `'agents.excluded' must not contain duplicate agent id 'sr-reviewer'`,
+        )
+        expect(messages).toContain(
+          `'agents.selected' and 'agents.excluded' must not overlap: sr-reviewer`,
+        )
+      }
+    })
+
+    it('rejects unsafe per-agent override keys', () => {
+      expect(() =>
+        validateInstallConfig({
+          version: 1,
+          provider: 'kimi',
+          agents: { selected: ['sr-architect'] },
+          models: {
+            preset: 'balanced',
+            defaults: { model: 'k3' },
+            overrides: { '../escape': 'k3' },
+          },
+        }),
+      ).toThrow(/models\.overrides.*lowercase kebab-case agent id/)
+    })
+
     it('accepts an optional tier and preset', () => {
       const result = validateInstallConfig({
         version: 1,
@@ -104,14 +251,14 @@ describe('install-config', () => {
       }
     })
 
-    it('rejects codex provider with a coming-soon message', () => {
-      try {
-        validateInstallConfig({ version: 1, provider: 'codex', agents: { selected: [] } })
-      } catch (err) {
-        const msgs = (err as InvalidConfigError).errors.join('\n')
-        expect(msgs).toContain('Codex')
-        expect(msgs).toContain('coming soon')
-      }
+    it('accepts codex as a valid provider', () => {
+      const result = validateInstallConfig({
+        version: 1,
+        provider: 'codex',
+        agents: { selected: [] },
+      })
+      expect(result.provider).toBe('codex')
+      expect(result.models?.defaults.model).toBe('gpt-5.5-mini')
     })
 
     it('rejects missing agents.selected', () => {
@@ -187,6 +334,7 @@ describe('install-config', () => {
       expect(cfg!.provider).toBe('claude')
       expect(cfg!.agents.selected).toEqual(['sr-architect', 'sr-developer'])
       expect(cfg!.agents.preset).toBe('balanced')
+      expect(cfg!.models?.defaults.model).toBe('sonnet')
     })
 
     it('surfaces YAML parse errors as InvalidConfigError', () => {
@@ -208,6 +356,46 @@ describe('install-config', () => {
       const cfg = loadInstallConfig(p)
       expect(cfg!.tier).toBe('quick')
       expect(cfg!.agents.preset).toBe('max')
+      expect(cfg!.models).toEqual({
+        preset: 'max',
+        defaults: { model: 'sonnet' },
+        overrides: {
+          'sr-architect': 'opus',
+          'sr-product-manager': 'opus',
+        },
+      })
+    })
+  })
+
+  describe('integration contract consistency', () => {
+    it('publishes exactly the config providers and preset values the validator resolves', () => {
+      const contract = JSON.parse(
+        readFileSync(path.join(process.cwd(), 'integration-contract.json'), 'utf8'),
+      ) as {
+        schemaVersion: string
+        configSchema: { fields: Record<string, string> }
+        modelPresets: Record<
+          'balanced' | 'budget' | 'max',
+          {
+            defaults: { model: string }
+            overrides: Record<string, string>
+          }
+        >
+      }
+
+      expect(contract.schemaVersion).toBe('3.2')
+      expect(contract.configSchema.fields.provider).toBe(
+        'string — claude | codex | gemini | kimi',
+      )
+      expect(contract.configSchema.fields.provider).not.toContain('auto')
+
+      for (const preset of ['balanced', 'budget', 'max'] as const) {
+        const resolved = resolveProviderModelConfig('claude', preset)
+        expect(contract.modelPresets[preset]).toMatchObject({
+          defaults: resolved.defaults,
+          overrides: resolved.overrides,
+        })
+      }
     })
   })
 })

--- a/src/installer/phases/install-config.ts
+++ b/src/installer/phases/install-config.ts
@@ -8,13 +8,22 @@ import { pathExists, readTextFile, writeFileLf } from '../util/fs.js'
 /**
  * Provider identifier. Kept in lock-step with `provider-detect.ts` `Provider`.
  */
-export type Provider = 'claude' | 'codex' | 'gemini'
+export type Provider = 'claude' | 'codex' | 'gemini' | 'kimi'
 
 /** Install tier selected at install time. */
 export type Tier = 'full' | 'quick'
 
 /** Cost / capability preset for the model picker. */
 export type ModelPreset = 'balanced' | 'budget' | 'max'
+
+/** Provider-native model selection retained verbatim in install-config.yaml. */
+export interface InstallModelConfig {
+  preset: ModelPreset
+  defaults: {
+    model: string
+  }
+  overrides: Record<string, string>
+}
 
 /**
  * Shape of the `.specrails/install-config.yaml` file — the single
@@ -27,7 +36,64 @@ export interface InstallConfig {
   tier?: Tier
   agents: {
     selected: string[]
+    excluded?: string[]
+    /** Legacy pre-models-section location, accepted for backward compatibility. */
     preset?: ModelPreset
+  }
+  models?: InstallModelConfig
+}
+
+const PROVIDER_DEFAULT_MODELS: Record<Provider, string> = {
+  claude: 'sonnet',
+  codex: 'gpt-5.5-mini',
+  gemini: 'gemini-3.5-flash',
+  kimi: 'k3',
+}
+
+/**
+ * Agent ids become provider-native file/directory names. Keep them to the
+ * portable direct-child skill grammar so config cannot escape an install root
+ * or create names that Kimi's managed runner will later reject.
+ */
+const SAFE_AGENT_ID = /^[a-z0-9][a-z0-9-]{0,63}$/
+
+/**
+ * Must remain byte-for-byte equivalent to the canonical Kimi runtime and the
+ * public integration contract. Config validation happens before any framework
+ * write so an unsafe model can never create an install that only fails later at
+ * process launch.
+ */
+const SAFE_KIMI_MODEL_ID = /^[A-Za-z0-9][A-Za-z0-9._/:-]{0,127}$/
+
+/**
+ * Resolve a preset into provider-native identifiers. Kimi currently exposes no
+ * Core-defined cost/capability tier mapping, so every named preset resolves to
+ * its explicit `k3` default. User-supplied exact identifiers are handled later
+ * and are never interpreted as Claude aliases.
+ */
+export function resolveProviderModelConfig(
+  provider: Provider,
+  preset: ModelPreset = 'balanced',
+): InstallModelConfig {
+  if (provider === 'claude') {
+    if (preset === 'budget') {
+      return { preset, defaults: { model: 'haiku' }, overrides: {} }
+    }
+    if (preset === 'max') {
+      return {
+        preset,
+        defaults: { model: 'sonnet' },
+        overrides: {
+          'sr-architect': 'opus',
+          'sr-product-manager': 'opus',
+        },
+      }
+    }
+  }
+  return {
+    preset,
+    defaults: { model: PROVIDER_DEFAULT_MODELS[provider] },
+    overrides: {},
   }
 }
 
@@ -90,8 +156,15 @@ export function validateInstallConfig(raw: unknown): InstallConfig {
 
   if (doc.provider === undefined) {
     errors.push(`missing required 'provider' field`)
-  } else if (doc.provider !== 'claude' && doc.provider !== 'codex' && doc.provider !== 'gemini') {
-    errors.push(`unsupported provider '${String(doc.provider)}' (expected: claude, codex, or gemini)`)
+  } else if (
+    doc.provider !== 'claude' &&
+    doc.provider !== 'codex' &&
+    doc.provider !== 'gemini' &&
+    doc.provider !== 'kimi'
+  ) {
+    errors.push(
+      `unsupported provider '${String(doc.provider)}' (expected: claude, codex, gemini, or kimi)`,
+    )
   }
 
   if (doc.tier !== undefined && doc.tier !== 'full' && doc.tier !== 'quick') {
@@ -99,11 +172,38 @@ export function validateInstallConfig(raw: unknown): InstallConfig {
   }
 
   const agents = doc.agents as Record<string, unknown> | undefined
+  let selectedAgents: string[] = []
+  let excludedAgents: string[] | undefined
   if (!agents || typeof agents !== 'object') {
     errors.push(`missing required 'agents' section with 'selected' list`)
   } else {
     if (!Array.isArray(agents.selected)) {
       errors.push(`'agents.selected' must be a list`)
+    } else {
+      selectedAgents = validateAgentIdList(
+        agents.selected,
+        'agents.selected',
+        errors,
+      )
+    }
+    if (agents.excluded !== undefined && !Array.isArray(agents.excluded)) {
+      errors.push(`'agents.excluded' must be a list`)
+    } else if (Array.isArray(agents.excluded)) {
+      excludedAgents = validateAgentIdList(
+        agents.excluded,
+        'agents.excluded',
+        errors,
+      )
+    }
+    if (Array.isArray(agents.selected) && Array.isArray(agents.excluded)) {
+      const excluded = new Set(excludedAgents ?? [])
+      for (const agent of selectedAgents) {
+        if (excluded.has(agent)) {
+          errors.push(
+            `'agents.selected' and 'agents.excluded' must not overlap: ${agent}`,
+          )
+        }
+      }
     }
     if (
       agents.preset !== undefined &&
@@ -117,17 +217,72 @@ export function validateInstallConfig(raw: unknown): InstallConfig {
     }
   }
 
+  const models = doc.models as Record<string, unknown> | undefined
+  if (doc.models !== undefined && (!models || typeof models !== 'object')) {
+    errors.push(`'models' must be a mapping`)
+  }
+  const modelPreset = models?.preset
+  if (
+    modelPreset !== undefined &&
+    modelPreset !== 'balanced' &&
+    modelPreset !== 'budget' &&
+    modelPreset !== 'max'
+  ) {
+    errors.push(
+      `unsupported model preset '${String(modelPreset)}' (expected: balanced, budget, or max)`,
+    )
+  }
+  const provider = doc.provider as Provider
+  const modelDefaults = models?.defaults as Record<string, unknown> | undefined
+  if (
+    models?.defaults !== undefined &&
+    (!modelDefaults || typeof modelDefaults !== 'object')
+  ) {
+    errors.push(`'models.defaults' must be a mapping`)
+  } else if (
+    modelDefaults?.model !== undefined &&
+    !isValidModelIdentifier(provider, modelDefaults.model)
+  ) {
+    errors.push(modelIdentifierError('models.defaults.model', provider))
+  }
+  const modelOverrides = models?.overrides
+  if (
+    modelOverrides !== undefined &&
+    (!modelOverrides || typeof modelOverrides !== 'object' || Array.isArray(modelOverrides))
+  ) {
+    errors.push(`'models.overrides' must be a mapping`)
+  } else if (modelOverrides && typeof modelOverrides === 'object') {
+    for (const [agent, model] of Object.entries(modelOverrides)) {
+      if (!SAFE_AGENT_ID.test(agent)) {
+        errors.push(
+          `'models.overrides' key '${agent}' must be a lowercase kebab-case agent id (1-64 characters)`,
+        )
+      }
+      if (!isValidModelIdentifier(provider, model)) {
+        errors.push(modelIdentifierError(`models.overrides.${agent}`, provider))
+      }
+    }
+  }
+
   if (errors.length > 0) {
     throw new InvalidConfigError(errors)
   }
 
-  const selected = (agents?.selected as string[]) ?? []
+  const preset = (modelPreset ?? agents?.preset ?? 'balanced') as ModelPreset
+  const resolvedModels = resolveProviderModelConfig(provider, preset)
+  if (typeof modelDefaults?.model === 'string') {
+    resolvedModels.defaults.model = modelDefaults.model
+  }
+  if (modelOverrides && typeof modelOverrides === 'object') {
+    resolvedModels.overrides = { ...(modelOverrides as Record<string, string>) }
+  }
   const result: InstallConfig = {
     version: 1,
-    provider: doc.provider as Provider,
+    provider,
     agents: {
-      selected,
+      selected: selectedAgents,
     },
+    models: resolvedModels,
   }
   // NOTE: a legacy `agent_teams` field may still be present in older configs.
   // It is intentionally ignored (not rejected) for backward compatibility.
@@ -137,7 +292,63 @@ export function validateInstallConfig(raw: unknown): InstallConfig {
   if (agents?.preset !== undefined) {
     result.agents.preset = agents.preset as ModelPreset
   }
+  if (excludedAgents !== undefined) {
+    result.agents.excluded = excludedAgents
+  }
   return result
+}
+
+function validateAgentIdList(
+  value: unknown[],
+  field: string,
+  errors: string[],
+): string[] {
+  const valid: string[] = []
+  const seen = new Set<string>()
+  for (const [index, entry] of value.entries()) {
+    if (typeof entry !== 'string' || !SAFE_AGENT_ID.test(entry)) {
+      errors.push(
+        `'${field}[${index}]' must be a lowercase kebab-case agent id (1-64 characters)`,
+      )
+      continue
+    }
+    if (seen.has(entry)) {
+      errors.push(`'${field}' must not contain duplicate agent id '${entry}'`)
+      continue
+    }
+    seen.add(entry)
+    valid.push(entry)
+  }
+  return valid
+}
+
+function isValidModelIdentifier(
+  provider: Provider,
+  value: unknown,
+): value is string {
+  if (provider === 'kimi') {
+    return typeof value === 'string' && SAFE_KIMI_MODEL_ID.test(value)
+  }
+  return isExactModelIdentifier(value)
+}
+
+function modelIdentifierError(field: string, provider: Provider): string {
+  if (provider === 'kimi') {
+    return (
+      `'${field}' must be a safe Kimi model id: 1-128 characters matching ` +
+      `[A-Za-z0-9][A-Za-z0-9._/:-]*`
+    )
+  }
+  return `'${field}' must be a nonblank provider model identifier`
+}
+
+function isExactModelIdentifier(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.trim().length > 0 &&
+    value === value.trim()
+  )
 }
 
 /**

--- a/src/installer/phases/manifest.test.ts
+++ b/src/installer/phases/manifest.test.ts
@@ -108,6 +108,51 @@ describe('manifest', () => {
       })
       expect(manifest.installed_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/)
     })
+
+    it('records and unions provider inventory for multi-provider workspaces', () => {
+      const scriptDir = path.join(tmpDir, 'core')
+      const repoRoot = path.join(tmpDir, 'repo')
+      setupFakePackage(scriptDir)
+      const claude = buildManifest({
+        scriptDir,
+        repoRoot,
+        version: '1.0.0',
+        providers: ['claude'],
+        primaryProvider: 'claude',
+      })
+      writeManifestFiles(repoRoot, claude)
+      const kimi = buildManifest({
+        scriptDir,
+        repoRoot,
+        version: '1.0.0',
+        providers: ['kimi'],
+        primaryProvider: 'kimi',
+      })
+      expect(kimi.providers).toEqual(['claude', 'kimi'])
+      expect(kimi.primary_provider).toBe('claude')
+    })
+
+    it('tracks the managed Kimi headless skill runner as a versioned artifact', () => {
+      const manifest = buildManifest({
+        scriptDir: process.cwd(),
+        repoRoot: path.join(tmpDir, 'repo-runner'),
+        version: 'test',
+      })
+      expect(
+        manifest.artifacts['templates/kimi/specrails/run-skill.mjs'],
+      ).toMatch(/^sha256:[0-9a-f]{64}$/)
+      expect(
+        manifest.artifacts[
+          'templates/kimi/specrails/vendor/js-yaml/js-yaml.mjs'
+        ],
+      ).toMatch(/^sha256:[0-9a-f]{64}$/)
+      expect(
+        manifest.artifacts['templates/kimi/specrails/vendor/js-yaml/LICENSE'],
+      ).toMatch(/^sha256:[0-9a-f]{64}$/)
+      expect(
+        manifest.artifacts['templates/kimi/specrails/vendor/js-yaml/NOTICE.md'],
+      ).toMatch(/^sha256:[0-9a-f]{64}$/)
+    })
   })
 
   describe('writeManifestFiles', () => {

--- a/src/installer/phases/manifest.ts
+++ b/src/installer/phases/manifest.ts
@@ -3,7 +3,7 @@ import { readdirSync, statSync } from 'node:fs'
 import path from 'node:path'
 
 import { FilesystemError } from '../util/errors.js'
-import { readBytes, writeFileLf } from '../util/fs.js'
+import { pathExists, readBytes, readTextFile, writeFileLf } from '../util/fs.js'
 
 /**
  * Shape of the `.specrails/specrails-manifest.json` file the installer
@@ -13,6 +13,9 @@ import { readBytes, writeFileLf } from '../util/fs.js'
 export interface SpecrailsManifest {
   version: string
   installed_at: string
+  /** Provider inventory is emitted only by provider-aware lifecycle callers. */
+  providers?: string[]
+  primary_provider?: string
   artifacts: Record<string, string>
 }
 
@@ -34,6 +37,9 @@ export interface BuildManifestInput {
   version: string
   /** Override "installed_at" — exposed for deterministic testing. */
   installedAt?: string
+  /** Provider(s) materialized by this lifecycle pass. Existing entries are unioned. */
+  providers?: string[]
+  primaryProvider?: string
 }
 
 /**
@@ -60,10 +66,41 @@ export function buildManifest(input: BuildManifestInput): SpecrailsManifest {
   artifacts['commands/specrails/enrich.md'] = sha256Of(enrichPath)
   artifacts['commands/specrails/doctor.md'] = sha256Of(doctorPath)
 
-  return {
+  const manifest: SpecrailsManifest = {
     version: input.version,
     installed_at,
     artifacts: sortKeys(artifacts),
+  }
+  if (input.providers && input.providers.length > 0) {
+    const existing = readExistingProviderInventory(input.repoRoot)
+    manifest.providers = [...new Set([...existing.providers, ...input.providers])]
+    manifest.primary_provider =
+      existing.primaryProvider ?? input.primaryProvider ?? manifest.providers[0]
+  }
+  return manifest
+}
+
+function readExistingProviderInventory(repoRoot: string): {
+  providers: string[]
+  primaryProvider?: string
+} {
+  const manifestPath = path.join(repoRoot, '.specrails', 'specrails-manifest.json')
+  if (!pathExists(manifestPath)) return { providers: [] }
+  try {
+    const parsed = JSON.parse(readTextFile(manifestPath)) as {
+      providers?: unknown
+      primary_provider?: unknown
+    }
+    const providers = Array.isArray(parsed.providers)
+      ? parsed.providers.filter((provider): provider is string => typeof provider === 'string')
+      : []
+    return {
+      providers,
+      primaryProvider:
+        typeof parsed.primary_provider === 'string' ? parsed.primary_provider : undefined,
+    }
+  } catch {
+    return { providers: [] }
   }
 }
 

--- a/src/installer/phases/prereqs.test.ts
+++ b/src/installer/phases/prereqs.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs'
+import { chmodSync, existsSync, mkdtempSync, rmSync, symlinkSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
@@ -6,7 +6,28 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { mkdirp, writeFileLf } from '../util/fs.js'
 import { initRepo } from '../util/git.js'
-import { checkPrerequisites } from './prereqs.js'
+import {
+  MIN_NODE_VERSION,
+  checkPrerequisites,
+  isSupportedNodeVersion,
+} from './prereqs.js'
+
+describe('Node.js runtime floor', () => {
+  it('matches the OpenSpec 1.4.1 minimum exactly', () => {
+    expect(MIN_NODE_VERSION).toBe('20.19.0')
+    expect(isSupportedNodeVersion('20.18.9')).toBe(false)
+    expect(isSupportedNodeVersion('20.19.0')).toBe(true)
+    expect(isSupportedNodeVersion('v20.19.1')).toBe(true)
+    expect(isSupportedNodeVersion('21.0.0')).toBe(true)
+    expect(isSupportedNodeVersion('22.19.0')).toBe(true)
+  })
+
+  it('rejects malformed and incomplete versions instead of guessing', () => {
+    expect(isSupportedNodeVersion('20.19')).toBe(false)
+    expect(isSupportedNodeVersion('latest')).toBe(false)
+    expect(isSupportedNodeVersion('')).toBe(false)
+  })
+})
 
 /**
  * checkPrerequisites is integration-shaped: it talks to git, the AI
@@ -20,16 +41,24 @@ import { checkPrerequisites } from './prereqs.js'
 describe('checkPrerequisites — OSS detection', () => {
   let tmpDir: string
   let prevSkip: string | undefined
+  let prevPath: string | undefined
+  let prevKimiHome: string | undefined
 
   beforeEach(() => {
     tmpDir = mkdtempSync(path.join(os.tmpdir(), 'specrails-prereqs-test-'))
     prevSkip = process.env.SPECRAILS_SKIP_PREREQS
+    prevPath = process.env.PATH
+    prevKimiHome = process.env.KIMI_CODE_HOME
     process.env.SPECRAILS_SKIP_PREREQS = '1'
   })
 
   afterEach(() => {
     if (prevSkip === undefined) delete process.env.SPECRAILS_SKIP_PREREQS
     else process.env.SPECRAILS_SKIP_PREREQS = prevSkip
+    if (prevPath === undefined) delete process.env.PATH
+    else process.env.PATH = prevPath
+    if (prevKimiHome === undefined) delete process.env.KIMI_CODE_HOME
+    else process.env.KIMI_CODE_HOME = prevKimiHome
     rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
   })
 
@@ -116,4 +145,88 @@ describe('checkPrerequisites — OSS detection', () => {
       expect(result.ossSignals.isOss).toBe(false)
     }
   })
+
+  function findExecutable(name: string): string {
+    for (const dir of (prevPath ?? '').split(path.delimiter)) {
+      const candidate = path.join(dir, name)
+      if (existsSync(candidate)) return candidate
+    }
+    throw new Error(`test prerequisite missing: ${name}`)
+  }
+
+  function installFakeKimi(version: string): void {
+    const binDir = path.join(tmpDir, `bin-${version.replace(/\W/g, '-')}`)
+    const kimi = path.join(binDir, 'kimi')
+    writeFileLf(
+      kimi,
+      `#!/bin/sh\nif [ "$1" = "--version" ]; then echo "kimi-code ${version}"; exit 0; fi\nexit 0\n`,
+    )
+    chmodSync(kimi, 0o755)
+    process.env.PATH = `${binDir}${path.delimiter}${prevPath ?? ''}`
+    const kimiHome = path.join(tmpDir, `kimi-home-${version}`)
+    process.env.KIMI_CODE_HOME = kimiHome
+    writeFileLf(
+      path.join(kimiHome, 'credentials', 'kimi-code.json'),
+      '{"credential":"never-read"}\n',
+    )
+  }
+
+  it.skipIf(process.platform === 'win32')(
+    'fails explicit Kimi selection with an official installation hint when kimi is missing',
+    async () => {
+      const binDir = path.join(tmpDir, 'controlled-path')
+      mkdirp(binDir)
+      for (const executable of ['which', 'git', 'npm']) {
+        symlinkSync(findExecutable(executable), path.join(binDir, executable))
+      }
+      process.env.PATH = binDir
+      const repoRoot = path.join(tmpDir, 'missing-kimi')
+      mkdirp(repoRoot)
+      await initRepo(repoRoot)
+      await expect(
+        checkPrerequisites({
+          repoRoot,
+          autoYes: true,
+          explicitProvider: 'kimi',
+          skipPrereqs: false,
+        }),
+      ).rejects.toThrow(/Kimi Code CLI is not installed.*https:\/\//)
+    },
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'rejects a Kimi CLI below the tested version floor',
+    async () => {
+      installFakeKimi('0.26.9')
+      const repoRoot = path.join(tmpDir, 'old-kimi')
+      mkdirp(repoRoot)
+      await initRepo(repoRoot)
+      await expect(
+        checkPrerequisites({
+          repoRoot,
+          autoYes: true,
+          explicitProvider: 'kimi',
+          skipPrereqs: false,
+        }),
+      ).rejects.toThrow(/0\.26\.9 is unsupported.*0\.27\.0/)
+    },
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'accepts a supported authenticated Kimi-only selection',
+    async () => {
+      installFakeKimi('0.27.0')
+      const repoRoot = path.join(tmpDir, 'supported-kimi')
+      mkdirp(repoRoot)
+      await initRepo(repoRoot)
+      const result = await checkPrerequisites({
+        repoRoot,
+        autoYes: true,
+        explicitProvider: 'kimi',
+        skipPrereqs: false,
+      })
+      expect(result.provider).toBe('kimi')
+      expect(result.availability.kimi).toBe(true)
+    },
+  )
 })

--- a/src/installer/phases/prereqs.ts
+++ b/src/installer/phases/prereqs.ts
@@ -10,10 +10,35 @@ import {
   type Provider,
   type ProviderAvailability,
   assertClaudeAuthenticated,
+  assertKimiAuthenticated,
   claudeVersion,
   detectAvailability,
+  isSupportedKimiVersion,
+  kimiVersion,
+  MIN_KIMI_VERSION,
   resolveProvider,
 } from './provider-detect.js'
+
+/**
+ * OpenSpec 1.4.1, which the installer invokes during the default init/update
+ * flow, requires Node >=20.19.0. Keep this floor independent from Kimi's npm
+ * package requirement: SpecRails launches an externally installed Kimi CLI and
+ * does not require the Kimi npm distribution.
+ */
+export const MIN_NODE_VERSION = '20.19.0'
+
+export function isSupportedNodeVersion(version: string): boolean {
+  const parsed = /^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(version.trim())
+  if (!parsed) return false
+
+  const actual = parsed.slice(1, 4).map(Number)
+  const minimum = MIN_NODE_VERSION.split('.').map(Number)
+  for (let index = 0; index < minimum.length; index++) {
+    if (actual[index]! > minimum[index]!) return true
+    if (actual[index]! < minimum[index]!) return false
+  }
+  return true
+}
 
 /**
  * Phase 1 prerequisite bundle. Mirrors install.sh's Phase 1 flow but
@@ -61,6 +86,16 @@ export interface OssSignals {
  * lines matching the retired bash output.
  */
 export async function checkPrerequisites(options: PrereqOptions): Promise<PrereqResult> {
+  const nodeVersion = process.versions.node
+  if (!isSupportedNodeVersion(nodeVersion)) {
+    throw new PrerequisiteError(
+      `Node.js ${nodeVersion} is unsupported. SpecRails requires Node.js ` +
+        `${MIN_NODE_VERSION} or newer because OpenSpec 1.4.1 uses that runtime floor. ` +
+        'Install a supported Node.js release from https://nodejs.org/',
+    )
+  }
+  ok(`Node.js: ${nodeVersion}`)
+
   if (!(await gitInstalled())) {
     throw new PrerequisiteError(
       'git is required but not on PATH. Install git: https://git-scm.com/',
@@ -96,11 +131,42 @@ export async function checkPrerequisites(options: PrereqOptions): Promise<Prereq
       ok(`Provider: claude (--provider flag)`)
     }
   }
+  if (provider === 'kimi') {
+    if (availability.kimi) {
+      const v = await kimiVersion()
+      if (!isSupportedKimiVersion(v) && !options.skipPrereqs) {
+        throw new PrerequisiteError(
+          `Kimi Code ${v} is unsupported. Upgrade to ${MIN_KIMI_VERSION} or newer: ` +
+            'https://www.kimi.com/code/docs/en/kimi-code-cli/guides/getting-started.html',
+        )
+      }
+      ok(`Kimi Code CLI: ${v}`)
+    } else if (options.explicitProvider === 'kimi') {
+      if (!options.skipPrereqs) {
+        throw new PrerequisiteError(
+          'Kimi Code CLI is not installed. Install it from https://www.kimi.com/code/docs/en/ ' +
+            'and retry, or run with SPECRAILS_SKIP_PREREQS=1 for fixture generation.',
+        )
+      }
+      ok('Provider: kimi (--provider flag)')
+    }
+  }
 
   // 1.3 Authentication for the selected provider.
   if (provider === 'claude') {
     await assertClaudeAuthenticated({ skipPrereqs: options.skipPrereqs })
     ok('Claude: authenticated')
+  }
+  if (provider === 'kimi' && availability.kimi) {
+    const status = await assertKimiAuthenticated({ skipPrereqs: options.skipPrereqs })
+    if (status === 'authenticated') {
+      ok('Kimi: authentication evidence found')
+    } else if (status === 'unknown') {
+      info(
+        'Kimi authentication could not be proven without a billable prompt; ' +
+          'the first workflow will report 401/login errors. Run `kimi login` if needed.',
+      )
+    }
   }
 
   // 1.4 npm — required for running the TUI and for the `update` command.
@@ -109,7 +175,7 @@ export async function checkPrerequisites(options: PrereqOptions): Promise<Prereq
       warn('npm not found (skipped — SPECRAILS_SKIP_PREREQS=1)')
     } else {
       throw new PrerequisiteError(
-        'npm is required but not on PATH. Install Node.js 20+ from https://nodejs.org/',
+        `npm is required but not on PATH. Install Node.js ${MIN_NODE_VERSION}+ from https://nodejs.org/`,
       )
     }
   } else {

--- a/src/installer/phases/provider-detect.test.ts
+++ b/src/installer/phases/provider-detect.test.ts
@@ -1,7 +1,18 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
+import { writeFileLf } from '../util/fs.js'
 import { ProviderError } from '../util/errors.js'
-import { derivedPaths, resolveProvider } from './provider-detect.js'
+import {
+  derivedPaths,
+  isSupportedKimiVersion,
+  parseCliVersion,
+  probeKimiAuthentication,
+  resolveProvider,
+} from './provider-detect.js'
 
 describe('provider-detect.resolveProvider', () => {
   it('uses explicit claude flag unconditionally', async () => {
@@ -53,6 +64,13 @@ describe('provider-detect.derivedPaths', () => {
   it('Gemini uses .gemini + GEMINI.md', () => {
     expect(derivedPaths('gemini')).toEqual({ providerDir: '.gemini', instructionsFile: 'GEMINI.md' })
   })
+
+  it('Kimi uses provider-local .kimi-code/AGENTS.md', () => {
+    expect(derivedPaths('kimi')).toEqual({
+      providerDir: '.kimi-code',
+      instructionsFile: '.kimi-code/AGENTS.md',
+    })
+  })
 })
 
 describe('provider-detect.resolveProvider — gemini', () => {
@@ -66,5 +84,76 @@ describe('provider-detect.resolveProvider — gemini', () => {
 
   it('still prefers claude over gemini when both are installed', async () => {
     expect(await resolveProvider({ claude: true, codex: false, gemini: true })).toBe('claude')
+  })
+})
+
+describe('provider-detect — kimi', () => {
+  it('uses explicit kimi selection even when Claude is installed', async () => {
+    expect(
+      await resolveProvider(
+        { claude: true, codex: true, gemini: true, kimi: false },
+        { explicit: 'kimi' },
+      ),
+    ).toBe('kimi')
+  })
+
+  it('returns kimi when it is the only installed provider', async () => {
+    expect(
+      await resolveProvider({ claude: false, codex: false, gemini: false, kimi: true }),
+    ).toBe('kimi')
+  })
+
+  it('keeps Claude-first auto-selection when Claude and Kimi are installed', async () => {
+    expect(
+      await resolveProvider({ claude: true, codex: false, gemini: false, kimi: true }),
+    ).toBe('claude')
+  })
+
+  it('parses and enforces the tested Kimi version floor', () => {
+    expect(parseCliVersion('kimi-code 0.27.0')).toBe('0.27.0')
+    expect(parseCliVersion('Kimi CLI v1.2.3 (typescript)')).toBe('1.2.3')
+    expect(isSupportedKimiVersion('0.26.9')).toBe(false)
+    expect(isSupportedKimiVersion('0.27.0')).toBe(true)
+    expect(isSupportedKimiVersion('0.28.1')).toBe(true)
+    expect(isSupportedKimiVersion('unknown')).toBe(false)
+  })
+
+  it('requires both process model and API key as authentication evidence', async () => {
+    const emptyHome = mkdtempSync(path.join(os.tmpdir(), 'kimi-auth-empty-'))
+    try {
+      expect(
+        await probeKimiAuthentication({
+          kimiCodeHome: emptyHome,
+          env: { PATH: '', KIMI_MODEL_API_KEY: 'secret-not-read' },
+        }),
+      ).toBe('unknown')
+      expect(
+        await probeKimiAuthentication({
+          kimiCodeHome: emptyHome,
+          env: {
+            PATH: '',
+            KIMI_MODEL_API_KEY: 'secret-not-read',
+            KIMI_MODEL_NAME: 'third-party-model',
+          },
+        }),
+      ).toBe('authenticated')
+    } finally {
+      rmSync(emptyHome, { recursive: true, force: true })
+    }
+  })
+
+  it('recognises the managed credential file without reading its secret', async () => {
+    const kimiHome = mkdtempSync(path.join(os.tmpdir(), 'kimi-auth-file-'))
+    try {
+      writeFileLf(
+        path.join(kimiHome, 'credentials', 'kimi-code.json'),
+        '{"must-not-be-parsed":"or-copied"}\n',
+      )
+      expect(
+        await probeKimiAuthentication({ kimiCodeHome: kimiHome, env: { PATH: '' } }),
+      ).toBe('authenticated')
+    } finally {
+      rmSync(kimiHome, { recursive: true, force: true })
+    }
   })
 })

--- a/src/installer/phases/provider-detect.ts
+++ b/src/installer/phases/provider-detect.ts
@@ -7,24 +7,27 @@ import { pathExists, readTextFile } from '../util/fs.js'
 
 /**
  * Provider detection + authentication checks. These mirror the Phase
- * 1.2 / 1.3 branches of the retired install.sh. Codex detection is
- * preserved so its "coming soon" error can still be surfaced when a
- * user has only codex installed.
+ * 1.2 / 1.3 branches of the retired install.sh.
  */
 
-export type Provider = 'claude' | 'codex' | 'gemini'
+export type Provider = 'claude' | 'codex' | 'gemini' | 'kimi'
+
+/** Oldest TypeScript Kimi Code CLI release covered by this integration. */
+export const MIN_KIMI_VERSION = '0.27.0'
 
 export interface ProviderAvailability {
   claude: boolean
   codex: boolean
   /** Optional so callers/tests predating Gemini still typecheck; absent = false. */
   gemini?: boolean
+  /** Optional so callers/tests predating Kimi still typecheck; absent = false. */
+  kimi?: boolean
 }
 
 export interface ProviderDerivedPaths {
-  /** Root directory inside the user's repo: `.claude` / `.codex` / `.gemini`. */
+  /** Root directory inside the user's repo: `.claude` / `.codex` / `.gemini` / `.kimi-code`. */
   providerDir: string
-  /** Top-level instructions file: `CLAUDE.md` / `AGENTS.md` / `GEMINI.md`. */
+  /** Instructions file relative to the artifact root. */
   instructionsFile: string
 }
 
@@ -33,12 +36,13 @@ export interface ProviderDerivedPaths {
  * `which` on POSIX via the cross-platform commandExists helper.
  */
 export async function detectAvailability(): Promise<ProviderAvailability> {
-  const [claude, codex, gemini] = await Promise.all([
+  const [claude, codex, gemini, kimi] = await Promise.all([
     commandExists('claude'),
     commandExists('codex'),
     commandExists('gemini'),
+    commandExists('kimi'),
   ])
-  return { claude, codex, gemini }
+  return { claude, codex, gemini, kimi }
 }
 
 /**
@@ -54,13 +58,37 @@ export async function claudeVersion(): Promise<string> {
   }
 }
 
+/** Returns the raw Kimi Code CLI version or `unknown` when it cannot be probed. */
+export async function kimiVersion(): Promise<string> {
+  try {
+    const { stdout, stderr } = await runCommand('kimi', ['--version'], {
+      inherit: false,
+      timeoutMs: 10_000,
+    })
+    return stdout.trim() || stderr.trim() || 'unknown'
+  } catch {
+    return 'unknown'
+  }
+}
+
+/** Extracts a semver-like triple from version output such as `kimi-code 0.27.0`. */
+export function parseCliVersion(raw: string): string | null {
+  return /(?:^|[^\d])(\d+)\.(\d+)\.(\d+)(?:[^\d]|$)/.exec(raw)?.slice(1, 4).join('.') ?? null
+}
+
+/** True when `raw` identifies a Kimi CLI at or above {@link MIN_KIMI_VERSION}. */
+export function isSupportedKimiVersion(raw: string): boolean {
+  const parsed = parseCliVersion(raw)
+  if (!parsed) return false
+  return compareVersionTriples(parsed, MIN_KIMI_VERSION) >= 0
+}
+
 /**
  * Resolves which provider the installer should use. Priority:
  *   1. Explicit `--provider claude` flag (already passed through args).
  *   2. Config file (read upstream in install-config.ts).
  *   3. Whichever CLI is installed.
  *
- * Codex-only installs error out — see design: Codex is "coming soon".
  * The caller may bypass prereq failures with `skipPrereqs: true`
  * (env `SPECRAILS_SKIP_PREREQS=1`).
  */
@@ -71,19 +99,22 @@ export async function resolveProvider(
   if (options.explicit === 'codex') return 'codex'
   if (options.explicit === 'claude') return 'claude'
   if (options.explicit === 'gemini') return 'gemini'
+  if (options.explicit === 'kimi') return 'kimi'
 
   // No multi-provider auto-pick beyond the historical Claude-first default: when
   // several CLIs are installed and no provider was requested, prefer Claude so
   // existing projects don't get re-bootstrapped onto a different provider. Users
-  // pick codex/gemini via --provider or install-config.yaml.
+  // pick codex/gemini/kimi via --provider or install-config.yaml.
   if (availability.claude) return 'claude'
   if (availability.codex) return 'codex'
   if (availability.gemini) return 'gemini'
+  if (availability.kimi) return 'kimi'
   if (options.skipPrereqs) return 'claude'
   throw new ProviderError(
     'No AI CLI found. Install Claude Code (https://claude.ai/download), ' +
       'Codex CLI (https://developers.openai.com/codex), or ' +
-      'Gemini CLI (https://github.com/google-gemini/gemini-cli) before running specrails-core init.',
+      'Gemini CLI (https://github.com/google-gemini/gemini-cli), or ' +
+      'Kimi Code (https://www.kimi.com/code/docs/en/) before running specrails-core init.',
   )
 }
 
@@ -91,6 +122,8 @@ export async function resolveProvider(
  * Directory / filename conventions the provider dictates.
  *   - Claude Code:  .claude/ + CLAUDE.md
  *   - Codex:        .codex/  + AGENTS.md
+ *   - Gemini CLI:   .gemini/ + GEMINI.md
+ *   - Kimi Code:    .kimi-code/ + AGENTS.md
  */
 export function derivedPaths(provider: Provider): ProviderDerivedPaths {
   if (provider === 'codex') {
@@ -99,7 +132,13 @@ export function derivedPaths(provider: Provider): ProviderDerivedPaths {
   if (provider === 'gemini') {
     return { providerDir: '.gemini', instructionsFile: 'GEMINI.md' }
   }
-  return { providerDir: '.claude', instructionsFile: 'CLAUDE.md' }
+  if (provider === 'kimi') {
+    return { providerDir: '.kimi-code', instructionsFile: '.kimi-code/AGENTS.md' }
+  }
+  if (provider === 'claude') {
+    return { providerDir: '.claude', instructionsFile: 'CLAUDE.md' }
+  }
+  throw new ProviderError(`Unsupported provider: ${String(provider)}`)
 }
 
 /**
@@ -126,6 +165,72 @@ export async function assertClaudeAuthenticated(
   )
 }
 
+export type KimiAuthenticationStatus = 'authenticated' | 'unauthenticated' | 'unknown'
+
+/**
+ * Bounded, non-billing Kimi authentication probe.
+ *
+ * Kimi 0.27 has no CLI command that proves managed OAuth readiness without
+ * starting a model request. We therefore recognise non-secret evidence (the
+ * managed credential file or a process-scoped model key), and honour explicit
+ * login failures emitted by `kimi doctor`. A successful `kimi doctor` only
+ * validates configuration, so it deliberately yields `unknown`.
+ */
+export async function probeKimiAuthentication(
+  options: { kimiCodeHome?: string; env?: NodeJS.ProcessEnv } = {},
+): Promise<KimiAuthenticationStatus> {
+  const env = options.env ?? process.env
+  if (
+    typeof env.KIMI_MODEL_API_KEY === 'string' &&
+    env.KIMI_MODEL_API_KEY.length > 0 &&
+    typeof env.KIMI_MODEL_NAME === 'string' &&
+    env.KIMI_MODEL_NAME.length > 0
+  ) {
+    return 'authenticated'
+  }
+
+  const kimiHome =
+    options.kimiCodeHome ??
+    (typeof env.KIMI_CODE_HOME === 'string' && env.KIMI_CODE_HOME.length > 0
+      ? env.KIMI_CODE_HOME
+      : path.join(homedir(), '.kimi-code'))
+  if (pathExists(path.join(kimiHome, 'credentials', 'kimi-code.json'))) {
+    return 'authenticated'
+  }
+
+  try {
+    const { stdout, stderr } = await runCommand('kimi', ['doctor'], {
+      inherit: false,
+      timeoutMs: 10_000,
+      env,
+    })
+    return textReportsMissingKimiLogin(`${stdout}\n${stderr}`) ? 'unauthenticated' : 'unknown'
+  } catch (error) {
+    const probe = error as { stdout?: string; stderr?: string; message?: string }
+    const text = `${probe.stdout ?? ''}\n${probe.stderr ?? ''}\n${probe.message ?? ''}`
+    return textReportsMissingKimiLogin(text) ? 'unauthenticated' : 'unknown'
+  }
+}
+
+/**
+ * Rejects only a conclusive login failure. `unknown` is allowed because setup
+ * must not spend quota merely to prove authentication.
+ */
+export async function assertKimiAuthenticated(
+  options: { skipPrereqs?: boolean; kimiCodeHome?: string; env?: NodeJS.ProcessEnv } = {},
+): Promise<KimiAuthenticationStatus> {
+  const status = await probeKimiAuthentication(options)
+  if (status !== 'unauthenticated' || options.skipPrereqs) return status
+  throw new ProviderError(
+    [
+      'Kimi Code is installed but login is required.',
+      '',
+      '  Run: kimi login',
+      '  Then retry specrails-core init.',
+    ].join('\n'),
+  )
+}
+
 async function hasClaudeApiKeyConfigured(): Promise<boolean> {
   try {
     const { stdout } = await runCommand('claude', ['config', 'list'], { inherit: false })
@@ -144,4 +249,25 @@ async function hasClaudeOauthJson(): Promise<boolean> {
   } catch {
     return false
   }
+}
+
+function textReportsMissingKimiLogin(raw: string): boolean {
+  const text = raw.toLowerCase()
+  return (
+    text.includes('login required') ||
+    text.includes('not logged in') ||
+    text.includes('not authenticated') ||
+    text.includes('please run kimi login') ||
+    text.includes('run `kimi login`')
+  )
+}
+
+function compareVersionTriples(left: string, right: string): number {
+  const a = left.split('.').map(Number)
+  const b = right.split('.').map(Number)
+  for (let i = 0; i < 3; i++) {
+    const diff = (a[i] ?? 0) - (b[i] ?? 0)
+    if (diff !== 0) return diff
+  }
+  return 0
 }

--- a/src/installer/phases/scaffold.test.ts
+++ b/src/installer/phases/scaffold.test.ts
@@ -1091,7 +1091,9 @@ describe('Kimi scaffold', () => {
         ),
       ),
     ).toBe('js-yaml fixture license\n')
-    expect(assembled.links.specrails).toBe('symlink')
+    expect(assembled.links.specrails).toBe(
+      process.platform === 'win32' ? 'junction' : 'symlink',
+    )
   })
 
   it('never overwrites a flat custom role when the legacy nested migration conflicts', () => {

--- a/src/installer/phases/scaffold.test.ts
+++ b/src/installer/phases/scaffold.test.ts
@@ -2,13 +2,25 @@ import { createHash } from 'node:crypto'
 import { mkdtempSync, rmSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { isDir, pathExists, readTextFile, writeFileLf } from '../util/fs.js'
 import {
+  isDir,
+  isSymlink,
+  listDir,
+  pathExists,
+  readTextFile,
+  writeFileLf,
+} from '../util/fs.js'
+import {
+  assembleProjectWorkspace,
   detectExistingSetup,
+  ensureCurrentSymlink,
+  installFramework,
   scaffoldInstallation,
+  translateClaudeTextForKimi,
   translateOpsxSkillCallsForGemini,
   writeGeminiAgentAcknowledgments,
 } from './scaffold.js'
@@ -764,5 +776,702 @@ describe('writeGeminiAgentAcknowledgments', () => {
     const ack = JSON.parse(readTextFile(ackFile())) as Record<string, Record<string, string>>
     expect(ack[workspace]['sr-architect']).toBe(sha('ws-arch\n'))
     expect(ack[repo]).toBeUndefined() // repo is NOT the key under relocation
+  })
+})
+
+describe('Kimi scaffold', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'specrails-kimi-scaffold-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+  })
+
+  function setupKimiSource(scriptDir: string): void {
+    setupRichFakeSource(scriptDir)
+    writeFileLf(
+      path.join(scriptDir, 'templates', 'kimi', 'specrails', 'run-skill.mjs'),
+      '// managed Kimi runner fixture\n',
+    )
+    writeFileLf(
+      path.join(
+        scriptDir,
+        'templates',
+        'kimi',
+        'specrails',
+        'vendor',
+        'js-yaml',
+        'js-yaml.mjs',
+      ),
+      '// vendored js-yaml fixture\n',
+    )
+    writeFileLf(
+      path.join(
+        scriptDir,
+        'templates',
+        'kimi',
+        'specrails',
+        'vendor',
+        'js-yaml',
+        'LICENSE',
+      ),
+      'js-yaml fixture license\n',
+    )
+    writeFileLf(
+      path.join(
+        scriptDir,
+        'templates',
+        'kimi',
+        'specrails',
+        'vendor',
+        'js-yaml',
+        'NOTICE.md',
+      ),
+      'js-yaml fixture notice\n',
+    )
+    writeFileLf(
+      path.join(scriptDir, 'templates', 'agents', 'sr-architect.md'),
+      [
+        '---',
+        'name: sr-architect',
+        'description: "Architecture role"',
+        'model: sonnet',
+        '---',
+        'Run Skill("opsx:ff", "<change>") and read .claude/rules/.',
+        '',
+      ].join('\n'),
+    )
+  }
+
+  it('renders directory workflows and rail roles without Claude invocation syntax', () => {
+    const scriptDir = path.join(tmpDir, 'core')
+    const repoRoot = path.join(tmpDir, 'repo')
+    setupKimiSource(scriptDir)
+
+    scaffoldInstallation({
+      scriptDir,
+      artifactRoot: repoRoot,
+      codeRoot: repoRoot,
+      provider: 'kimi',
+      providerDir: '.kimi-code',
+      tier: 'quick',
+    })
+
+    const workflow = readTextFile(
+      path.join(repoRoot, '.kimi-code', 'skills', 'specrails-implement', 'SKILL.md'),
+    )
+    expect(workflow).toContain('name: specrails-implement')
+    expect(workflow).toContain('description:')
+    expect(workflow).toContain('Skill(skill="specrails-implement"')
+    expect(workflow).toContain('kimi-code/k3')
+    expect(workflow).not.toContain('/specrails:')
+    expect(workflow).not.toContain('/skill:')
+    expect(workflow).not.toContain('subagent_type')
+    expect(workflow).not.toContain('.claude/')
+
+    const role = readTextFile(
+      path.join(repoRoot, '.kimi-code', 'skills', 'sr-architect', 'SKILL.md'),
+    )
+    expect(role).toContain('name: sr-architect')
+    expect(role).toContain(
+      'Skill(skill="openspec-ff-change", args="<change>")',
+    )
+    expect(role).toContain('.kimi-code/rules/')
+    expect(role).not.toContain('Skill("opsx:')
+    expect(role).not.toContain('/skill:')
+
+    const instructions = readTextFile(path.join(repoRoot, '.kimi-code', 'AGENTS.md'))
+    expect(instructions).toContain('/skill:specrails-<command>')
+    expect(pathExists(path.join(repoRoot, '.kimi-code', 'mcp.json'))).toBe(true)
+    expect(pathExists(path.join(repoRoot, 'AGENTS.md'))).toBe(false)
+    expect(pathExists(path.join(repoRoot, '.kimi-code', 'commands'))).toBe(false)
+    expect(pathExists(path.join(repoRoot, '.kimi-code', 'agents'))).toBe(false)
+    expect(
+      pathExists(
+        path.join(repoRoot, '.kimi-code', 'specrails', 'run-skill.mjs'),
+      ),
+    ).toBe(true)
+    expect(
+      pathExists(
+        path.join(
+          repoRoot,
+          '.kimi-code',
+          'specrails',
+          'vendor',
+          'js-yaml',
+          'js-yaml.mjs',
+        ),
+      ),
+    ).toBe(true)
+    expect(
+      pathExists(
+        path.join(repoRoot, '.kimi-code', 'skills', 'specrails', 'run-skill.mjs'),
+      ),
+    ).toBe(false)
+  })
+
+  it('rematerializes a same-version framework that still has nested role skills', () => {
+    const scriptDir = path.join(tmpDir, 'core')
+    const frameworkDir = path.join(tmpDir, 'framework')
+    setupKimiSource(scriptDir)
+
+    const initial = installFramework({
+      scriptDir,
+      frameworkDir,
+      provider: 'kimi',
+      providerDir: '.kimi-code',
+      version: '1.2.3',
+    })
+    expect(initial.materialized).toBe(true)
+
+    const skillsDir = path.join(initial.providerFrameworkDir, 'skills')
+    rmSync(path.join(skillsDir, 'sr-architect'), { recursive: true, force: true })
+    writeFileLf(
+      path.join(skillsDir, 'rails', 'sr-architect', 'SKILL.md'),
+      'undiscoverable-pre-release-role\n',
+    )
+
+    const repaired = installFramework({
+      scriptDir,
+      frameworkDir,
+      provider: 'kimi',
+      providerDir: '.kimi-code',
+      version: '1.2.3',
+    })
+    expect(repaired.materialized).toBe(true)
+    expect(pathExists(path.join(skillsDir, 'rails'))).toBe(false)
+    expect(pathExists(path.join(skillsDir, 'sr-architect', 'SKILL.md'))).toBe(true)
+
+    const idempotent = installFramework({
+      scriptDir,
+      frameworkDir,
+      provider: 'kimi',
+      providerDir: '.kimi-code',
+      version: '1.2.3',
+    })
+    expect(idempotent.materialized).toBe(false)
+  })
+
+  it('repairs a same-version framework that predates the managed skill runner', () => {
+    const scriptDir = path.join(tmpDir, 'core')
+    const frameworkDir = path.join(tmpDir, 'framework-runner-repair')
+    setupKimiSource(scriptDir)
+
+    const initial = installFramework({
+      scriptDir,
+      frameworkDir,
+      provider: 'kimi',
+      providerDir: '.kimi-code',
+      version: '1.2.3',
+    })
+    const runnerPath = path.join(
+      initial.providerFrameworkDir,
+      'specrails',
+      'run-skill.mjs',
+    )
+    rmSync(runnerPath, { force: true })
+
+    const repaired = installFramework({
+      scriptDir,
+      frameworkDir,
+      provider: 'kimi',
+      providerDir: '.kimi-code',
+      version: '1.2.3',
+    })
+    expect(repaired.materialized).toBe(true)
+    expect(readTextFile(runnerPath)).toBe('// managed Kimi runner fixture\n')
+  })
+
+  it('repairs a same-version framework missing the runner YAML vendor', () => {
+    const scriptDir = path.join(tmpDir, 'core')
+    const frameworkDir = path.join(tmpDir, 'framework-vendor-repair')
+    setupKimiSource(scriptDir)
+
+    const initial = installFramework({
+      scriptDir,
+      frameworkDir,
+      provider: 'kimi',
+      providerDir: '.kimi-code',
+      version: '1.2.3',
+    })
+    const vendorPath = path.join(
+      initial.providerFrameworkDir,
+      'specrails',
+      'vendor',
+      'js-yaml',
+      'js-yaml.mjs',
+    )
+    rmSync(vendorPath, { force: true })
+
+    const repaired = installFramework({
+      scriptDir,
+      frameworkDir,
+      provider: 'kimi',
+      providerDir: '.kimi-code',
+      version: '1.2.3',
+    })
+    expect(repaired.materialized).toBe(true)
+    expect(readTextFile(vendorPath)).toBe('// vendored js-yaml fixture\n')
+  })
+
+  it('assembles granular skills while preserving OpenSpec, custom roles, and user MCP config', () => {
+    const scriptDir = path.join(tmpDir, 'core')
+    const frameworkDir = path.join(tmpDir, 'framework')
+    const workspace = path.join(tmpDir, 'workspace')
+    const codeRoot = path.join(tmpDir, 'repo')
+    setupKimiSource(scriptDir)
+
+    installFramework({
+      scriptDir,
+      frameworkDir,
+      provider: 'kimi',
+      providerDir: '.kimi-code',
+      version: '1.2.3',
+    })
+    ensureCurrentSymlink(frameworkDir, '1.2.3')
+    writeFileLf(
+      path.join(workspace, '.kimi-code', 'skills', 'rails', 'custom-auditor', 'SKILL.md'),
+      'custom-role-byte-content\n',
+    )
+    writeFileLf(
+      path.join(workspace, '.kimi-code', 'skills', 'openspec-apply-change', 'SKILL.md'),
+      'corrected-upstream-byte-content\n',
+    )
+    writeFileLf(path.join(workspace, '.kimi-code', 'mcp.json'), '{"user":true}\n')
+
+    const assembled = assembleProjectWorkspace({
+      workspace,
+      frameworkDir,
+      provider: 'kimi',
+      providerDir: '.kimi-code',
+      version: '1.2.3',
+      codeRoot,
+      scriptDir,
+    })
+
+    expect(
+      readTextFile(
+        path.join(workspace, '.kimi-code', 'skills', 'custom-auditor', 'SKILL.md'),
+      ),
+    ).toBe('custom-role-byte-content\n')
+    expect(pathExists(path.join(workspace, '.kimi-code', 'skills', 'rails'))).toBe(false)
+    expect(
+      readTextFile(
+        path.join(workspace, '.kimi-code', 'skills', 'openspec-apply-change', 'SKILL.md'),
+      ),
+    ).toBe('corrected-upstream-byte-content\n')
+    expect(readTextFile(path.join(workspace, '.kimi-code', 'mcp.json'))).toBe('{"user":true}\n')
+    expect(
+      pathExists(
+        path.join(workspace, '.kimi-code', 'skills', 'sr-architect', 'SKILL.md'),
+      ),
+    ).toBe(true)
+    expect(
+      pathExists(path.join(workspace, '.kimi-code', 'skills', 'specrails-implement', 'SKILL.md'),
+    )).toBe(true)
+    expect(pathExists(path.join(workspace, '.kimi-code', 'AGENTS.md'))).toBe(true)
+    expect(pathExists(path.join(workspace, 'AGENTS.md'))).toBe(false)
+    expect(
+      readTextFile(
+        path.join(workspace, '.kimi-code', 'specrails', 'run-skill.mjs'),
+      ),
+    ).toBe('// managed Kimi runner fixture\n')
+    expect(
+      readTextFile(
+        path.join(
+          workspace,
+          '.kimi-code',
+          'specrails',
+          'vendor',
+          'js-yaml',
+          'LICENSE',
+        ),
+      ),
+    ).toBe('js-yaml fixture license\n')
+    expect(assembled.links.specrails).toBe('symlink')
+  })
+
+  it('never overwrites a flat custom role when the legacy nested migration conflicts', () => {
+    const scriptDir = path.join(tmpDir, 'core')
+    const frameworkDir = path.join(tmpDir, 'framework')
+    const workspace = path.join(tmpDir, 'workspace-conflict')
+    setupKimiSource(scriptDir)
+
+    installFramework({
+      scriptDir,
+      frameworkDir,
+      provider: 'kimi',
+      providerDir: '.kimi-code',
+      version: '1.2.3',
+    })
+    ensureCurrentSymlink(frameworkDir, '1.2.3')
+    writeFileLf(
+      path.join(workspace, '.kimi-code', 'skills', 'custom-auditor', 'SKILL.md'),
+      'canonical-custom-role\n',
+    )
+    writeFileLf(
+      path.join(
+        workspace,
+        '.kimi-code',
+        'skills',
+        'rails',
+        'custom-auditor',
+        'SKILL.md',
+      ),
+      'legacy-conflicting-role\n',
+    )
+
+    assembleProjectWorkspace({
+      workspace,
+      frameworkDir,
+      provider: 'kimi',
+      providerDir: '.kimi-code',
+      version: '1.2.3',
+      codeRoot: path.join(tmpDir, 'repo-conflict'),
+      scriptDir,
+    })
+
+    expect(
+      readTextFile(
+        path.join(workspace, '.kimi-code', 'skills', 'custom-auditor', 'SKILL.md'),
+      ),
+    ).toBe('canonical-custom-role\n')
+    expect(
+      readTextFile(
+        path.join(
+          workspace,
+          '.kimi-code',
+          'skills',
+          'rails',
+          'custom-auditor',
+          'SKILL.md',
+        ),
+      ),
+    ).toBe('legacy-conflicting-role\n')
+  })
+
+  it('keeps MCP registries as isolated real files across relocated workspaces', () => {
+    const scriptDir = path.join(tmpDir, 'core')
+    const frameworkDir = path.join(tmpDir, 'framework')
+    const workspaceA = path.join(tmpDir, 'workspace-a')
+    const workspaceB = path.join(tmpDir, 'workspace-b')
+    setupKimiSource(scriptDir)
+
+    installFramework({
+      scriptDir,
+      frameworkDir,
+      provider: 'kimi',
+      providerDir: '.kimi-code',
+      version: '1.2.3',
+    })
+    ensureCurrentSymlink(frameworkDir, '1.2.3')
+    for (const [workspace, repo] of [
+      [workspaceA, path.join(tmpDir, 'repo-a')],
+      [workspaceB, path.join(tmpDir, 'repo-b')],
+    ]) {
+      assembleProjectWorkspace({
+        workspace,
+        frameworkDir,
+        provider: 'kimi',
+        providerDir: '.kimi-code',
+        version: '1.2.3',
+        codeRoot: repo,
+        scriptDir,
+      })
+    }
+
+    const mcpA = path.join(workspaceA, '.kimi-code', 'mcp.json')
+    const mcpB = path.join(workspaceB, '.kimi-code', 'mcp.json')
+    const frameworkMcp = path.join(
+      frameworkDir,
+      '1.2.3',
+      '.kimi-code',
+      'mcp.json',
+    )
+    expect(isSymlink(mcpA)).toBe(false)
+    expect(isSymlink(mcpB)).toBe(false)
+    expect(pathExists(frameworkMcp)).toBe(false)
+
+    writeFileLf(mcpA, '{"mcpServers":{"desktop-project-a":{"command":"a"}}}\n')
+    expect(readTextFile(mcpB)).toBe('{\n  "mcpServers": {}\n}\n')
+    expect(pathExists(frameworkMcp)).toBe(false)
+  })
+
+  it('translates provider paths, workflow names, and non-uniform OpenSpec ids', () => {
+    expect(
+      translateClaudeTextForKimi(
+        'Skill("opsx:sync") /specrails:why /sr:implement .claude/agents/sr-reviewer.md subagent_type',
+      ),
+    ).toBe(
+      'Skill(skill="openspec-sync-specs", args="") ' +
+        'Skill(skill="specrails-why", args=<arguments following this command>) ' +
+        'Skill(skill="specrails-implement", args=<arguments following this command>) ' +
+        '.kimi-code/skills/sr-reviewer/SKILL.md role_skill',
+    )
+  })
+
+  it('renders the complete real-template inventory with no forbidden provider syntax', async () => {
+    const scriptDir = process.cwd()
+    const repoRoot = path.join(tmpDir, 'real-inventory')
+    scaffoldInstallation({
+      scriptDir,
+      artifactRoot: repoRoot,
+      codeRoot: repoRoot,
+      provider: 'kimi',
+      providerDir: '.kimi-code',
+      tier: 'quick',
+      materializeAllAgents: true,
+    })
+
+    const canonicalCommands = listDir(path.join(scriptDir, 'templates', 'commands', 'specrails'))
+      .filter((entry) => entry.endsWith('.md') && path.basename(entry) !== 'setup.md')
+      .map((entry) => `specrails-${path.basename(entry, '.md')}`)
+      .sort()
+    const workflowRoot = path.join(repoRoot, '.kimi-code', 'skills')
+    const generatedSkillDirs = listDir(workflowRoot).filter((entry) => isDir(entry))
+    expect(generatedSkillDirs.map((entry) => path.basename(entry))).not.toContain('rails')
+    expect(generatedSkillDirs.map((entry) => path.basename(entry))).not.toContain('personas')
+    for (const skillDir of generatedSkillDirs) {
+      expect(pathExists(path.join(skillDir, 'SKILL.md'))).toBe(true)
+    }
+
+    const workflows = generatedSkillDirs
+      .filter((entry) => isDir(entry) && path.basename(entry).startsWith('specrails-'))
+      .map((entry) => path.basename(entry))
+      .sort()
+    expect(workflows).toEqual(canonicalCommands)
+
+    const canonicalRoles = listDir(path.join(scriptDir, 'templates', 'agents'))
+      .filter((entry) => entry.endsWith('.md'))
+      .map((entry) => path.basename(entry, '.md'))
+      .sort()
+    const roles = generatedSkillDirs
+      .filter((entry) => isDir(entry) && path.basename(entry).startsWith('sr-'))
+      .map((entry) => path.basename(entry))
+      .sort()
+    expect(roles).toEqual(canonicalRoles)
+
+    const allSkillFiles = [
+      ...workflows.map((name) => path.join(workflowRoot, name, 'SKILL.md')),
+      ...roles.map((name) => path.join(workflowRoot, name, 'SKILL.md')),
+    ]
+    for (const skillFile of allSkillFiles) {
+      const rendered = readTextFile(skillFile)
+      expect(rendered).toMatch(/^---\nname: [^\n]+\ndescription: [^\n]+\ntype: prompt\n---\n/)
+      expect(rendered).not.toContain('.claude')
+      expect(rendered).not.toContain('/specrails:')
+      expect(rendered).not.toContain('/skill:')
+      expect(rendered).not.toContain('subagent_type')
+      expect(rendered).not.toContain('Skill("opsx:')
+      expect(rendered).toContain('## Kimi runtime context contract')
+      expect(rendered).not.toMatch(/\{\{[A-Z_]+\}\}/)
+    }
+    for (const workflow of workflows) {
+      const rendered = readTextFile(
+        path.join(workflowRoot, workflow, 'SKILL.md'),
+      )
+      expect(rendered).toContain(
+        '--role-wave-file .specrails/kimi-role-wave.json',
+      )
+      expect(rendered).toContain('"roles": [')
+      expect(rendered).toContain('"workspace": "current"')
+      expect(rendered).toContain('"profile": "inherit"')
+      expect(rendered).toContain('`"worktree:<feature-id>"`')
+      expect(rendered).toContain('manifest `baseCommit`')
+      expect(rendered).not.toContain('ROLE_ARGS=')
+      expect(rendered).not.toContain('ROLE_MODEL=')
+    }
+
+    const implement = readTextFile(
+      path.join(workflowRoot, 'specrails-implement', 'SKILL.md'),
+    )
+    expect(implement).toContain('.kimi-code/skills/$id/SKILL.md')
+    expect(implement).toContain('parsed `AGENT_MODEL` map')
+    expect(implement).toContain(
+      '"model": "<exact profile model or k3>"',
+    )
+    expect(implement).toContain('.kimi-code/specrails/run-skill.mjs')
+    expect(implement).toContain(
+      '--role-wave-file .specrails/kimi-role-wave.json',
+    )
+    expect(implement).toContain(
+      '--role-wave-status <stable-run-id>',
+    )
+    expect(implement).toContain(
+      '--role-merge-file .specrails/kimi-role-merge.json',
+    )
+    expect(implement).toContain('--role-wave-cleanup <run>')
+    expect(implement).toContain('"kimi_role_wave": {')
+    expect(implement).toContain('Every change is `{status:"A"|"M"|"D",path}`')
+    expect(implement).toContain('Filenames may contain spaces, Unicode')
+    expect(implement).not.toContain('cp <worktree-path>/<file>')
+    expect(implement).not.toContain('git -C <worktree-path> diff main')
+    expect(implement).not.toContain('ROLE_ARGS=')
+    expect(implement).not.toContain('ROLE_MODEL=')
+    expect(implement).not.toContain('--args "$ROLE_ARGS"')
+    expect(implement).not.toContain('-p "/skill:$ROLE_ID')
+    expect(implement).not.toContain('${AGENT_MODEL[')
+    expect(implement).toContain('--add-dir "${SPECRAILS_REPO_DIR:-.}"')
+    expect(implement).toContain('.specrails/profiles/kimi-default.json')
+    expect(implement).not.toContain('.specrails/profiles/project-default.json')
+    expect(implement).not.toContain('.kimi-code/agents/')
+    expect(implement).not.toContain('Apply per-agent model overrides')
+    expect(implement).toContain('KIMI_PR_CREATE')
+
+    const batch = readTextFile(
+      path.join(workflowRoot, 'specrails-batch-implement', 'SKILL.md'),
+    )
+    expect(batch).toContain('`skill:"specrails-implement"`')
+    expect(batch).toContain('`workspace:"worktree:<feature-id>"`')
+    expect(batch).toContain('effective concurrency')
+    expect(batch).toContain('`--role-wave-status`')
+    expect(batch).toContain('Do not call multiple built-in `Skill` tools')
+    expect(batch).toContain('KIMI_BACKLOG_VIEW')
+
+    const autoPropose = readTextFile(
+      path.join(
+        workflowRoot,
+        'specrails-auto-propose-backlog-specs',
+        'SKILL.md',
+      ),
+    )
+    expect(autoPropose).toContain('`skill:"sr-product-analyst"`')
+    expect(autoPropose).not.toContain('role_skill: Explore')
+    expect(autoPropose).toContain('KIMI_RUNTIME_PERSONA_FILE_READ_LIST')
+
+    const enrich = readTextFile(
+      path.join(workflowRoot, 'specrails-enrich', 'SKILL.md'),
+    )
+    expect(enrich).toContain('update --provider kimi')
+    expect(enrich).toContain('.kimi-code/project-context.md')
+    expect(enrich).not.toContain('opus')
+    expect(enrich).not.toContain('.kimi-code/commands/')
+    expect(enrich).not.toContain('.kimi-code/agents/')
+
+    const reconfig = readTextFile(
+      path.join(workflowRoot, 'specrails-reconfig', 'SKILL.md'),
+    )
+    expect(reconfig).toContain('.specrails/profiles/kimi-default.json')
+    expect(reconfig).toContain(
+      'Never edit any role SKILL.md under `.kimi-code/skills/`',
+    )
+
+    const telemetry = readTextFile(
+      path.join(workflowRoot, 'specrails-telemetry', 'SKILL.md'),
+    )
+    expect(telemetry).toContain('session_index.jsonl')
+    expect(telemetry).toContain('type:"usage.record"')
+    expect(telemetry).toContain('`cost_usd:null`')
+    expect(telemetry).not.toContain('published Claude pricing')
+
+    const retry = readTextFile(
+      path.join(workflowRoot, 'specrails-retry', 'SKILL.md'),
+    )
+    expect(retry).toContain('`KIMI_ROLE_WAVE`')
+    expect(retry).toContain('--role-wave-status <run>')
+    expect(retry).toContain('never cleanup before')
+
+    const productManager = readTextFile(
+      path.join(workflowRoot, 'sr-product-manager', 'SKILL.md'),
+    )
+    expect(productManager).toContain('.kimi-code/personas/')
+    expect(productManager).not.toContain('.kimi-code/skills/personas/')
+    expect(productManager).toContain('KIMI_RUNTIME_PERSONA_COUNT')
+
+    const installedRunner = await import(
+      pathToFileURL(
+        path.join(repoRoot, '.kimi-code', 'specrails', 'run-skill.mjs'),
+      ).href
+    ) as {
+      parseSkillDocument: (source: string) => {
+        description: string
+        argumentNames: string[]
+      }
+      prepareSkillLaunch: (options: {
+        providerRoot: string
+        skill: string
+        model: string
+        rawArgs: string
+        sessionId?: string
+        additionalDirs: string[]
+        attachmentPaths: string[]
+      }) => {
+        prompt: string
+        kimiArgs: string[]
+      }
+      resolveKimiLaunch: (
+        args: string[],
+        options: {
+          platform: string
+          binary: string
+          readFile: () => string
+          fileExists: () => boolean
+        },
+      ) => {
+        command: string
+        args: string[]
+        stdinText?: string
+      }
+      windowsCommandLineLength: (command: string, args: string[]) => number
+    }
+    const parsed = installedRunner.parseSkillDocument(
+      [
+        '---',
+        'name: installed-yaml',
+        'description: >-',
+        '  Loaded through the copied',
+        '  vendored parser',
+        'arguments: &args [target, 7, mode]',
+        'metadata: { copy: true }',
+        '---',
+        '$target $mode',
+      ].join('\n'),
+    )
+    expect(parsed.description).toBe(
+      'Loaded through the copied vendored parser',
+    )
+    expect(parsed.argumentNames).toEqual(['target', 'mode'])
+
+    const windowsShim =
+      'C:\\Users\\Jane Doe\\AppData\\Roaming\\npm\\kimi.cmd'
+    const windowsShimSource =
+      '@ECHO off\r\n"%_prog%" "%dp0%\\node_modules\\@moonshot-ai\\kimi-code\\dist\\main.mjs" %*\r\n'
+    let largestMaterializedPrompt = 0
+    for (const skillFile of allSkillFiles) {
+      const skill = path.basename(path.dirname(skillFile))
+      const prepared = installedRunner.prepareSkillLaunch({
+        providerRoot: path.join(repoRoot, '.kimi-code'),
+        skill,
+        model: 'k3',
+        rawArgs: 'ticket #42 — contexto Unicode 🚀\nsegunda línea',
+        sessionId: 'ses_prompt_budget',
+        additionalDirs: [],
+        attachmentPaths: [],
+      })
+      largestMaterializedPrompt = Math.max(
+        largestMaterializedPrompt,
+        prepared.prompt.length,
+      )
+      const launch = installedRunner.resolveKimiLaunch(prepared.kimiArgs, {
+        platform: 'win32',
+        binary: windowsShim,
+        readFile: () => windowsShimSource,
+        fileExists: () => false,
+      })
+      expect(launch.stdinText).toBe(prepared.prompt)
+      expect(launch.args).not.toContain(prepared.prompt)
+      expect(
+        installedRunner.windowsCommandLineLength(
+          launch.command,
+          launch.args,
+        ),
+      ).toBeLessThanOrEqual(30_000)
+    }
+    // Proves the test exercises the historical CreateProcess regression rather
+    // than only small fixtures: implement/enrich exceed 60K materialized.
+    expect(largestMaterializedPrompt).toBeGreaterThan(60_000)
   })
 })

--- a/src/installer/phases/scaffold.ts
+++ b/src/installer/phases/scaffold.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { rmSync } from 'node:fs'
+import { renameSync, rmSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
@@ -12,6 +12,7 @@ import {
   listDir,
   mkdirp,
   pathExists,
+  readBytes,
   readTextFile,
   removePath,
   symlinkOrCopy,
@@ -80,6 +81,21 @@ const OPSX_TO_GEMINI_SKILL: Record<string, string> = {
   onboard: 'openspec-onboard',
 }
 
+/** OpenSpec's published Kimi skill ids. The mapping is intentionally explicit. */
+const OPSX_TO_KIMI_SKILL: Record<string, string> = {
+  propose: 'openspec-propose',
+  ff: 'openspec-ff-change',
+  new: 'openspec-new-change',
+  apply: 'openspec-apply-change',
+  continue: 'openspec-continue-change',
+  archive: 'openspec-archive-change',
+  'bulk-archive': 'openspec-bulk-archive-change',
+  sync: 'openspec-sync-specs',
+  verify: 'openspec-verify-change',
+  explore: 'openspec-explore',
+  onboard: 'openspec-onboard',
+}
+
 /**
  * Rewrite every literal `Skill("opsx:<id>"[, …])` call in a Claude-authored agent
  * body into the Gemini `activate_skill(name="…")` form. Positional skill input
@@ -93,6 +109,51 @@ export function translateOpsxSkillCallsForGemini(body: string): string {
     const skill = OPSX_TO_GEMINI_SKILL[id]
     return skill ? `activate_skill(name="${skill}")` : match
   })
+}
+
+/**
+ * Port shared Claude-authored prose to Kimi's directory-skill contract.
+ *
+ * Kimi's TUI/ACP clients intercept `/skill:*`, but a materialized workflow is
+ * already running inside a Session and must activate nested workflows through
+ * Kimi's built-in `Skill` tool (`{ skill, args }`). Emitting slash text here
+ * would silently become ordinary model text under `kimi -p`. Interactive slash
+ * examples therefore belong only in AGENTS/docs, never generated skill bodies.
+ * This is render-only; canonical Claude/Codex/Gemini templates stay unchanged.
+ */
+export function translateClaudeTextForKimi(body: string): string {
+  let translated = body.replace(
+    /Skill\("opsx:([a-z-]+)"(?:\s*,\s*("[^"]*"|'[^']*'|[^)]*))?\)/g,
+    (_match, id: string, input: string | undefined) => {
+      const skill = OPSX_TO_KIMI_SKILL[id]
+      if (!skill) return `Unresolved Kimi Skill tool mapping for "opsx:${id}"`
+      const args = input?.replace(/^["']|["']$/g, '') ?? ''
+      return `Skill(skill="${skill}", args=${JSON.stringify(args)})`
+    },
+  )
+  translated = translated
+    .replace(/\.claude\/agents\/personas\//g, '.kimi-code/personas/')
+    .replace(/\.claude\/agents\//g, '.kimi-code/skills/')
+    .replace(
+      /(\.kimi-code\/skills\/[^\s`"'()]+)\.md/g,
+      '$1/SKILL.md',
+    )
+    .replace(/\.claude\//g, '.kimi-code/')
+    .replace(/\.claude\b/g, '.kimi-code')
+    .replace(/\bCLAUDE\.md\b/g, '.kimi-code/AGENTS.md')
+    .replace(
+      /\/(?:specrails|sr):([a-z0-9-]+)/g,
+      'Skill(skill="specrails-$1", args=<arguments following this command>)',
+    )
+    .replace(
+      /\/(?:specrails|sr):/g,
+      'Skill(skill="specrails-<command>", args=<arguments following this command>)',
+    )
+    .replace(/\bsubagent_type\b/g, 'role_skill')
+    .replace(/\bClaude Code\b/g, 'Kimi Code')
+    .replace(/\bClaude CLI\b/g, 'Kimi CLI')
+    .replace(/\bAgent tool\b/g, 'external Kimi role process')
+  return translated
 }
 
 /**
@@ -211,7 +272,7 @@ export interface ScaffoldInput {
   scriptDir: string
   /**
    * Absolute path to the relocated artifact root — where every Specrails-managed
-   * artifact (.specrails/.claude/.codex/.gemini/CLAUDE.md/AGENTS.md/GEMINI.md/.mcp.json)
+   * artifact (.specrails/.claude/.codex/.gemini/.kimi-code and instruction/settings files)
    * is written. Under relocate-always this is the `$HOME` workspace, NOT the repo.
    */
   artifactRoot: string
@@ -268,7 +329,19 @@ const LINKED_PROVIDER_SUBTREES: Record<Provider, string[]> = {
   claude: ['agents', 'commands', 'skills', 'rules'],
   codex: ['skills'],
   gemini: ['agents', 'commands'],
+  // Kimi skills are linked one directory at a time so direct-child OpenSpec
+  // skills and user-owned custom-* roles can coexist. The self-contained
+  // headless runner and its vendored parser are Core-owned and linked as a
+  // separate static subtree.
+  kimi: ['rules', 'specrails'],
 }
+
+const KIMI_RUNNER_RELATIVE_FILES = [
+  'run-skill.mjs',
+  path.join('vendor', 'js-yaml', 'js-yaml.mjs'),
+  path.join('vendor', 'js-yaml', 'LICENSE'),
+  path.join('vendor', 'js-yaml', 'NOTICE.md'),
+] as const
 
 /**
  * Returns true iff any of the provider directories already contains
@@ -317,6 +390,10 @@ export function scaffoldInstallation(input: ScaffoldInput): ScaffoldResult {
     // subagents under .gemini/agents/. No skills/ tree.
     mk(path.join(input.artifactRoot, input.providerDir, 'commands', 'specrails'))
     mk(path.join(input.artifactRoot, input.providerDir, 'agents'))
+  } else if (input.provider === 'kimi') {
+    mk(path.join(input.artifactRoot, input.providerDir, 'skills'))
+    mk(path.join(input.artifactRoot, input.providerDir, 'specrails'))
+    mk(path.join(input.artifactRoot, input.providerDir, 'rules'))
   } else {
     mk(path.join(input.artifactRoot, input.providerDir, 'commands', 'specrails'))
     mk(path.join(input.artifactRoot, input.providerDir, 'skills'))
@@ -338,6 +415,14 @@ export function scaffoldInstallation(input: ScaffoldInput): ScaffoldResult {
   if (input.artifactRoot === input.codeRoot) {
     const gitignoreEntries = ['.claude/agent-memory/', '.specrails/']
     if (input.provider === 'gemini') gitignoreEntries.push('.gemini/agent-memory/')
+    if (input.provider === 'kimi') {
+      gitignoreEntries.push(
+        '.kimi-code/agent-memory/',
+        '.kimi-code/pipeline-state/',
+        '.kimi-code/.dry-run/',
+        '.kimi-code/telemetry/',
+      )
+    }
     ensureGitignore(input.codeRoot, gitignoreEntries)
   }
 
@@ -361,6 +446,9 @@ export function scaffoldInstallation(input: ScaffoldInput): ScaffoldResult {
   // --- Write bundled commands (enrich.md + doctor.md) ---
   copyBundledCommands({ ...input, copiedIncrement: (n) => (copiedFiles += n) })
   pruneLegacyArtifacts(input)
+  if (input.provider === 'kimi') {
+    copiedFiles += placeKimiSkillRunner(input)
+  }
 
   // --- Quick tier: direct-placement short-circuit ---
   if (input.tier === 'quick') {
@@ -402,14 +490,28 @@ export function scaffoldInstallation(input: ScaffoldInput): ScaffoldResult {
     if (written > 0) {
       info(`Gemini provider: wrote ${written} setting file(s) (settings.json, GEMINI.md)`)
     }
+  } else if (input.provider === 'kimi') {
+    const written = applyKimiSettings(input)
+    copiedFiles += written
+    if (written > 0) {
+      info(`Kimi provider: wrote ${written} setting file(s) (.kimi-code/AGENTS.md, mcp.json)`)
+    }
   }
 
   // --- Full-tier hint: enrich is required to generate VPC artefacts ---
   if (input.tier === 'full') {
     const cliName =
-      input.provider === 'codex' ? 'Codex CLI' : input.provider === 'gemini' ? 'Gemini CLI' : 'Claude Code'
+      input.provider === 'codex'
+        ? 'Codex CLI'
+        : input.provider === 'gemini'
+          ? 'Gemini CLI'
+          : input.provider === 'kimi'
+            ? 'Kimi CLI'
+            : 'Claude Code'
+    const enrichCommand =
+      input.provider === 'kimi' ? '/skill:specrails-enrich' : '/specrails:enrich'
     info(
-      `Full tier staged. Run \`/specrails:enrich\` in ${cliName} to generate ` +
+      `Full tier staged. Run \`${enrichCommand}\` in ${cliName} to generate ` +
         'VPC personas and adapt agents (including sr-product-manager and ' +
         'sr-product-analyst) to this codebase.',
     )
@@ -443,7 +545,7 @@ export interface InstallFrameworkInput {
   frameworkDir: string
   /** Provider whose static subtree is being materialized. */
   provider: Provider
-  /** Derived provider dir (`.claude`/`.codex`/`.gemini`). */
+  /** Derived provider dir (`.claude`/`.codex`/`.gemini`/`.kimi-code`). */
   providerDir: string
   /** Framework version (the `<version>/` segment). */
   version: string
@@ -461,10 +563,134 @@ export interface InstallFrameworkResult {
 }
 
 /** Path to the per-version, per-provider materialization marker (manifest hash). */
-function frameworkStampPath(versionDir: string, providerDir: string): string {
+export function frameworkStampPath(versionDir: string, providerDir: string): string {
   // Store the stamp OUTSIDE the providerDir so it never leaks into the linked
   // subtree. `.stamp-<providerDir>.json` is provider-keyed.
   return path.join(versionDir, `.framework-stamp${providerDir}.json`)
+}
+
+interface FrameworkStamp {
+  schema: 1
+  version: string
+  provider: Provider
+  source_hash: string
+  content_hash: string
+}
+
+/**
+ * Stable Merkle-like digest over regular files. Relative POSIX paths and raw
+ * bytes are both framed into the hash, so renames, missing files, additions and
+ * byte corruption are detected. Directory mtimes and traversal order never
+ * affect the result.
+ */
+function hashFrameworkTrees(
+  roots: Array<{ label: string; dir: string }>,
+  options: { ignorePackageNoise?: boolean } = {},
+): string {
+  const hash = createHash('sha256')
+
+  const walk = (root: string, current: string, label: string): void => {
+    const entries = listDir(current).sort((a, b) =>
+      path.basename(a).localeCompare(path.basename(b)),
+    )
+    for (const entry of entries) {
+      const name = path.basename(entry)
+      if (
+        options.ignorePackageNoise === true &&
+        (name === 'node_modules' || name === 'package-lock.json')
+      ) {
+        continue
+      }
+      const rel = path.relative(root, entry).split(path.sep).join('/')
+      if (isDir(entry)) {
+        walk(root, entry, label)
+        continue
+      }
+      if (!pathExists(entry)) continue
+      const framedPath = `${label}/${rel}`
+      const bytes = readBytes(entry)
+      hash.update(`file\0${Buffer.byteLength(framedPath)}\0${framedPath}\0`)
+      hash.update(`${bytes.byteLength}\0`)
+      hash.update(bytes)
+    }
+  }
+
+  for (const root of [...roots].sort((a, b) => a.label.localeCompare(b.label))) {
+    hash.update(`root\0${root.label}\0`)
+    if (isDir(root.dir)) {
+      walk(root.dir, root.dir, root.label)
+    } else {
+      hash.update('missing\0')
+    }
+  }
+  return `sha256:${hash.digest('hex')}`
+}
+
+/** Hash of every package input that can influence provider materialization. */
+function frameworkSourceHash(scriptDir: string, provider: Provider): string {
+  const treeHash = hashFrameworkTrees(
+    [
+      { label: 'templates', dir: path.join(scriptDir, 'templates') },
+      { label: 'commands', dir: path.join(scriptDir, 'commands') },
+    ],
+    { ignorePackageNoise: true },
+  )
+  return `sha256:${createHash('sha256')
+    .update(treeHash)
+    .update('\0provider\0')
+    .update(provider)
+    .digest('hex')}`
+}
+
+/** Hash of the provider-static tree workspace links consume. */
+function frameworkContentHash(providerFrameworkDir: string): string {
+  return hashFrameworkTrees([
+    { label: 'provider', dir: providerFrameworkDir },
+  ])
+}
+
+function readFrameworkStamp(stampPath: string): FrameworkStamp | null {
+  if (!pathExists(stampPath)) return null
+  try {
+    const parsed = JSON.parse(readTextFile(stampPath)) as Partial<FrameworkStamp>
+    if (
+      parsed.schema !== 1 ||
+      typeof parsed.version !== 'string' ||
+      typeof parsed.provider !== 'string' ||
+      typeof parsed.source_hash !== 'string' ||
+      typeof parsed.content_hash !== 'string'
+    ) {
+      return null
+    }
+    return parsed as FrameworkStamp
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Validate one provider in a materialized version without needing the source
+ * package. Used by the final swap gate: the stamp identity and current output
+ * hash must still agree immediately before `current` moves.
+ */
+export function frameworkMaterializationProblem(
+  versionDir: string,
+  version: string,
+  provider: Provider,
+  providerDir: string,
+): string | null {
+  const providerFrameworkDir = path.join(versionDir, providerDir)
+  const stampPath = frameworkStampPath(versionDir, providerDir)
+  if (!isDir(providerFrameworkDir)) return `missing ${providerDir}/`
+  const stamp = readFrameworkStamp(stampPath)
+  if (!stamp) return `missing or invalid ${path.basename(stampPath)}`
+  if (stamp.version !== version || stamp.provider !== provider) {
+    return `invalid stamp (expected version=${version}, provider=${provider})`
+  }
+  if (stamp.content_hash !== frameworkContentHash(providerFrameworkDir)) {
+    return 'managed content does not match stamp'
+  }
+  return null
 }
 
 /**
@@ -479,11 +705,28 @@ export function installFramework(input: InstallFrameworkInput): InstallFramework
   const versionDir = path.join(input.frameworkDir, input.version)
   const providerFrameworkDir = path.join(versionDir, input.providerDir)
   const stampPath = frameworkStampPath(versionDir, input.providerDir)
+  const sourceHash = frameworkSourceHash(input.scriptDir, input.provider)
+  const stamp = readFrameworkStamp(stampPath)
 
-  // Idempotency: existing materialization with a matching stamp → skip.
-  if (isDir(providerFrameworkDir) && pathExists(stampPath)) {
+  // Same-version reuse is allowed only when BOTH provenance and every managed
+  // output byte still match the deterministic stamp. A legacy/timestamp-only
+  // stamp, a changed package source, or any missing/corrupt/extra managed file
+  // falls through to a clean provider-tree repair.
+  if (
+    isDir(providerFrameworkDir) &&
+    stamp?.version === input.version &&
+    stamp.provider === input.provider &&
+    stamp.source_hash === sourceHash &&
+    stamp.content_hash === frameworkContentHash(providerFrameworkDir)
+  ) {
     return { providerFrameworkDir, versionDir, materialized: false }
   }
+
+  // Framework provider trees are entirely Core-owned. Rebuilding from a clean
+  // destination removes stale files as well as repairing corrupt/missing ones,
+  // without touching sibling providers already materialized in this version.
+  removePath(providerFrameworkDir)
+  removePath(stampPath)
 
   // Reuse scaffoldInstallation's static-placement helpers by pointing
   // `artifactRoot` at the version dir. `seedProjectDirs: false` keeps the copy
@@ -518,11 +761,23 @@ export function installFramework(input: InstallFrameworkInput): InstallFramework
   for (const f of ['AGENTS.md', 'GEMINI.md', 'CLAUDE.md']) {
     rmSync(path.join(versionDir, f), { force: true })
   }
+  // Kimi's instruction and MCP files are provider-local rather than root-local,
+  // but both are project-specific and must be real files in each workspace.
+  // In particular, linking mcp.json would let Desktop mutate the shared
+  // framework and leak one project's MCP registry into every other project.
+  if (input.provider === 'kimi') {
+    rmSync(path.join(providerFrameworkDir, 'AGENTS.md'), { force: true })
+    rmSync(path.join(providerFrameworkDir, 'mcp.json'), { force: true })
+  }
 
-  writeFileLf(
-    stampPath,
-    `${JSON.stringify({ version: input.version, provider: input.provider, at: new Date().toISOString() }, null, 2)}\n`,
-  )
+  const frameworkStamp: FrameworkStamp = {
+    schema: 1,
+    version: input.version,
+    provider: input.provider,
+    source_hash: sourceHash,
+    content_hash: frameworkContentHash(providerFrameworkDir),
+  }
+  writeFileLf(stampPath, `${JSON.stringify(frameworkStamp, null, 2)}\n`)
   return { providerFrameworkDir, versionDir, materialized: true }
 }
 
@@ -544,7 +799,7 @@ export interface AssembleProjectWorkspaceInput {
   frameworkDir: string
   /** Provider whose subtrees are linked into the workspace. */
   provider: Provider
-  /** Derived provider dir (`.claude`/`.codex`/`.gemini`). */
+  /** Derived provider dir (`.claude`/`.codex`/`.gemini`/`.kimi-code`). */
   providerDir: string
   /** Framework version (used for the manifest record). */
   version: string
@@ -565,7 +820,7 @@ export interface AssembleProjectWorkspaceInput {
    * the workspace instead of SYMLINKED. Used by the in-repo standalone install
    * (`init`/`update` with `artifactRoot === codeRoot`) so the repo gets real,
    * committable files — a symlink into `$HOME/.specrails/framework` would be
-   * invisible to a standalone user's `claude`/`codex`/`gemini` running in the
+   * invisible to a standalone user's `claude`/`codex`/`gemini`/`kimi` running in the
    * repo. The PROJECT layer (agent-memory, manifest, instruction files) is real
    * either way. Defaults to false (relocated workspaces symlink — the desktop /
    * `--relocate` path).
@@ -628,12 +883,29 @@ export function assembleProjectWorkspace(
       links[sub] = symlinkOrCopy(target, dest, preferCopy)
     }
   }
+  if (input.provider === 'kimi') {
+    const kimiSkillsTarget = path.join(currentProviderDir, 'skills')
+    const kimiSkillsDest = path.join(workspaceProviderDir, 'skills')
+    migrateLegacyKimiRoleLayout(kimiSkillsDest)
+    if (pathExists(kimiSkillsTarget)) {
+      links.skills = linkKimiSkillDirectories(
+        kimiSkillsTarget,
+        kimiSkillsDest,
+        selectedAgentSet,
+        preferCopy,
+      )
+    }
+  }
 
-  // Link the provider-invariant settings file (codex config.toml / gemini
-  // settings.json) when the framework has one and the user has not authored a
-  // local override in the workspace.
+  // Link only provider-invariant settings (codex config.toml / gemini
+  // settings.json). Kimi mcp.json is a mutable per-project registry and is
+  // seeded below as a real workspace file.
   const settingsFile =
-    input.provider === 'codex' ? 'config.toml' : input.provider === 'gemini' ? 'settings.json' : null
+    input.provider === 'codex'
+      ? 'config.toml'
+      : input.provider === 'gemini'
+        ? 'settings.json'
+        : null
   if (settingsFile) {
     const settingsTarget = path.join(currentProviderDir, settingsFile)
     const settingsLink = path.join(workspaceProviderDir, settingsFile)
@@ -651,6 +923,8 @@ export function assembleProjectWorkspace(
     scriptDir: input.scriptDir,
     repoRoot: input.workspace,
     version: input.version,
+    providers: [input.provider],
+    primaryProvider: input.provider,
   })
   writeManifestFiles(input.workspace, manifest)
 
@@ -716,9 +990,68 @@ function seedProjectLayer(input: AssembleProjectWorkspaceInput, currentProviderD
     } catch (err) {
       warn(`gemini agent pre-acknowledgment skipped: ${(err as Error).message}`)
     }
+  } else if (input.provider === 'kimi') {
+    const skillsDir = path.join(currentProviderDir, 'skills')
+    if (isDir(skillsDir)) {
+      for (const roleDir of listDir(skillsDir)) {
+        if (!isDir(roleDir)) continue
+        const id = path.basename(roleDir)
+        if (
+          /^sr-[a-z0-9-]+$/.test(id) &&
+          selected.has(id) &&
+          !QUICK_EXCLUDED_AGENTS.has(id) &&
+          pathExists(path.join(roleDir, 'SKILL.md'))
+        ) {
+          placedAgentIds.push(id)
+        }
+      }
+    }
+    for (const id of placedAgentIds) {
+      mkdirp(path.join(input.workspace, '.kimi-code', 'agent-memory', id))
+      seededMemoryAgents.push(id)
+      if (EXPLANATION_AUTHORS.has(id)) {
+        mkdirp(path.join(input.workspace, '.kimi-code', 'agent-memory', 'explanations'))
+      }
+    }
+    seedInstructionFile(
+      path.join(input.workspace, '.kimi-code', 'AGENTS.md'),
+      renderInitialKimiAgentsMd(input.codeRoot),
+    )
+    seedKimiMcpFile(path.join(input.workspace, '.kimi-code', 'mcp.json'))
+    if (input.workspace === input.codeRoot) {
+      ensureGitignore(input.codeRoot, [
+        '.kimi-code/agent-memory/',
+        '.kimi-code/pipeline-state/',
+        '.kimi-code/.dry-run/',
+        '.kimi-code/telemetry/',
+        '.specrails/',
+      ])
+    }
   }
 
   return seededMemoryAgents
+}
+
+/**
+ * Ensure Kimi's per-project MCP registry is a real writable file. Older Core
+ * builds could create a framework symlink here; migrate a readable link by
+ * copying its bytes locally, or seed an empty registry when the link is stale.
+ */
+function seedKimiMcpFile(mcpPath: string): void {
+  if (isSymlink(mcpPath)) {
+    let existing = '{\n  "mcpServers": {}\n}\n'
+    try {
+      existing = readTextFile(mcpPath)
+    } catch {
+      // A version swap can leave the obsolete shared-framework link dangling.
+    }
+    removePath(mcpPath)
+    writeFileLf(mcpPath, existing)
+    return
+  }
+  if (!pathExists(mcpPath)) {
+    writeFileLf(mcpPath, '{\n  "mcpServers": {}\n}\n')
+  }
 }
 
 /**
@@ -795,6 +1128,96 @@ function linkAgentFiles(
 }
 
 /**
+ * Assemble Kimi skills without turning the whole directory into a symlink.
+ * Kimi's loader inspects only immediate children of `.kimi-code/skills`, so
+ * workflows (`specrails-*`), OpenSpec skills (`openspec-*`), managed roles
+ * (`sr-*`), and user roles (`custom-*`) all share this flat directory.
+ * OpenSpec and custom/unknown skills must survive every update.
+ */
+function linkKimiSkillDirectories(
+  frameworkSkillsDir: string,
+  workspaceSkillsDir: string,
+  selectedRoleIds: Set<string>,
+  preferCopy: boolean,
+): 'symlink' | 'junction' | 'copy' {
+  mkdirp(workspaceSkillsDir)
+  const linkedFrameworkNames = new Set<string>()
+  let mechanism: 'symlink' | 'junction' | 'copy' = 'symlink'
+
+  for (const source of listDir(frameworkSkillsDir)) {
+    if (!isDir(source)) continue
+    const name = path.basename(source)
+    if (name === 'rails') {
+      // A same-version framework materialized by the experimental build may
+      // still contain this container. `installFramework` normally rematerializes
+      // it, but never expose nested roles if a caller supplies one directly.
+      continue
+    }
+    if (
+      /^sr-[a-z0-9-]+$/.test(name) &&
+      (!selectedRoleIds.has(name) || QUICK_EXCLUDED_AGENTS.has(name))
+    ) {
+      continue
+    }
+    linkedFrameworkNames.add(name)
+    const used = symlinkOrCopy(source, path.join(workspaceSkillsDir, name), preferCopy)
+    if (used === 'copy') mechanism = 'copy'
+    else if (used === 'junction' && mechanism !== 'copy') mechanism = 'junction'
+  }
+
+  // `specrails-*` workflows and `sr-*` roles are framework-owned. OpenSpec,
+  // custom-* and unknown/user skill directories remain outside this boundary.
+  for (const existing of listDir(workspaceSkillsDir)) {
+    const name = path.basename(existing)
+    if (linkedFrameworkNames.has(name)) continue
+    if (name.startsWith('specrails-') || /^sr-[a-z0-9-]+$/.test(name)) {
+      removePath(existing)
+    }
+  }
+  return mechanism
+}
+
+/**
+ * Migrate the pre-release `skills/rails/<role>` layout without risking user
+ * data. Framework-owned `sr-*` directories are dropped (the caller recreates
+ * them at the discoverable flat path). Reserved `custom-*` roles are atomically
+ * moved to `skills/custom-*` when that target is free. A collision or unknown
+ * child remains byte-untouched under `rails/` and doctor reports it, requiring
+ * explicit user resolution rather than destructive guessing.
+ */
+function migrateLegacyKimiRoleLayout(skillsDir: string): void {
+  const legacyRolesDir = path.join(skillsDir, 'rails')
+  if (!isDir(legacyRolesDir)) return
+
+  for (const source of listDir(legacyRolesDir)) {
+    if (!isDir(source)) continue
+    const id = path.basename(source)
+    if (/^sr-[a-z0-9-]+$/.test(id)) {
+      removePath(source)
+      continue
+    }
+    if (!id.startsWith('custom-')) continue
+
+    const destination = path.join(skillsDir, id)
+    if (pathExists(destination)) {
+      warn(
+        `Kimi role migration kept ${path.relative(skillsDir, source)} because ` +
+          `${id}/ already exists; resolve the duplicate manually`,
+      )
+      continue
+    }
+    try {
+      renameSync(source, destination)
+      info(`Migrated Kimi role skills/rails/${id} → skills/${id}`)
+    } catch (err) {
+      warn(`failed to migrate Kimi role ${id}: ${(err as Error).message}`)
+    }
+  }
+
+  if (listDir(legacyRolesDir).length === 0) removePath(legacyRolesDir)
+}
+
+/**
  * True when `name` (an `<id>.md`) matches a framework-owned agent id (`sr-*`).
  * Used to identify a stale COPY-fallback framework agent on Windows that the
  * current framework version no longer provides, so it can be cleaned up on a
@@ -803,6 +1226,34 @@ function linkAgentFiles(
  */
 function isFrameworkAgentName(name: string): boolean {
   return /^sr-[a-z0-9-]+\.md$/.test(name)
+}
+
+/**
+ * Install Core's self-contained Kimi headless skill runner and the vendored
+ * js-yaml parser used by upstream Kimi 0.27. These files are provider-static
+ * and managed: updates replace them through the same framework copy/link
+ * lifecycle as rules. They intentionally live outside `skills/` so Kimi never
+ * attempts to discover executable support files as skills.
+ */
+function placeKimiSkillRunner(input: ScaffoldInput): number {
+  for (const relative of KIMI_RUNNER_RELATIVE_FILES) {
+    copyFile(
+      path.join(
+        input.scriptDir,
+        'templates',
+        'kimi',
+        'specrails',
+        relative,
+      ),
+      path.join(
+        input.artifactRoot,
+        input.providerDir,
+        'specrails',
+        relative,
+      ),
+    )
+  }
+  return KIMI_RUNNER_RELATIVE_FILES.length
 }
 
 /** Write or sentinel-upsert a project instruction file (AGENTS.md/GEMINI.md). */
@@ -819,6 +1270,11 @@ function seedInstructionFile(filePath: string, content: string): void {
 function copyBundledCommands(input: ScaffoldInput & { copiedIncrement: (n: number) => void }): void {
   const commandsSrc = path.join(input.scriptDir, 'commands')
   if (!isDir(commandsSrc)) return
+
+  // Kimi's complete workflow catalog is rendered from the canonical
+  // templates/commands/specrails sources in placeKimiSkills. Do not let this
+  // generic bundled-command pass fall through to Claude's file layout.
+  if (input.provider === 'kimi') return
 
   if (input.provider === 'codex') {
     // Codex: each bundled command ships as a SKILL under
@@ -979,6 +1435,773 @@ function writeClaudeSkillFromCommand(args: {
     '',
   ].join('\n')
   writeFileLf(args.dest, frontmatter + body)
+}
+
+const KIMI_ROLE_EXECUTION_CONTRACT = [
+  '## Kimi role execution contract',
+  '',
+  'These rules override later Claude-specific `role_skill`, `isolation`, and',
+  '`run_in_background` notation. When this workflow asks for one role or a',
+  'parallel group, submit exactly one foreground role wave. The managed helper',
+  'starts one external Kimi CLI per role, runs the wave concurrently, attributes',
+  'every output event, and waits for every required role. Never emulate a role',
+  'in the orchestrator and never start concurrent helper commands.',
+  '',
+  'First use the structured WriteFile tool (never Shell, a heredoc, `printf`,',
+  'or `echo`) to write `.specrails/kimi-role-wave.json`. Choose one lowercase',
+  'letters/digits/hyphens run id (1–64 characters) and reuse it for the whole',
+  'workflow. The file must have exactly this shape (1–32 roles):',
+  '',
+  '```json',
+  '{',
+  '  "run": "<stable-run-id>",',
+  '  "roles": [',
+  '    {',
+  '      "key": "<unique-role-call-id>",',
+  '      "skill": "<role-skill>",',
+  '      "model": "<exact profile model or k3>",',
+  '      "profile": "inherit",',
+  '      "args": "<complete role context>",',
+  '      "workspace": "current"',
+  '    }',
+  '  ]',
+  '}',
+  '```',
+  '',
+  'Every `key`, profile stem, and worktree id uses the same 1–64 character grammar as `run`.',
+  'Use `"current"` for roles that target the orchestrator repository. The',
+  'helper gives each such role a private execution directory while setting its',
+  '`SPECRAILS_REPO_DIR` to that repository, so nested calls and run-state do not',
+  'collide. Where later instructions request `isolation: worktree`, use',
+  '`"worktree:<feature-id>"`; reuse that exact value for the developer, test,',
+  'documentation, and other sequential roles belonging to the same feature.',
+  'Never put two roles for the same worktree in one wave.',
+  '',
+  'Resolve each role model in the orchestrator and encode all context as JSON;',
+  'set `profile` to `inherit`, or to a validated profile filename stem for a',
+  'per-rail override under `.specrails/profiles/<stem>.json`. The helper passes',
+  'that absolute profile path only to that child process.',
+  'do not place any model or context text in a shell command. Then run this',
+  'exact static command in the foreground:',
+  '',
+  '```sh',
+  'node .kimi-code/specrails/run-skill.mjs \\',
+  '  --role-wave-file .specrails/kimi-role-wave.json \\',
+  '  --add-dir "${SPECRAILS_REPO_DIR:-.}"',
+  '```',
+  '',
+  'The helper accepts only that fixed, regular, non-symlink one-shot file,',
+  'bounds it to 1 MiB, validates the exact schema and every identifier, and',
+  'deletes it before creating a worktree or process. For an isolated role it',
+  'creates or reuses a detached git worktree from a synthetic baseline commit',
+  'that snapshots the starting tracked and non-ignored untracked workspace,',
+  'exposes the',
+  'managed `.kimi-code`, and sets the child repository root to that worktree.',
+  'It persists the base commit and key/path mapping under',
+  '`.specrails/kimi-role-worktrees/<run>.json` and emits',
+  '`specrails.role.workspace` frames. Replace every later',
+  '`<worktree-path>` placeholder with that emitted `repoDir`; compare against',
+  'the manifest `baseCommit`, not a hard-coded `main` ref.',
+  '',
+  'The helper frames child stdout/stderr with its role key, emits one completion',
+  'frame per role, and exits nonzero after the whole wave if any role failed.',
+  'A termination signal is forwarded to every live child. Partial failures',
+  'leave completed worktrees and the manifest available for retry; newly',
+  'created partial worktrees are removed only when setup itself fails. Apply',
+  'the workflow cleanup step after merge using the exact static command',
+  '`node .kimi-code/specrails/run-skill.mjs --role-wave-cleanup <run>`.',
+  'Cleanup removes registered worktrees, execution state, the manifest, and',
+  'the private synthetic-baseline ref; never clean up a failed run before retry.',
+  'The helper normalizes only the three',
+  'official short model ids (`k3` launches as `kimi-code/k3`); safe custom',
+  'aliases pass through unchanged.',
+  'There is no SpecRails-owned Kimi server or bundled Kimi binary.',
+  '',
+].join('\n')
+
+const KIMI_NESTED_SKILL_CONTRACT = [
+  '## Kimi nested skill activation',
+  '',
+  'When these instructions show `Skill(skill="<id>", args="<raw args>")`, call',
+  'Kimi\'s built-in `Skill` tool with those `skill` and `args` fields. Do not',
+  'print the notation as prose and do not send an interactive slash command as',
+  'model text. This native tool path preserves Kimi\'s nested-skill behavior and',
+  'skill activation telemetry.',
+  '',
+].join('\n')
+
+const KIMI_RUNTIME_CONTEXT_CONTRACT = [
+  '## Kimi runtime context contract',
+  '',
+  'SpecRails deliberately resolves project-specific context at activation time;',
+  'the Kimi enrich workflow does not rewrite framework-owned role or workflow',
+  'SKILL.md files. Resolve every `KIMI_RUNTIME_*`, `KIMI_BACKLOG_*`, and',
+  '`KIMI_PR_CREATE` marker below before acting. These are semantic markers,',
+  'never executable command names; do not pass them to Shell.',
+  '',
+  'Use `${SPECRAILS_REPO_DIR}` when set as the code repository, otherwise the',
+  'current repository. Read `.kimi-code/project-context.md` for stack, layers,',
+  'CI commands, conventions, warnings, architecture, and important paths; when',
+  'a field is absent, inspect package/build/CI files and report the inferred',
+  'value explicitly. Scan `.kimi-code/personas/*.md` at runtime and read only',
+  'regular non-symlink files; derive persona names, roles, score columns, and',
+  'VPC sections from that live inventory. An empty inventory means “no personas',
+  'configured”, never fabricated rows or scores.',
+  '',
+  'For every `KIMI_BACKLOG_*` marker, first read and validate',
+  '`.specrails/backlog-config.json`. Route `local` through structured reads and',
+  'atomic writes of `.specrails/local-tickets.json`; route `github` through the',
+  'approved `gh issue` operation; route `jira` only through the configured',
+  'project/base URL and credentials. Honour read-only mode and never perform a',
+  'write operation when configuration is missing, invalid, or read-only.',
+  'Arguments shown after a marker describe the operation; they are not shell',
+  'argv. Resolve `KIMI_PR_CREATE` with the repository’s configured PR workflow',
+  'and ask before publishing when the active workflow requires confirmation.',
+  '',
+].join('\n')
+
+const KIMI_RUNTIME_PLACEHOLDERS: Record<string, string> = {
+  ARCHITECTURE_DIAGRAM: 'KIMI_RUNTIME_ARCHITECTURE_DIAGRAM',
+  AREA_TABLE: 'KIMI_RUNTIME_AREA_TABLE',
+  BACKEND_ARCHITECTURE_DIAGRAM: 'KIMI_RUNTIME_BACKEND_ARCHITECTURE_DIAGRAM',
+  BACKEND_CRITICAL_RULES: 'KIMI_RUNTIME_BACKEND_CRITICAL_RULES',
+  BACKEND_EXPERTISE: 'KIMI_RUNTIME_BACKEND_EXPERTISE',
+  BACKEND_LAYER_CONVENTIONS: 'KIMI_RUNTIME_BACKEND_LAYER_CONVENTIONS',
+  BACKEND_STACK: 'KIMI_RUNTIME_BACKEND_STACK',
+  BACKEND_TECH_LIST: 'KIMI_RUNTIME_BACKEND_TECH_LIST',
+  BACKLOG_COMMENT_CMD: 'KIMI_BACKLOG_COMMENT',
+  BACKLOG_CREATE_CMD: 'KIMI_BACKLOG_CREATE',
+  BACKLOG_DELETE_CMD: 'KIMI_BACKLOG_DELETE',
+  BACKLOG_FETCH_ALL_CMD: 'KIMI_BACKLOG_FETCH_ALL',
+  BACKLOG_FETCH_CLOSED_CMD: 'KIMI_BACKLOG_FETCH_CLOSED',
+  BACKLOG_FETCH_CMD: 'KIMI_BACKLOG_FETCH',
+  BACKLOG_INIT_LABELS_CMD: 'KIMI_BACKLOG_INIT_LABELS',
+  BACKLOG_PARTIAL_COMMENT_CMD: 'KIMI_BACKLOG_PARTIAL_COMMENT',
+  BACKLOG_PREFLIGHT: 'KIMI_BACKLOG_PREFLIGHT',
+  BACKLOG_PROVIDER_NAME: 'KIMI_RUNTIME_BACKLOG_PROVIDER_NAME',
+  BACKLOG_UPDATE_CMD: 'KIMI_BACKLOG_UPDATE',
+  BACKLOG_VIEW_CMD: 'KIMI_BACKLOG_VIEW',
+  CI_CHECK_TABLE_ROWS: 'KIMI_RUNTIME_CI_CHECK_TABLE_ROWS',
+  CI_COMMANDS: 'KIMI_RUNTIME_CI_COMMANDS',
+  CI_COMMANDS_BACKEND: 'KIMI_RUNTIME_CI_COMMANDS_BACKEND',
+  CI_COMMANDS_FRONTEND: 'KIMI_RUNTIME_CI_COMMANDS_FRONTEND',
+  CI_COMMANDS_FULL: 'KIMI_RUNTIME_CI_COMMANDS_FULL',
+  CI_COMMON_PITFALLS: 'KIMI_RUNTIME_CI_COMMON_PITFALLS',
+  CI_CRITICAL_WARNINGS: 'KIMI_RUNTIME_CI_CRITICAL_WARNINGS',
+  CI_KNOWN_GAPS: 'KIMI_RUNTIME_CI_KNOWN_GAPS',
+  CODE_QUALITY_CHECKLIST: 'KIMI_RUNTIME_CODE_QUALITY_CHECKLIST',
+  CODE_QUALITY_STANDARDS: 'KIMI_RUNTIME_CODE_QUALITY_STANDARDS',
+  COMPETITIVE_LANDSCAPE: 'KIMI_RUNTIME_COMPETITIVE_LANDSCAPE',
+  DEPENDENCY_CHECK_COMMANDS: 'KIMI_RUNTIME_DEPENDENCY_CHECK_COMMANDS',
+  DOMAIN_EXPERTISE: 'KIMI_RUNTIME_DOMAIN_EXPERTISE',
+  DOMAIN_KNOWLEDGE: 'KIMI_RUNTIME_DOMAIN_KNOWLEDGE',
+  FRONTEND_ARCHITECTURE_DIAGRAM: 'KIMI_RUNTIME_FRONTEND_ARCHITECTURE_DIAGRAM',
+  FRONTEND_CRITICAL_RULES: 'KIMI_RUNTIME_FRONTEND_CRITICAL_RULES',
+  FRONTEND_EXPERTISE: 'KIMI_RUNTIME_FRONTEND_EXPERTISE',
+  FRONTEND_LAYER_CONVENTIONS: 'KIMI_RUNTIME_FRONTEND_LAYER_CONVENTIONS',
+  FRONTEND_STACK: 'KIMI_RUNTIME_FRONTEND_STACK',
+  FRONTEND_TECH_LIST: 'KIMI_RUNTIME_FRONTEND_TECH_LIST',
+  GIT_ACCESS: 'KIMI_RUNTIME_GIT_ACCESS',
+  JIRA_BASE_URL: 'KIMI_RUNTIME_JIRA_BASE_URL',
+  JIRA_PROJECT_KEY: 'KIMI_RUNTIME_JIRA_PROJECT_KEY',
+  KEY_FILE_PATHS: 'KIMI_RUNTIME_KEY_FILE_PATHS',
+  LAYER_CLAUDE_MD_PATHS: 'KIMI_RUNTIME_LAYER_CONTEXT_PATHS',
+  LAYER_CONVENTIONS: 'KIMI_RUNTIME_LAYER_CONVENTIONS',
+  LAYER_LIST: 'KIMI_RUNTIME_LAYER_LIST',
+  LAYER_NAME: 'KIMI_RUNTIME_LAYER_NAME',
+  LAYER_PATH: 'KIMI_RUNTIME_LAYER_PATH',
+  LAYER_TAGS: 'KIMI_RUNTIME_LAYER_TAGS',
+  MAINTAINER_PERSONA_LINE: 'KIMI_RUNTIME_MAINTAINER_PERSONA_LINE',
+  MAX_SCORE: 'KIMI_RUNTIME_PERSONA_MAX_SCORE',
+  PERSONA_COUNT: 'KIMI_RUNTIME_PERSONA_COUNT',
+  PERSONA_FILES: 'KIMI_RUNTIME_PERSONA_FILES',
+  PERSONA_FILE_LIST: 'KIMI_RUNTIME_PERSONA_FILE_LIST',
+  PERSONA_FILE_READ_LIST: 'KIMI_RUNTIME_PERSONA_FILE_READ_LIST',
+  PERSONA_FIT_FORMAT: 'KIMI_RUNTIME_PERSONA_FIT_FORMAT',
+  PERSONA_NAMES: 'KIMI_RUNTIME_PERSONA_NAMES',
+  PERSONA_NAMES_WITH_ROLES: 'KIMI_RUNTIME_PERSONA_NAMES_WITH_ROLES',
+  PERSONA_SCORE_FORMAT: 'KIMI_RUNTIME_PERSONA_SCORE_FORMAT',
+  PERSONA_SCORE_HEADERS: 'KIMI_RUNTIME_PERSONA_SCORE_HEADERS',
+  PERSONA_SCORE_SEPARATORS: 'KIMI_RUNTIME_PERSONA_SCORE_SEPARATORS',
+  PERSONA_VPC_SECTIONS: 'KIMI_RUNTIME_PERSONA_VPC_SECTIONS',
+  PR_CREATE_CMD: 'KIMI_PR_CREATE',
+  PROJECT_CONTEXT: 'KIMI_RUNTIME_PROJECT_CONTEXT',
+  TECH_EXPERTISE: 'KIMI_RUNTIME_TECH_EXPERTISE',
+  TEST_QUALITY_CHECKLIST: 'KIMI_RUNTIME_TEST_QUALITY_CHECKLIST',
+  TEST_RUNNER_CHECK: 'KIMI_RUNTIME_TEST_RUNNER_CHECK',
+  WARNINGS: 'KIMI_RUNTIME_WARNINGS',
+}
+
+function writeKimiWorkflowSkill(args: {
+  src: string
+  dest: string
+  commandName: string
+  placeholders: Record<string, string>
+}): void {
+  if (!pathExists(args.src)) return
+  const { body, description } = stripFrontmatter(readTextFile(args.src))
+  const skillName = `specrails-${args.commandName}`
+  const providerNeutral = renderPlaceholders(body, {
+    ...KIMI_RUNTIME_PLACEHOLDERS,
+    ...args.placeholders,
+    MEMORY_PATH: '.kimi-code/agent-memory/',
+  }).replaceAll(
+    '.specrails/profiles/project-default.json',
+    '.specrails/profiles/kimi-default.json',
+  )
+  const rendered = translateClaudeTextForKimi(
+    adaptKimiWorkflowBody(args.commandName, providerNeutral),
+  )
+  const frontmatter = [
+    '---',
+    `name: ${skillName}`,
+    `description: ${JSON.stringify(
+      translateClaudeTextForKimi(
+        renderPlaceholders(
+          description ?? `SpecRails ${args.commandName} workflow for Kimi Code.`,
+          {
+            ...KIMI_RUNTIME_PLACEHOLDERS,
+            ...args.placeholders,
+          },
+        ),
+      ),
+    )}`,
+    'type: prompt',
+    '---',
+    '',
+  ].join('\n')
+  writeFileLf(
+    args.dest,
+    frontmatter +
+      KIMI_NESTED_SKILL_CONTRACT +
+      KIMI_ROLE_EXECUTION_CONTRACT +
+      KIMI_RUNTIME_CONTEXT_CONTRACT +
+      rendered,
+  )
+}
+
+function adaptKimiWorkflowBody(commandName: string, body: string): string {
+  if (commandName === 'batch-implement') {
+    return adaptKimiBatchImplement(body)
+  }
+  if (commandName === 'auto-propose-backlog-specs') {
+    return adaptKimiAutoPropose(body)
+  }
+  if (commandName === 'enrich') {
+    return renderKimiEnrichWorkflow()
+  }
+  if (commandName === 'reconfig') {
+    return renderKimiReconfigWorkflow()
+  }
+  if (commandName === 'telemetry') {
+    return renderKimiTelemetryWorkflow()
+  }
+  if (commandName === 'retry') {
+    return adaptKimiRetry(body)
+  }
+  if (commandName !== 'implement') return body
+  let adapted = replaceMarkdownSection(
+    body,
+    '##### Apply per-agent model overrides (profile mode only)',
+    '##### Legacy mode — preserve current behavior',
+    [
+      '##### Resolve per-role model overrides (profile mode only)',
+      '',
+      'Keep each `AGENT_MODEL[id]` value exactly as declared in the profile.',
+      'Do **not** rewrite role `SKILL.md` frontmatter: Kimi directory skills do',
+      'not carry per-role model configuration. In the orchestrator, resolve the',
+      'role id against the parsed `AGENT_MODEL` map, then write the exact result',
+      'into that role wave entry\'s JSON `model` field using WriteFile. Use',
+      'the provider default `k3` when absent; never depend on a shell array from',
+      'a previous tool call. Only the official short ids `k3`,',
+      '`kimi-for-coding`, and `kimi-for-coding-highspeed` gain the',
+      '`kimi-code/` prefix at the CLI boundary. Never map Claude aliases.',
+      '',
+    ].join('\n'),
+  )
+  adapted = replaceMarkdownSection(
+    adapted,
+    '##### Legacy mode — preserve current behavior',
+    '##### Agent roles (both modes)',
+    [
+      '##### Legacy mode — preserve current behavior',
+      '',
+      'If no profile is active, discover role directories without mutating them:',
+      '',
+      '```bash',
+      'AVAILABLE_AGENTS="$(find -L .kimi-code/skills -mindepth 2 -maxdepth 2 \\',
+      '  -type f -name SKILL.md -print 2>/dev/null | sed \'s|.*/skills/||;s|/SKILL.md$||\' \\',
+      '  | grep -E \'^(sr|custom)-\' | sort)"',
+      'PROFILE_MODE="legacy"',
+      'PROFILE_NAME=""',
+      '```',
+      '',
+      'Per-role model overrides are empty in legacy mode. External role',
+      'processes use the explicit Kimi default (`k3`, launched as',
+      '`kimi-code/k3`).',
+      '',
+    ].join('\n'),
+  )
+  adapted = replaceMarkdownSection(
+    adapted,
+    '#### Merge Algorithm',
+    '**Step 4: Record outcomes**',
+    [
+      '#### Kimi role-wave merge algorithm',
+      '',
+      'The role-wave contract above overrides the generic runtime-supplied',
+      'worktree assumptions. Use the stable run id chosen for this workflow.',
+      'First run this command (the run id grammar is validated before git):',
+      '',
+      '```sh',
+      'node .kimi-code/specrails/run-skill.mjs --role-wave-status <stable-run-id>',
+      '```',
+      '',
+      'The single `specrails.merge.inventory` frame supplies `baseCommit`,',
+      '`manifestPath`, and each safe worktree id, `repoDir`, and complete',
+      '`changes` list. Every change is `{status:"A"|"M"|"D",path}`. This',
+      'inventory compares against the synthetic baseline snapshot, includes',
+      'committed/staged/unstaged and non-ignored untracked role output, and',
+      'excludes `.kimi-code` plus SpecRails run-state. Never discover changed',
+      'files with a shell loop, newline splitting, or a hard-coded `main` ref.',
+      '',
+      'Classify paths across all worktrees before applying anything:',
+      '- `exclusive_files`: appears in one worktree only.',
+      '- `shared_files`: appears in two or more worktrees.',
+      '- Preserve each A/M/D status; a D path has no source file to copy.',
+      '',
+      '**Exclusive A/M/D actions**',
+      '',
+      'For each feature in `MERGE_ORDER`, use structured WriteFile (never shell',
+      'interpolation) to write `.specrails/kimi-role-merge.json`:',
+      '',
+      '```json',
+      '{',
+      '  "run": "<stable-run-id>",',
+      '  "actions": [',
+      '    {"worktree":"<safe-id>","path":"<exact-git-path>","operation":"copy"},',
+      '    {"worktree":"<safe-id>","path":"<deleted-path>","operation":"delete"}',
+      '  ]',
+      '}',
+      '```',
+      '',
+      'Use `copy` for A/M and `delete` for D, then run exactly:',
+      '',
+      '```sh',
+      'node .kimi-code/specrails/run-skill.mjs \\',
+      '  --role-merge-file .specrails/kimi-role-merge.json',
+      '```',
+      '',
+      'The helper validates the one-shot file, manifest, registered worktree,',
+      'and path containment, then copies bytes/symlinks or deletes the target',
+      'without a shell. Filenames may contain spaces, Unicode, quotes, `$()`,',
+      'or leading dashes; never place them in a Bash command. It rejects',
+      'provider/run-state paths, traversal, duplicate targets, directories,',
+      'and symlinked target parents.',
+      '',
+      '**Shared paths**',
+      '',
+      'Process shared paths in `MERGE_ORDER`:',
+      '1. D in every contributor: submit one validated `delete` action.',
+      '2. D versus A/M: record a delete/modify conflict; do not silently copy',
+      '   or delete it.',
+      '3. A/M text: use structured ReadFile on each emitted `repoDir` + exact',
+      '   path and on the current merge target. Apply the existing Markdown',
+      '   section-aware strategy for `.md`; for other text perform a three-way',
+      '   semantic merge against the current target, writing through WriteFile.',
+      '4. Binary/type conflicts: record them for `sr-merge-resolver`; never',
+      '   decode or round-trip binary data through model text.',
+      '5. A resolved whole-file winner may be applied with one validated copy',
+      '   action. Any unresolved region receives the existing conflict markers',
+      '   and `MERGE_REPORT` entry.',
+      '',
+      'When `DRY_RUN=true`, do not invoke the repository merge-action helper.',
+      'Write resolved A/M outputs under `CACHE_DIR` with structured WriteFile',
+      'and record D paths as deletion operations in `.cache-manifest.json`.',
+      'Keep worktrees for inspection as the surrounding dry-run rule requires.',
+      '',
+    ].join('\n'),
+  )
+  adapted = adapted
+    .replace(
+      '  "implemented_files": [],',
+      [
+        '  "implemented_files": [],',
+        '  "kimi_role_wave": {',
+        '    "run": "<stable-run-id>",',
+        '    "manifest_path": ".specrails/kimi-role-worktrees/<stable-run-id>.json",',
+        '    "base_commit": null,',
+        '    "workspaces": {}',
+        '  },',
+      ].join('\n'),
+    )
+    .replace(
+      'If the write succeeds: set `PIPELINE_STATE_AVAILABLE=true`.',
+      [
+        'If the write succeeds: set `PIPELINE_STATE_AVAILABLE=true`.',
+        '',
+        '**Kimi retry state:** after every `specrails.role.workspace` frame,',
+        'atomically refresh `kimi_role_wave.manifest_path`, `base_commit`, and',
+        '`workspaces[<feature-id>]` from the helper output. Never synthesize',
+        'these values. Keep the same `run` and `worktree:<feature-id>` for that',
+        'feature through developer, test, docs, and review. On any failure keep',
+        'the manifest and worktrees. After every required change has been merged',
+        'successfully, run the static cleanup command from the Kimi role',
+        'contract and set `kimi_role_wave` to `null` in pipeline state.',
+      ].join('\n'),
+    )
+    .replaceAll(
+      'git -C <worktree-path> diff main --name-only',
+      'git -C <worktree-path> diff <base-commit> --name-only',
+    )
+    .replaceAll(
+      'git -C <worktree-path> diff main -- <file>',
+      'git -C <worktree-path> diff <base-commit> -- <file>',
+    )
+    .replace(
+      '(`<worktree-path>` is an absolute git-worktree path supplied by the runtime; `git -C <worktree-path>` already targets it directly.)',
+      '(`<worktree-path>` is the `repoDir` emitted by the role-wave helper, and `<base-commit>` is read from its persisted manifest; `git -C <worktree-path>` already targets it directly.)',
+    )
+  return adapted
+}
+
+function adaptKimiBatchImplement(body: string): string {
+  return replaceMarkdownSection(
+    body,
+    '### Wave invocation',
+    '### Failure isolation',
+    [
+      '### Kimi wave invocation',
+      '',
+      'Nested `specrails-implement` executions are independent foreground Kimi',
+      'processes. Do not call multiple built-in `Skill` tools in one Kimi',
+      'session and do not share one checkout concurrently.',
+      '',
+      'Choose one safe `BATCH_RUN` id. For dependency wave `W`, derive the',
+      'deterministic safe run id `<BATCH_RUN>-w<W>`. Process waves sequentially:',
+      '',
+      '1. For a normal repository launch, partition each dependency wave into',
+      '   foreground batches of at most `min(CONCURRENCY,32)` entries. Each entry uses',
+      '   `skill:"specrails-implement"`, `workspace:"worktree:<feature-id>"`,',
+      '   the complete `<ref> [--dry-run]` arguments, the selected profile stem',
+      '   (or `"inherit"`), and that profile\'s exact `orchestrator.model` (or',
+      '   `k3`). Feature ids and keys must be collision-free safe ids.',
+      '2. Wait for all completion frames. A failed entry fails only that ticket;',
+      '   preserve its manifest/worktree for diagnosis and record the failure.',
+      '3. Before a downstream dependency wave, call `--role-wave-status` for',
+      '   the completed wave. Merge each successful worktree\'s A/M/D inventory',
+      '   into the batch repository with the same structured merge-file and',
+      '   shared-path rules defined by `specrails-implement`. Never interpolate',
+      '   a filename into Shell. If merge succeeds, run',
+      '   `node .kimi-code/specrails/run-skill.mjs --role-wave-cleanup <run>`.',
+      '   This makes predecessor output part of the next wave\'s newly captured',
+      '   synthetic baseline. Do not cleanup failed or unmerged worktrees.',
+      '4. Record `{ref,wave,status,profile,error_summary,run,manifest_path,',
+      '   workspace}` in `WAVE_RESULTS` before starting another batch.',
+      '',
+      'Inside a specrails-desktop isolated rail worktree, effective concurrency',
+      'is exactly 1. Submit a one-entry foreground role wave per ticket with',
+      '`workspace:"current"` and a deterministic unique run id; wait before the',
+      'next ticket. No sibling worktree, status merge, or cleanup is needed',
+      'because every nested implementation writes directly into the desktop',
+      'rail\'s current repository.',
+      '',
+      'Per-ticket profiles remain isolated: `profile` is either `inherit` or the',
+      'validated filename stem from `PROFILE_MAP`; `model` is resolved from the',
+      'same profile before writing JSON. Never export a profile globally.',
+      '',
+    ].join('\n'),
+  )
+}
+
+function adaptKimiAutoPropose(body: string): string {
+  return body
+    .replace(
+      'Launch a **single** explorer subagent (`subagent_type: Explore`, `run_in_background: true`) for product discovery.',
+      [
+        'Launch one **sr-product-analyst** role in a foreground Kimi role wave.',
+        'Use `skill:"sr-product-analyst"`, `workspace:"current"`,',
+        '`profile:"inherit"`, and pass the complete discovery prompt below as',
+        '`args`. Before writing the wave, enumerate regular non-symlink',
+        '`.kimi-code/personas/*.md` files and include their exact paths plus',
+        'contents in that context; stop with guidance to run',
+        '`Skill(skill="specrails-enrich", args="")` when none exist. Wait for its attributed',
+        'completion/output frames. Kimi has no Claude Explore subagent type;',
+        'never select a non-existent Explore role.',
+      ].join(' '),
+    )
+    .replaceAll('The Explore agent receives this prompt:', 'The sr-product-analyst role receives this prompt:')
+    .replaceAll('After the Explore agent completes:', 'After the sr-product-analyst role completes:')
+}
+
+function adaptKimiRetry(body: string): string {
+  return body
+    .replace(
+      '- `PHASE_STATUSES` ← `phases` map (`architect`, `developer`, `test-writer`, `doc-sync`, `reviewer`, `ship`, `ci` → `"done"`, `"failed"`, `"skipped"`, or `"pending"`)',
+      [
+        '- `PHASE_STATUSES` ← `phases` map (`architect`, `developer`, `test-writer`, `doc-sync`, `reviewer`, `ship`, `ci` → `"done"`, `"failed"`, `"skipped"`, or `"pending"`)',
+        '- `KIMI_ROLE_WAVE` ← `kimi_role_wave` (required when an isolated Kimi',
+        '  phase has already started): persisted `run`, `manifest_path`,',
+        '  `base_commit`, and feature→workspace mapping.',
+      ].join('\n'),
+    )
+    .replace(
+      '**Validation:**',
+      [
+        '**Kimi workspace validation (before any phase):**',
+        '',
+        'If `KIMI_ROLE_WAVE` is non-null, validate its safe run id by invoking',
+        '`node .kimi-code/specrails/run-skill.mjs --role-wave-status <run>`.',
+        'The returned manifest path, base commit, and workspace ids must exactly',
+        'match pipeline state. Any mismatch/missing/unregistered worktree is a',
+        'hard stop: report recovery instructions and do not create a replacement',
+        'worktree. A retry must use the same run and exact',
+        '`worktree:<feature-id>` mapping so successful developer changes survive',
+        'a later test/docs/reviewer failure. Refresh state from emitted frames',
+        'after each resumed role. Never choose a new run while valid state',
+        'exists; never cleanup before every required phase and merge succeeds.',
+        '',
+        '**Validation:**',
+      ].join('\n'),
+    )
+    .replace(
+      'Include PR URL if ship ran successfully.',
+      [
+        'Include PR URL if ship ran successfully.',
+        '',
+        'After all required isolated outputs have been safely merged, invoke the',
+        'static `--role-wave-cleanup <run>` helper. Only after its cleanup frame',
+        'succeeds set `kimi_role_wave` to `null`. A failed retry retains state.',
+      ].join('\n'),
+    )
+}
+
+function renderKimiEnrichWorkflow(): string {
+  return [
+    '# Enrich SpecRails for Kimi Code',
+    '',
+    'Refresh the Kimi-native SpecRails installation, analyze this repository,',
+    'and maintain project context/personas without generating Claude artifacts.',
+    'Kimi skills are managed provider artifacts; never rewrite their SKILL.md',
+    'frontmatter or create Claude-style command/agent trees.',
+    '',
+    '## Mode selection',
+    '',
+    'Parse `$ARGUMENTS`: `--update`, `--quick`, and `--from-config` are mutually',
+    'exclusive. With no flag run interactive full mode.',
+    '',
+    '1. Resolve the repository as `${SPECRAILS_REPO_DIR:-.}` and verify',
+    '   `.kimi-code/specrails/run-skill.mjs` plus',
+    '   `.specrails/install-config.yaml` exist.',
+    '2. Read install config and require provider `kimi` (or an explicitly',
+    '   provider-neutral legacy config). Refuse a different provider.',
+    '3. Refresh managed provider artifacts with the installed Core CLI:',
+    '   `npx specrails-core update --provider kimi --root-dir "${SPECRAILS_REPO_DIR:-.}"`.',
+    '   Use the process result as a hard gate. This provider-aware materializer',
+    '   regenerates direct-child workflows/roles, rules, runner, OpenSpec skills,',
+    '   settings, manifest, and framework links. Do not reproduce its templates',
+    '   with model-authored file copying.',
+    '4. Validate `.specrails/profiles/kimi-default.json`: schemaVersion 1,',
+    '   provider `kimi`, required architect/developer/reviewer, unique role ids,',
+    '   safe model ids, and valid routing. Preserve exact model identifiers.',
+    '',
+    '## Quick mode',
+    '',
+    'Inspect package/build metadata and the top-level source tree. Atomically',
+    'write `.kimi-code/project-context.md` with stack, architecture, test/lint/',
+    'build commands, repository conventions, and the UTC refresh time. Preserve',
+    'existing `.kimi-code/personas/`. Report that full mode can add VPC personas.',
+    '',
+    '## From-config mode',
+    '',
+    'Do not ask questions. Apply the tier, selected agents, backlog, git, and',
+    'model choices already present in install config/profile; the Core update is',
+    'the only artifact-generation authority. For quick tier run Quick mode. For',
+    'full tier perform the same repository analysis as Full mode, retain existing',
+    'personas when present, and generate conservative personas only when the',
+    'config enables product roles and the persona directory is empty.',
+    '',
+    '## Update mode',
+    '',
+    'Run the provider-aware refresh, re-analyze commands/conventions, and',
+    'atomically refresh only `.kimi-code/project-context.md`. Keep user personas,',
+    'custom-* skills, agent memory, profiles, MCP configuration, and security',
+    'exemptions byte-for-byte. Report stale/missing persona references but do not',
+    'invent replacements.',
+    '',
+    '## Full mode',
+    '',
+    'Analyze the complete codebase and present findings. Ask concise questions',
+    'about target users, pains, gains, product goals, and repository shipping',
+    'policy. Research externally only with user-approved network tooling.',
+    'Generate 2–4 Value Proposition Canvas personas as real Markdown files under',
+    '`.kimi-code/personas/<safe-kebab-id>.md`; include jobs, pains, gains,',
+    'behavior, success criteria, and evidence/assumptions. On OSS projects also',
+    'materialize the bundled maintainer persona from setup templates. Never',
+    'overwrite an existing persona without showing the proposed change.',
+    '',
+    'Refresh `.kimi-code/project-context.md` and ensure every selected product',
+    'role has an agent-memory directory. Workflows discover persona files at',
+    'runtime, so do not fork or mutate framework-owned skills to embed a static',
+    'persona list.',
+    '',
+    '## Verification and report',
+    '',
+    'Run `npx specrails-core doctor --provider kimi --root-dir',
+    '"${SPECRAILS_REPO_DIR:-.}"`. Verify every immediate skill directory has one',
+    'valid SKILL.md, no role is nested under `skills/rails`, no unresolved',
+    'template token remains, the Kimi profile validates, and no Claude model',
+    'alias/path was generated. Report mode, provider version, context/persona',
+    'files, selected roles, exact models, and doctor result.',
+    '',
+  ].join('\n')
+}
+
+function renderKimiReconfigWorkflow(): string {
+  return [
+    '# Reconfig: apply Kimi models to a provider profile',
+    '',
+    'Kimi role skills do not carry per-role model frontmatter. Reconfiguration',
+    'updates a provider-bound profile; workflows read that profile and put each',
+    'exact model id in the structured role wave.',
+    '',
+    '1. Parse `$ARGUMENTS` as optional `--profile <safe-name>`; default to the',
+    '   active `SPECRAILS_PROFILE_PATH`, then',
+    '   `.specrails/profiles/kimi-default.json`.',
+    '2. Require a regular non-symlink JSON file inside `.specrails/profiles/`.',
+    '   Validate it against profile schema v1, require `provider:"kimi"`, unique',
+    '   agents, the baseline trio, valid routing references, and Kimi-safe model',
+    '   ids (`^[A-Za-z0-9][A-Za-z0-9._/:-]*$`, maximum 128 characters).',
+    '3. Read `.specrails/agents.yaml` only as an optional legacy input. Ask for',
+    '   confirmation before migrating its defaults/per-agent model values. Claude',
+    '   aliases `opus`, `sonnet`, and `haiku` are not Kimi models and must never',
+    '   be translated silently; require an explicit Kimi replacement.',
+    '4. Present the orchestrator and per-role old→new model table. Apply approved',
+    '   edits to a complete in-memory profile object, validate again, then use',
+    '   structured WriteFile for one atomic logical replacement. Preserve name,',
+    '   description, required flags, agent order, and routing.',
+    '5. Re-read and validate the result. Report changed/unchanged/skipped roles.',
+    '',
+    'Never edit any role SKILL.md under `.kimi-code/skills/`, never create Claude agent files,',
+    'and never put a model id in a shell command.',
+    '',
+  ].join('\n')
+}
+
+function renderKimiTelemetryWorkflow(): string {
+  return [
+    '# Kimi agent telemetry',
+    '',
+    'Analyze real Kimi Code session usage for this repository. Accepted flags:',
+    '`--period today|week|all` (default `week`), `--agent <id>`,',
+    '`--format markdown|json`, and `--save`. Cost is not derivable from Kimi logs and must remain',
+    '`null`/`unavailable`; never apply a Claude or invented rate card.',
+    '',
+    '## Discover and validate sessions',
+    '',
+    'Read `~/.kimi-code/session_index.jsonl` line by line. Ignore only a final',
+    'truncated JSON line; warn on any other malformed line. Fold records by',
+    '`sessionId`, keeping the latest valid entry and honoring an explicit latest',
+    'deletion/tombstone record. A live entry provides `sessionId`, `sessionDir`,',
+    'and `workDir`. Require safe scalar strings, match canonical `workDir` to',
+    '`${SPECRAILS_REPO_DIR:-.}`, and require canonical `sessionDir` to remain',
+    'inside `~/.kimi-code/sessions/`. Reject symlinks/path traversal and ignore',
+    'missing or deleted session directories.',
+    '',
+    'For each accepted session, read its regular non-symlink `state.json` and',
+    'validate its `workDir`, timestamps, and title. Then scan only regular',
+    '`agents/*/wire.jsonl` files within that same session directory. Tolerate a',
+    'truncated final line; count and warn on other malformed records.',
+    '',
+    '## Usage schema and attribution',
+    '',
+    'Consume only records with `type:"usage.record"` and a safe `model` plus',
+    '`usage:{inputOther,output,inputCacheRead,inputCacheCreation}`. Treat absent',
+    'numeric counters as zero; reject negative/non-finite values. Preserve',
+    '`usageScope` and aggregate input-other, output, cache-read, cache-creation,',
+    'and total tokens per model/session.',
+    '',
+    'Attribute an external role session by canonical workDir: first use its',
+    '`.specrails-role-workspace.json` marker; otherwise match `repoDir` in valid',
+    '`.specrails/kimi-role-worktrees/*.json` manifests. Attribute the top-level',
+    'session to `orchestrator`; use `unknown` only when no verified mapping',
+    'exists. Apply period and agent filters after attribution. Deduplicate by',
+    'session id + agent wire path + record position.',
+    '',
+    'Duration comes only from validated state timestamps. The wire schema does',
+    'not provide a trustworthy role success/failure outcome, so expose that',
+    'metric as unavailable rather than inferring it from the last event.',
+    '',
+    '## Output',
+    '',
+    'Show session/run count, duration, exact models, and all four token counters',
+    'per role plus totals and cache ratio. In JSON use',
+    '`cost_usd:null`, `avg_cost_per_run_usd:null`, and',
+    '`success_rate:null` with `unavailable_reason`. In Markdown print',
+    '`Cost: unavailable (Kimi logs contain usage, not billing rates)`.',
+    'Recommendations may discuss token/cache/runtime outliers only.',
+    '',
+    'With `--save`, write the same JSON object under',
+    '`.kimi-code/telemetry/<UTC-date>-<period>.json` using structured WriteFile;',
+    'never include prompt text, credentials, raw wire records, or paths outside',
+    'the repository/session identifiers.',
+    '',
+  ].join('\n')
+}
+
+function replaceMarkdownSection(
+  body: string,
+  startHeading: string,
+  endHeading: string,
+  replacement: string,
+): string {
+  const start = body.indexOf(startHeading)
+  if (start < 0) return body
+  const end = body.indexOf(endHeading, start + startHeading.length)
+  if (end < 0) return body
+  return body.slice(0, start) + replacement + body.slice(end)
+}
+
+function writeKimiRoleSkill(args: {
+  src: string
+  dest: string
+  roleId: string
+  placeholders: Record<string, string>
+}): void {
+  if (!pathExists(args.src)) return
+  const { body, description } = stripFrontmatter(readTextFile(args.src))
+  const rendered = translateClaudeTextForKimi(
+    renderPlaceholders(body, {
+      ...KIMI_RUNTIME_PLACEHOLDERS,
+      ...args.placeholders,
+      MEMORY_PATH: `.kimi-code/agent-memory/${args.roleId}/`,
+    }),
+  )
+  const frontmatter = [
+    '---',
+    `name: ${args.roleId}`,
+    `description: ${JSON.stringify(
+      translateClaudeTextForKimi(
+        renderPlaceholders(
+          description ?? `SpecRails ${args.roleId} role for Kimi Code.`,
+          {
+            ...KIMI_RUNTIME_PLACEHOLDERS,
+            ...args.placeholders,
+          },
+        ),
+      ),
+    )}`,
+    'type: prompt',
+    '---',
+    '',
+  ].join('\n')
+  writeFileLf(
+    args.dest,
+    frontmatter +
+      KIMI_NESTED_SKILL_CONTRACT +
+      KIMI_RUNTIME_CONTEXT_CONTRACT +
+      rendered,
+  )
 }
 
 /**
@@ -1239,6 +2462,68 @@ function applyGeminiSettings(input: ScaffoldInput): number {
   return written
 }
 
+/**
+ * Kimi keeps both its project instructions and MCP configuration under
+ * `.kimi-code`. Existing user MCP configuration is never rewritten.
+ */
+function applyKimiSettings(input: ScaffoldInput): number {
+  let written = 0
+  const providerRoot = path.join(input.artifactRoot, input.providerDir)
+  const agentsMdPath = path.join(providerRoot, 'AGENTS.md')
+  const content = renderInitialKimiAgentsMd(input.codeRoot)
+  if (!pathExists(agentsMdPath)) {
+    writeFileLf(agentsMdPath, content)
+    written++
+  } else {
+    const existing = readTextFile(agentsMdPath)
+    const next = upsertAgentsMdManagedBlock(existing, extractManagedBlock(content))
+    if (next !== existing) {
+      writeFileLf(agentsMdPath, next)
+      written++
+    }
+  }
+
+  const mcpPath = path.join(providerRoot, 'mcp.json')
+  if (!pathExists(mcpPath)) {
+    writeFileLf(mcpPath, '{\n  "mcpServers": {}\n}\n')
+    written++
+  }
+  return written
+}
+
+function renderInitialKimiAgentsMd(repoRoot: string): string {
+  const projectName = path.basename(repoRoot)
+  return [
+    AGENTS_MD_START,
+    '',
+    `# ${projectName} — Kimi Code instructions`,
+    '',
+    'This project uses SpecRails skills under `.kimi-code/skills/`.',
+    'Kimi discovers only direct child skill directories. Interactive TUI sessions',
+    'invoke workflows as `/skill:specrails-<command>`. Headless prompt mode does',
+    'not dispatch slash skills, so automation must invoke',
+    '`.kimi-code/specrails/run-skill.mjs`. Role skills live at',
+    '`.kimi-code/skills/<sr-*|custom-*>/SKILL.md` and are launched by workflows in',
+    'separate helper-managed `kimi -p --output-format stream-json` processes.',
+    '',
+    '## Conventions',
+    '',
+    '- Read project source, `.git`, and `openspec/**` from',
+    '  `${SPECRAILS_REPO_DIR:-.}`.',
+    '- Read provider rules from `.kimi-code/rules/` and runtime memory from',
+    '  `.kimi-code/agent-memory/`.',
+    '- Preserve model ids from provider-aware profiles exactly. The Kimi CLI',
+    '  accepts configured aliases; official short ids use the `kimi-code/`',
+    '  prefix at launch (for example `kimi-code/k3`).',
+    '- OpenSpec workflows are invoked as `/skill:openspec-*`.',
+    '- Kimi is CLI-only: do not start a server, register a service, or copy',
+    '  credentials into this project.',
+    '',
+    AGENTS_MD_END,
+    '',
+  ].join('\n')
+}
+
 function renderInitialGeminiMd(repoRoot: string): string {
   const projectName = path.basename(repoRoot)
   return [
@@ -1284,6 +2569,18 @@ function pruneLegacyArtifacts(
     legacyPaths.push(path.join(input.artifactRoot, input.providerDir, 'skills'))
     legacyPaths.push(path.join(input.artifactRoot, input.providerDir, 'commands', 'setup.toml'))
     legacyPaths.push(path.join(input.artifactRoot, input.providerDir, 'commands', 'specrails', 'setup.toml'))
+  } else if (input.provider === 'kimi') {
+    // Early experimental builds used a Claude-shaped commands/agents layout
+    // inside `.kimi-code`. They also nested role skills one level too deep at
+    // `skills/rails/*`, which Kimi never discovers. Migrate reserved custom
+    // roles and prune only framework-owned nested roles before rendering the
+    // canonical flat layout. MCP config, AGENTS.md and unknown user files stay
+    // untouched.
+    migrateLegacyKimiRoleLayout(
+      path.join(input.artifactRoot, input.providerDir, 'skills'),
+    )
+    legacyPaths.push(path.join(input.artifactRoot, input.providerDir, 'commands'))
+    legacyPaths.push(path.join(input.artifactRoot, input.providerDir, 'agents'))
   } else {
     legacyPaths.push(path.join(input.artifactRoot, input.providerDir, 'commands', 'setup.md'))
     legacyPaths.push(path.join(input.artifactRoot, input.providerDir, 'commands', 'specrails', 'setup.md'))
@@ -1403,6 +2700,31 @@ function placeQuickTierArtefacts(input: ScaffoldInput): QuickPlacement {
       }
     }
     return { agents: 0, commands: commandsPlaced, rules: 0, skippedAgents: 0 }
+  }
+
+  if (input.provider === 'kimi') {
+    const setupTemplates = path.join(input.artifactRoot, '.specrails', 'setup-templates')
+    const rulesSrc = path.join(setupTemplates, 'rules')
+    const rulesDest = path.join(input.artifactRoot, input.providerDir, 'rules')
+    let rulesPlaced = 0
+    if (isDir(rulesSrc)) {
+      mkdirp(rulesDest)
+      for (const src of listDir(rulesSrc)) {
+        const name = path.basename(src)
+        if (!name.endsWith('.md')) continue
+        const rendered = translateClaudeTextForKimi(
+          renderPlaceholders(readTextFile(src), {
+            ...KIMI_RUNTIME_PLACEHOLDERS,
+            PROJECT_NAME: path.basename(input.codeRoot),
+            SECURITY_EXEMPTIONS_PATH: '.kimi-code/security-exemptions.yaml',
+            PERSONA_DIR: '.kimi-code/personas/',
+          }),
+        )
+        writeFileLf(path.join(rulesDest, name), rendered)
+        rulesPlaced++
+      }
+    }
+    return { agents: 0, commands: 0, rules: rulesPlaced, skippedAgents: 0 }
   }
 
   const setupTemplates = path.join(input.artifactRoot, '.specrails', 'setup-templates')
@@ -1701,6 +3023,71 @@ function placeSkills(input: ScaffoldInput): SkillsPlacement {
     result.placed += g.placed
     result.skipped += g.skipped
     result.filesCopied += g.filesCopied
+  }
+
+  if (input.provider === 'kimi') {
+    const setupRoot = path.join(input.artifactRoot, '.specrails', 'setup-templates')
+    const commandsSrc = path.join(setupRoot, 'commands', 'specrails')
+    const agentsSrc = path.join(setupRoot, 'agents')
+    const selectedAgents = input.selectedAgents
+      ? new Set([...input.selectedAgents, ...CORE_AGENTS])
+      : new Set([...CORE_AGENTS])
+    const placedRoleIds = new Set<string>()
+    const placeholders = {
+      PROJECT_NAME: path.basename(input.codeRoot),
+      SECURITY_EXEMPTIONS_PATH: '.kimi-code/security-exemptions.yaml',
+      PERSONA_DIR: '.kimi-code/personas/',
+    }
+
+    if (isDir(agentsSrc)) {
+      for (const src of listDir(agentsSrc)) {
+        const name = path.basename(src)
+        if (!name.endsWith('.md')) continue
+        const roleId = name.slice(0, -3)
+        if (!input.materializeAllAgents && !selectedAgents.has(roleId)) continue
+        if (!input.materializeAllAgents && QUICK_EXCLUDED_AGENTS.has(roleId)) {
+          result.skipped++
+          continue
+        }
+        writeKimiRoleSkill({
+          src,
+          dest: path.join(destBase, roleId, 'SKILL.md'),
+          roleId,
+          placeholders,
+        })
+        placedRoleIds.add(roleId)
+        result.placed++
+        result.filesCopied++
+        if (input.seedProjectDirs !== false) {
+          mkdirp(path.join(input.artifactRoot, input.providerDir, 'agent-memory', roleId))
+        }
+      }
+    }
+
+    const excludedCommands = new Set<string>()
+    if (!input.materializeAllAgents) {
+      for (const dep of COMMAND_AGENT_DEPENDENCIES) {
+        if (!dep.requires.every((role) => placedRoleIds.has(role))) {
+          excludedCommands.add(dep.command)
+        }
+      }
+    }
+    if (isDir(commandsSrc)) {
+      for (const src of listDir(commandsSrc)) {
+        const name = path.basename(src)
+        if (!name.endsWith('.md') || name === 'setup.md') continue
+        const commandName = name.slice(0, -3)
+        if (excludedCommands.has(commandName)) continue
+        writeKimiWorkflowSkill({
+          src,
+          dest: path.join(destBase, `specrails-${commandName}`, 'SKILL.md'),
+          commandName,
+          placeholders,
+        })
+        result.placed++
+        result.filesCopied++
+      }
+    }
   }
 
   return result

--- a/src/installer/profile-cli-validation.test.ts
+++ b/src/installer/profile-cli-validation.test.ts
@@ -1,0 +1,141 @@
+import { spawnSync } from 'node:child_process'
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const dispatcher = path.resolve(here, '..', '..', 'bin', 'specrails-core.mjs')
+
+interface Profile {
+  schemaVersion: number
+  name: string
+  orchestrator: { model: string }
+  agents: Array<{ id: string; model: string }>
+  routing: Array<
+    | { tags: string[]; agent: string }
+    | { default: true; agent: string }
+  >
+}
+
+function baselineProfile(): Profile {
+  return {
+    schemaVersion: 1,
+    name: 'semantic-validation',
+    orchestrator: { model: 'sonnet' },
+    agents: [
+      { id: 'sr-architect', model: 'sonnet' },
+      { id: 'sr-developer', model: 'sonnet' },
+      { id: 'sr-reviewer', model: 'sonnet' },
+    ],
+    routing: [{ default: true, agent: 'sr-developer' }],
+  }
+}
+
+describe('profile validate semantic invariants', () => {
+  let root: string
+  let sequence: number
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(os.tmpdir(), 'specrails-profile-cli-'))
+    sequence = 0
+  })
+
+  afterEach(() => {
+    rmSync(root, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 100,
+    })
+  })
+
+  function validate(profile: Profile) {
+    const profilePath = path.join(root, `profile-${sequence++}.json`)
+    writeFileSync(profilePath, `${JSON.stringify(profile)}\n`)
+    return spawnSync(
+      process.execPath,
+      [dispatcher, 'profile', 'validate', profilePath],
+      {
+        cwd: root,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          SPECRAILS_REGISTRY_HOME: path.join(root, 'home'),
+        },
+      },
+    )
+  }
+
+  it('accepts valid routing and keeps an empty routing list valid', () => {
+    const routed = validate(baselineProfile())
+    expect(routed.status).toBe(0)
+    expect(routed.stderr).toBe('')
+
+    const empty = baselineProfile()
+    empty.routing = []
+    const emptyResult = validate(empty)
+    expect(emptyResult.status).toBe(0)
+    expect(emptyResult.stderr).toBe('')
+  })
+
+  it('rejects duplicate agent ids after schema validation', () => {
+    const profile = baselineProfile()
+    profile.agents.push({ id: 'sr-developer', model: 'sonnet' })
+
+    const result = validate(profile)
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain(
+      '/agents/3/id duplicates agent id "sr-developer"',
+    )
+  })
+
+  it('rejects routing rules that reference an absent agent', () => {
+    const profile = baselineProfile()
+    profile.routing = [{ default: true, agent: 'custom-missing' }]
+
+    const result = validate(profile)
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain(
+      '/routing/0/agent references unknown agent "custom-missing"',
+    )
+  })
+
+  it('rejects multiple default routing rules', () => {
+    const profile = baselineProfile()
+    profile.routing = [
+      { default: true, agent: 'sr-architect' },
+      { default: true, agent: 'sr-developer' },
+    ]
+
+    const result = validate(profile)
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain(
+      '/routing must contain at most one default rule (found 2)',
+    )
+  })
+
+  it('rejects a default routing rule that is not terminal', () => {
+    const profile = baselineProfile()
+    profile.routing = [
+      { default: true, agent: 'sr-developer' },
+      { tags: ['architecture'], agent: 'sr-architect' },
+    ]
+
+    const result = validate(profile)
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain(
+      '/routing/0 default rule must be the last routing entry',
+    )
+  })
+})

--- a/src/installer/profile-schema.test.ts
+++ b/src/installer/profile-schema.test.ts
@@ -1,0 +1,111 @@
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+
+import type { ValidateFunction } from 'ajv'
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const Ajv2020 = (
+  require('ajv/dist/2020.js') as {
+    default: new (options: Record<string, unknown>) => {
+      compile: (schema: object) => ValidateFunction
+    }
+  }
+).default
+
+function validator(): ValidateFunction {
+  const schema = JSON.parse(
+    readFileSync(path.join(process.cwd(), 'schemas', 'profile.v1.json'), 'utf8'),
+  ) as object
+  return new Ajv2020({ allErrors: true, strict: false }).compile(schema)
+}
+
+function baselineProfile(): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    name: 'baseline',
+    orchestrator: { model: 'sonnet' },
+    agents: [
+      { id: 'sr-architect', model: 'sonnet' },
+      { id: 'sr-developer', model: 'sonnet' },
+      { id: 'sr-reviewer', model: 'sonnet' },
+    ],
+    routing: [{ default: true, agent: 'sr-developer' }],
+  }
+}
+
+describe('profile.v1 provider-aware models', () => {
+  it('keeps legacy provider-less Claude profiles valid', () => {
+    expect(validator()(baselineProfile())).toBe(true)
+  })
+
+  it('accepts exact Kimi model ids and custom role references', () => {
+    const profile = {
+      ...baselineProfile(),
+      provider: 'kimi',
+      orchestrator: { model: 'k3' },
+      agents: [
+        { id: 'sr-architect', model: 'k3' },
+        { id: 'sr-developer', model: 'kimi-for-coding-highspeed' },
+        { id: 'custom-auditor', model: 'my-provider/exact-model' },
+        { id: 'sr-reviewer', model: 'kimi-code/kimi-for-coding' },
+      ],
+    }
+    const validate = validator()
+    expect(validate(profile), JSON.stringify(validate.errors)).toBe(true)
+    expect((profile.orchestrator as { model: string }).model).toBe('k3')
+    expect((profile.agents[2] as { model: string }).model).toBe(
+      'my-provider/exact-model',
+    )
+  })
+
+  it('retains a custom Kimi alias even when its literal name matches a Claude alias', () => {
+    const profile = {
+      ...baselineProfile(),
+      provider: 'kimi',
+      orchestrator: { model: 'sonnet' },
+      agents: [
+        { id: 'sr-architect', model: 'k3' },
+        { id: 'sr-developer', model: 'k3' },
+        { id: 'sr-reviewer', model: 'k3' },
+      ],
+    }
+    const validate = validator()
+    expect(validate(profile), JSON.stringify(validate.errors)).toBe(true)
+    expect((profile.orchestrator as { model: string }).model).toBe('sonnet')
+  })
+
+  it.each([
+    'team model',
+    '"; touch /tmp/specrails-pwned; #',
+    '--auto',
+    `a${'b'.repeat(128)}`,
+  ])('rejects Kimi model ids that cannot cross the runtime boundary: %j', (model) => {
+    const profile = {
+      ...baselineProfile(),
+      provider: 'kimi',
+      orchestrator: { model },
+      agents: [
+        { id: 'sr-architect', model: 'k3' },
+        { id: 'sr-developer', model: 'k3' },
+        { id: 'sr-reviewer', model: 'k3' },
+      ],
+    }
+    expect(validator()(profile)).toBe(false)
+  })
+
+  it('ships a valid Kimi default with explicit k3 identifiers', () => {
+    const profile = JSON.parse(
+      readFileSync(
+        path.join(process.cwd(), 'templates', 'profiles', 'kimi-default.json'),
+        'utf8',
+      ),
+    ) as { provider: string; orchestrator: { model: string }; agents: Array<{ model?: string }> }
+    const validate = validator()
+    expect(validate(profile), JSON.stringify(validate.errors)).toBe(true)
+    expect(profile.provider).toBe('kimi')
+    expect(profile.orchestrator.model).toBe('k3')
+    expect(profile.agents.every((agent) => agent.model === 'k3')).toBe(true)
+  })
+})

--- a/src/installer/runtime/kimi-skill-runner.test.ts
+++ b/src/installer/runtime/kimi-skill-runner.test.ts
@@ -1365,9 +1365,7 @@ describe('managed Kimi skill runner — secure invocation', () => {
       )
       expect(readFileSync(path.join(repoDir, 'openspec', 'change.md'), 'utf8'))
         .toBe('untracked spec\n')
-      expect(realpathSync(path.join(repoDir, '.kimi-code'))).toBe(
-        realpathSync(providerRoot),
-      )
+      expectSamePath(path.join(repoDir, '.kimi-code'), providerRoot)
     }
     writeFileLf(path.join(String(featureA.repoDir), 'role-change.txt'), 'kept\n')
 
@@ -1843,9 +1841,11 @@ describe('managed Kimi skill runner — secure invocation', () => {
     const providerRoot = writeSkill('overlay-role', 'body')
     const workspace = path.join(tmpDir, 'windows-overlay')
     mkdirSync(workspace, { recursive: true })
-    const createLink = vi.fn(() => {
-      throw new Error('junction privilege unavailable')
-    })
+    const createLink = vi.fn(
+      (_source: string, _destination: string, _type: string) => {
+        throw new Error('junction privilege unavailable')
+      },
+    )
     const copyTree = vi.fn((source: string, destination: string) => {
       cpSync(source, destination, {
         recursive: true,
@@ -1857,11 +1857,12 @@ describe('managed Kimi skill runner — secure invocation', () => {
       symlink: createLink,
       copyTree,
     })
-    expect(createLink).toHaveBeenCalledWith(
-      realpathSync(providerRoot),
-      path.join(workspace, '.kimi-code'),
-      'junction',
-    )
+    expect(createLink).toHaveBeenCalledTimes(1)
+    const [linkSource, linkDestination, linkType] =
+      createLink.mock.calls[0]!
+    expectSamePath(String(linkSource), providerRoot)
+    expect(linkDestination).toBe(path.join(workspace, '.kimi-code'))
+    expect(linkType).toBe('junction')
     expect(copyTree).toHaveBeenCalled()
     expect(
       readFileSync(

--- a/src/installer/runtime/kimi-skill-runner.test.ts
+++ b/src/installer/runtime/kimi-skill-runner.test.ts
@@ -20,6 +20,30 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { writeFileLf } from '../util/fs.js'
 
+function canonicalPathIdentity(value: string): string {
+  const canonical =
+    typeof realpathSync.native === 'function'
+      ? realpathSync.native(value)
+      : realpathSync(value)
+  const resolved = path.resolve(canonical)
+  return process.platform === 'win32'
+    ? resolved.toLowerCase()
+    : resolved
+}
+
+function expectSamePath(actual: string, expected: string): void {
+  expect(canonicalPathIdentity(actual)).toBe(
+    canonicalPathIdentity(expected),
+  )
+}
+
+function toKimiPath(value: string): string {
+  const normalized = value.replaceAll('\\', '/')
+  return /^[a-z]:\//.test(normalized)
+    ? `${normalized[0]!.toUpperCase()}${normalized.slice(1)}`
+    : normalized
+}
+
 interface ParsedRunnerArgs {
   skill?: string
   model?: string
@@ -835,9 +859,10 @@ describe('managed Kimi skill runner — secure invocation', () => {
     const canonicalDir = realpathSync(
       path.join(frameworkRoot, 'skills', 'linked-skill'),
     )
-    expect(prepared.skillDir).toBe(canonicalDir)
-    expect(prepared.prompt).toContain(`Directory=${canonicalDir}`)
-    expect(prepared.prompt).not.toContain(linkedDir)
+    const kimiCanonicalDir = toKimiPath(canonicalDir)
+    expect(prepared.skillDir).toBe(kimiCanonicalDir)
+    expect(prepared.prompt).toContain(`Directory=${kimiCanonicalDir}`)
+    expect(prepared.prompt).not.toContain(toKimiPath(linkedDir))
   })
 
   it('spawns directly with shell disabled so hostile args remain prompt text', async () => {
@@ -993,97 +1018,102 @@ describe('managed Kimi skill runner — secure invocation', () => {
     expect(common.spawnChild).not.toHaveBeenCalled()
   })
 
-  it('loads a one-shot fixed role request without evaluating hostile context', async () => {
-    const cwd = path.join(tmpDir, 'role-request-e2e')
-    const providerRoot = path.join(cwd, '.kimi-code')
-    writeFileLf(
-      path.join(
-        providerRoot,
-        'skills',
-        'custom-auditor',
-        'SKILL.md',
-      ),
-      [
-        '---',
-        'name: custom-auditor',
-        'description: Request-file security test',
-        'type: prompt',
-        '---',
-        'Audit exactly: $ARGUMENTS',
-      ].join('\n'),
-    )
-    const marker = path.join(cwd, 'shell-injection-marker')
-    const hostileArgs =
-      `"quoted"; $(touch ${marker}) \`touch ${marker}\` <unsafe>`
-    const requestPath = path.join(
-      cwd,
-      '.specrails',
-      'kimi-role-request.json',
-    )
-    writeFileLf(
-      requestPath,
-      JSON.stringify({
-        skill: 'custom-auditor',
-        model: 'k3',
-        args: hostileArgs,
-      }),
-    )
-
-    const fakeBin = path.join(cwd, 'bin')
-    const capturePath = path.join(cwd, 'captured-argv.json')
-    const fakeKimi = path.join(fakeBin, 'kimi')
-    writeFileLf(
-      fakeKimi,
-      [
-        '#!/usr/bin/env node',
-        "const { writeFileSync } = require('node:fs')",
-        'const args = process.argv.slice(2)',
-        'writeFileSync(process.env.SPECRAILS_CAPTURE, JSON.stringify(args))',
-      ].join('\n'),
-    )
-    chmodSync(fakeKimi, 0o755)
-
-    await expect(
-      runner.runSkillCli(
+  it.skipIf(process.platform === 'win32')(
+    'loads a one-shot fixed role request without evaluating hostile context',
+    async () => {
+      const cwd = path.join(tmpDir, 'role-request-e2e')
+      const providerRoot = path.join(cwd, '.kimi-code')
+      writeFileLf(
+        path.join(
+          providerRoot,
+          'skills',
+          'custom-auditor',
+          'SKILL.md',
+        ),
         [
-          '--request-file',
-          '.specrails/kimi-role-request.json',
-          '--add-dir',
-          cwd,
-        ],
-        {
-          scriptPath: path.join(
-            providerRoot,
-            'specrails',
-            'run-skill.mjs',
-          ),
-          cwd,
-          platform: 'linux',
-          signalSource: new EventEmitter(),
-          env: {
-            PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ''}`,
-            SPECRAILS_CAPTURE: capturePath,
-          },
-          spawnChild: (command, args, options) => {
-            return spawn(
-              command,
-              args,
-              options as Parameters<typeof spawn>[2],
-            )
-          },
-        },
-      ),
-    ).resolves.toBe(0)
+          '---',
+          'name: custom-auditor',
+          'description: Request-file security test',
+          'type: prompt',
+          '---',
+          'Audit exactly: $ARGUMENTS',
+        ].join('\n'),
+      )
+      const marker = path.join(cwd, 'shell-injection-marker')
+      const hostileArgs =
+        `"quoted"; $(touch ${marker}) \`touch ${marker}\` <unsafe>`
+      const requestPath = path.join(
+        cwd,
+        '.specrails',
+        'kimi-role-request.json',
+      )
+      writeFileLf(
+        requestPath,
+        JSON.stringify({
+          skill: 'custom-auditor',
+          model: 'k3',
+          args: hostileArgs,
+        }),
+      )
 
-    expect(existsSync(marker)).toBe(false)
-    expect(existsSync(requestPath)).toBe(false)
-    const captured = JSON.parse(readFileSync(capturePath, 'utf8')) as string[]
-    const promptIndex = captured.indexOf('-p') + 1
-    expect(promptIndex).toBeGreaterThan(0)
-    expect(captured[promptIndex]).toContain(
-      hostileArgs.replaceAll('<', '&lt;').replaceAll('>', '&gt;'),
-    )
-  })
+      const fakeBin = path.join(cwd, 'bin')
+      const capturePath = path.join(cwd, 'captured-argv.json')
+      const fakeKimi = path.join(fakeBin, 'kimi')
+      writeFileLf(
+        fakeKimi,
+        [
+          '#!/usr/bin/env node',
+          "const { writeFileSync } = require('node:fs')",
+          'const args = process.argv.slice(2)',
+          'writeFileSync(process.env.SPECRAILS_CAPTURE, JSON.stringify(args))',
+        ].join('\n'),
+      )
+      chmodSync(fakeKimi, 0o755)
+
+      await expect(
+        runner.runSkillCli(
+          [
+            '--request-file',
+            '.specrails/kimi-role-request.json',
+            '--add-dir',
+            cwd,
+          ],
+          {
+            scriptPath: path.join(
+              providerRoot,
+              'specrails',
+              'run-skill.mjs',
+            ),
+            cwd,
+            platform: 'linux',
+            signalSource: new EventEmitter(),
+            env: {
+              PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ''}`,
+              SPECRAILS_CAPTURE: capturePath,
+            },
+            spawnChild: (command, args, options) => {
+              return spawn(
+                command,
+                args,
+                options as Parameters<typeof spawn>[2],
+              )
+            },
+          },
+        ),
+      ).resolves.toBe(0)
+
+      expect(existsSync(marker)).toBe(false)
+      expect(existsSync(requestPath)).toBe(false)
+      const captured = JSON.parse(
+        readFileSync(capturePath, 'utf8'),
+      ) as string[]
+      const promptIndex = captured.indexOf('-p') + 1
+      expect(promptIndex).toBeGreaterThan(0)
+      expect(captured[promptIndex]).toContain(
+        hostileArgs.replaceAll('<', '&lt;').replaceAll('>', '&gt;'),
+      )
+    },
+  )
 
   it('bounds and cleans fixed role request files and rejects alternate paths', () => {
     const cwd = path.join(tmpDir, 'role-request-validation')
@@ -1209,17 +1239,19 @@ describe('managed Kimi skill runner — secure invocation', () => {
     expect(new Set(executionCwds).size).toBe(2)
     for (const call of calls) {
       expect(call.options).toMatchObject({ shell: false })
-      expect(
-        (call.options.env as Record<string, string>).SPECRAILS_REPO_DIR,
-      ).toBe(realpathSync(repo))
+      expectSamePath(
+        (call.options.env as Record<string, string>).SPECRAILS_REPO_DIR!,
+        repo,
+      )
     }
     expect(calls[0]?.args.join('\n')).toContain(
       hostileArgs.replaceAll('<', '&lt;').replaceAll('>', '&gt;'),
     )
-    expect(
+    expectSamePath(
       (calls[1]?.options.env as Record<string, string>)
-        .SPECRAILS_PROFILE_PATH,
-    ).toBe(path.join(realpathSync(repo), '.specrails', 'profiles', 'rail-fast.json'))
+        .SPECRAILS_PROFILE_PATH!,
+      path.join(repo, '.specrails', 'profiles', 'rail-fast.json'),
+    )
     expect(
       existsSync(path.join(repo, '.specrails', 'kimi-role-wave.json')),
     ).toBe(false)

--- a/src/installer/runtime/kimi-skill-runner.test.ts
+++ b/src/installer/runtime/kimi-skill-runner.test.ts
@@ -1,0 +1,2254 @@
+import { EventEmitter } from 'node:events'
+import { spawn, spawnSync } from 'node:child_process'
+import { PassThrough, Writable } from 'node:stream'
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+} from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { writeFileLf } from '../util/fs.js'
+
+interface ParsedRunnerArgs {
+  skill?: string
+  model?: string
+  rawArgs: string
+  sessionId?: string
+  additionalDirs: string[]
+  attachmentPaths: string[]
+  extraPrompt?: string
+  requestFile?: string
+  roleWaveFile?: string
+  roleWaveStatus?: string
+  roleWaveCleanup?: string
+  roleMergeFile?: string
+  plainPromptStdin: boolean
+}
+
+interface RunnerModule {
+  WINDOWS_NPM_STDIN_BOOTSTRAP: string
+  WINDOWS_PROMPT_STDIN_TOKEN: string
+  expandSkillParameters: (
+    body: string,
+    rawArgs: string,
+    context: {
+      skillDir: string
+      sessionId?: string
+      argumentNames?: string[]
+    },
+  ) => string
+  normalizeKimiCliModel: (model: string) => string
+  forwardTerminationSignals: (
+    child: { kill?: (signal: string) => void },
+    source: EventEmitter,
+  ) => () => void
+  loadRoleRequest: (
+    parsed: ParsedRunnerArgs,
+    cwd: string,
+  ) => ParsedRunnerArgs
+  loadRoleWave: (
+    parsed: ParsedRunnerArgs,
+    cwd: string,
+  ) => {
+    run: string
+    roles: Array<{
+      key: string
+      skill: string
+      model: string
+      profile: string
+      rawArgs: string
+      workspace: string
+    }>
+    additionalDirs: string[]
+  } | undefined
+  loadRoleMerge: (
+    parsed: ParsedRunnerArgs,
+    cwd: string,
+  ) => {
+    run: string
+    actions: Array<{
+      worktree: string
+      path: string
+      operation: 'copy' | 'delete'
+    }>
+  } | undefined
+  inspectRoleWaveStatus: (
+    run: string,
+    options: Record<string, unknown>,
+  ) => {
+    run: string
+    baseRepo: string
+    baseCommit: string
+    manifestPath: string
+    worktrees: Record<
+      string,
+      {
+        repoDir: string
+        changes: Array<{ status: 'A' | 'M' | 'D'; path: string }>
+      }
+    >
+  }
+  applyRoleMerge: (
+    merge: {
+      run: string
+      actions: Array<{
+        worktree: string
+        path: string
+        operation: 'copy' | 'delete'
+      }>
+    },
+    options: Record<string, unknown>,
+  ) => { run: string; baseRepo: string; applied: number }
+  cleanupRoleWave: (
+    run: string,
+    options: Record<string, unknown>,
+  ) => {
+    run: string
+    baseRepo: string
+    removedWorktrees: number
+    manifestPath: string
+  }
+  materializeRoleWaveWorkspaces: (
+    wave: {
+      run: string
+      roles: Array<{
+        key: string
+        skill: string
+        model: string
+        profile: string
+        rawArgs: string
+        workspace: string
+      }>
+      additionalDirs: string[]
+    },
+    options: Record<string, unknown>,
+  ) => {
+    run: string
+    baseRepo: string
+    baseCommit: string
+    manifestPath: string
+    roles: Array<{
+      key: string
+      skill: string
+      model: string
+      profile: string
+      rawArgs: string
+      workspace: string
+      cwd: string
+      repoDir: string
+    }>
+  }
+  ensureProviderOverlay: (
+    providerRoot: string,
+    workspace: string,
+    platform: string,
+    dependencies?: Record<string, unknown>,
+  ) => void
+  parseNpmCmdShimEntry: (shimPath: string, contents: string) => string | null
+  parseRunnerArgs: (argv: string[]) => ParsedRunnerArgs
+  parseSkillDocument: (
+    text: string,
+    options?: { skillId?: string },
+  ) => {
+    name: string
+    description: string
+    argumentNames: string[]
+    body: string
+  }
+  prepareSkillLaunch: (options: {
+    providerRoot: string
+    skill: string
+    model: string
+    rawArgs: string
+    sessionId?: string
+    additionalDirs: string[]
+    attachmentPaths: string[]
+    extraPrompt?: string
+  }, dependencies?: {
+    resolvePath?: (file: string) => string
+  }) => {
+    prompt: string
+    kimiArgs: string[]
+    skillDir: string
+    skillName: string
+  }
+  renderUserSlashSkillPrompt: (input: {
+    skillName: string
+    skillArgs: string
+    skillContent: string
+    skillDir: string
+  }) => string
+  resolveKimiLaunch: (
+    args: string[],
+    options?: {
+      platform?: string
+      binary?: string
+      readFile?: (file: string) => string
+      fileExists?: (file: string) => boolean
+      env?: Record<string, string>
+    },
+  ) => { command: string; args: string[]; stdinText?: string }
+  resolveWindowsKimiBinary: (
+    env: Record<string, string>,
+    exists: (file: string) => boolean,
+  ) => string
+  runSkillCli: (
+    argv: string[],
+    dependencies: {
+      scriptPath: string
+      cwd: string
+      platform?: string
+      binary?: string
+      readFile?: (file: string) => string
+      fileExists?: (file: string) => boolean
+      env?: Record<string, string>
+      signalSource?: EventEmitter
+      spawnSync?: typeof spawnSync
+      tempRoot?: string
+      writeOutput?: (line: string) => void
+      readStdin?: () => string
+      spawnChild: (
+        command: string,
+        args: string[],
+        options: Record<string, unknown>,
+      ) => EventEmitter
+    },
+  ) => Promise<number>
+  stableKimiEnvironment: (
+    env: Record<string, string>,
+    model: string,
+  ) => Record<string, string>
+  tokenizeSkillArguments: (raw: string) => string[]
+  windowsCommandLineLength: (command: string, args: string[]) => number
+}
+
+let runner: RunnerModule
+let tmpDir: string
+
+beforeAll(async () => {
+  tmpDir = mkdtempSync(path.join(os.tmpdir(), 'specrails-kimi-runner-'))
+  const runnerUrl = pathToFileURL(
+    path.join(process.cwd(), 'templates', 'kimi', 'specrails', 'run-skill.mjs'),
+  ).href
+  runner = (await import(runnerUrl)) as RunnerModule
+})
+
+afterAll(() => {
+  rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+})
+
+function writeSkill(
+  id: string,
+  body: string,
+  frontmatter: string[] = [],
+): string {
+  const providerRoot = path.join(tmpDir, '.kimi-code')
+  const managedRunner = path.join(
+    providerRoot,
+    'specrails',
+    'run-skill.mjs',
+  )
+  if (!existsSync(managedRunner)) {
+    writeFileLf(
+      managedRunner,
+      readFileSync(
+        path.join(
+          process.cwd(),
+          'templates',
+          'kimi',
+          'specrails',
+          'run-skill.mjs',
+        ),
+        'utf8',
+      ),
+    )
+  }
+  writeFileLf(
+    path.join(providerRoot, 'skills', id, 'SKILL.md'),
+    [
+      '---',
+      `name: ${id}`,
+      `description: "${id} test skill"`,
+      'type: prompt',
+      ...frontmatter,
+      '---',
+      body,
+      '',
+    ].join('\n'),
+  )
+  return providerRoot
+}
+
+function createWaveRepo(name: string): string {
+  const repo = path.join(tmpDir, name)
+  mkdirSync(repo, { recursive: true })
+  for (const args of [
+    ['init', '-q'],
+    ['config', 'user.email', 'tests@specrails.dev'],
+    ['config', 'user.name', 'SpecRails Tests'],
+  ]) {
+    const result = spawnSync('git', args, { cwd: repo, encoding: 'utf8' })
+    if (result.status !== 0) throw new Error(result.stderr)
+  }
+  writeFileLf(path.join(repo, 'tracked.txt'), 'base\n')
+  const commit = spawnSync(
+    'git',
+    ['add', 'tracked.txt'],
+    { cwd: repo, encoding: 'utf8' },
+  )
+  if (commit.status !== 0) throw new Error(commit.stderr)
+  const committed = spawnSync(
+    'git',
+    ['commit', '-qm', 'base'],
+    { cwd: repo, encoding: 'utf8' },
+  )
+  if (committed.status !== 0) throw new Error(committed.stderr)
+  return repo
+}
+
+function writeRoleWave(
+  repo: string,
+  value: {
+    run: string
+    roles: Array<{
+      key: string
+      skill: string
+      model: string
+      profile?: string
+      args: string
+      workspace: string
+    }>
+  },
+): void {
+  writeFileLf(
+    path.join(repo, '.specrails', 'kimi-role-wave.json'),
+    `${JSON.stringify(
+      {
+        ...value,
+        roles: value.roles.map((role) => ({
+          ...role,
+          profile: role.profile ?? 'inherit',
+        })),
+      },
+      null,
+      2,
+    )}\n`,
+  )
+}
+
+function createRoleChild(
+  exitCode: number,
+  output: unknown,
+): EventEmitter & {
+  stdout: PassThrough
+  stderr: PassThrough
+  stdin: Writable
+  kill: ReturnType<typeof vi.fn>
+} {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: PassThrough
+    stderr: PassThrough
+    stdin: Writable
+    kill: ReturnType<typeof vi.fn>
+  }
+  child.stdout = new PassThrough()
+  child.stderr = new PassThrough()
+  child.stdin = new PassThrough()
+  child.kill = vi.fn((signal: string) => {
+    child.stdout.end()
+    child.stderr.end()
+    queueMicrotask(() => child.emit('exit', null, signal))
+    return true
+  })
+  queueMicrotask(() => {
+    child.stdout.end(`${JSON.stringify(output)}\n`)
+    child.stderr.end()
+    child.emit('exit', exitCode, null)
+  })
+  return child
+}
+
+describe('managed Kimi skill runner — upstream-compatible rendering', () => {
+  it('tokenizes quotes and Unicode whitespace with Kimi 0.27 semantics', () => {
+    expect(runner.tokenizeSkillArguments(`-m "fix login" '第二 行'\n🚀`)).toEqual([
+      '-m',
+      'fix login',
+      '第二 行',
+      '🚀',
+    ])
+    expect(runner.tokenizeSkillArguments(`"" 'unterminated`)).toEqual([
+      '',
+      'unterminated',
+    ])
+    expect(runner.tokenizeSkillArguments(String.raw`one\ two`)).toEqual([
+      'one\\',
+      'two',
+    ])
+  })
+
+  it('expands raw, indexed, positional, named, directory, and session placeholders', () => {
+    const rendered = runner.expandSkillParameters(
+      'raw=$ARGUMENTS zero=$0 one=$1 second=$ARGUMENTS[1] flag=$flag ' +
+        'message=$message dir=${KIMI_SKILL_DIR} session=${KIMI_SESSION_ID}',
+      '-m "fix <login>"',
+      {
+        skillDir: '/tmp/skills/commit',
+        sessionId: 'ses_1',
+        argumentNames: ['flag', 'message'],
+      },
+    )
+    expect(rendered).toBe(
+      'raw=-m "fix &lt;login&gt;" zero=-m one=fix &lt;login&gt; ' +
+        'second=fix &lt;login&gt; flag=-m message=fix &lt;login&gt; ' +
+        'dir=/tmp/skills/commit session=ses_1',
+    )
+  })
+
+  it('appends escaped raw arguments when only context placeholders were used', () => {
+    expect(
+      runner.expandSkillParameters(
+        'Read ${KIMI_SKILL_DIR}; session=${KIMI_SESSION_ID}.',
+        '<src/app.ts>',
+        { skillDir: '/skills/review' },
+      ),
+    ).toBe(
+      'Read /skills/review; session=.\n\nARGUMENTS: &lt;src/app.ts&gt;',
+    )
+  })
+
+  it('parses list, inline, and whitespace-separated frontmatter arguments', () => {
+    const list = runner.parseSkillDocument(
+      [
+        '---',
+        'name: review',
+        'description: Review',
+        'arguments:',
+        '  - target',
+        '  - mode',
+        '---',
+        '$target $mode',
+      ].join('\n'),
+    )
+    expect(list.argumentNames).toEqual(['target', 'mode'])
+
+    const inline = runner.parseSkillDocument(
+      [
+        '---',
+        'name: review',
+        'description: Review',
+        'arguments: [target, "review mode", 1]',
+        '---',
+        '$target',
+      ].join('\n'),
+    )
+    expect(inline.argumentNames).toEqual(['target', 'review mode'])
+
+    const text = runner.parseSkillDocument(
+      [
+        '---',
+        'name: review',
+        'description: Review',
+        'arguments: target mode',
+        '---',
+        '$target $mode',
+      ].join('\n'),
+    )
+    expect(text.argumentNames).toEqual(['target', 'mode'])
+  })
+
+  it('uses the vendored full YAML parser for folded scalars, anchors, and aliases', () => {
+    const parsed = runner.parseSkillDocument(
+      [
+        '---',
+        'name: "review-complex"',
+        'description: >-',
+        '  Review complex',
+        '  requests safely',
+        'type: prompt',
+        'argument_defaults: &argument_names',
+        '  - target',
+        '  - 7',
+        '  - mode',
+        'arguments: *argument_names',
+        'metadata:',
+        '  nested: { enabled: true }',
+        '---',
+        '$target $mode',
+      ].join('\n'),
+    )
+    expect(parsed.description).toBe('Review complex requests safely')
+    expect(parsed.argumentNames).toEqual(['target', 'mode'])
+
+    expect(() =>
+      runner.parseSkillDocument(
+        '---\n- not\n- a\n- mapping\n---\nbody',
+      ),
+    ).toThrow(/must be a mapping/)
+  })
+
+  it.each(['type:', "type: ''", 'type: 123'])(
+    'rejects a present but invalid upstream skill %s',
+    (typeLine) => {
+      expect(() =>
+        runner.parseSkillDocument(
+          [
+            '---',
+            'name: invalid-type',
+            'description: Invalid type',
+            typeLine,
+            '---',
+            'body',
+          ].join('\n'),
+        ),
+      ).toThrow(/invalid type/)
+    },
+  )
+
+  it('renders the exact user-slash wrapper and XML-escapes attributes', () => {
+    expect(
+      runner.renderUserSlashSkillPrompt({
+        skillName: 'custom-"review"',
+        skillArgs: '"a<b>" & notes',
+        skillContent: 'Target: a&lt;b&gt;',
+        skillDir: '/repo & work/skill',
+      }),
+    ).toBe(
+      'User activated the skill "custom-&quot;review&quot;". Follow the loaded skill instructions.\n\n' +
+        '<kimi-skill-loaded name="custom-&quot;review&quot;" trigger="user-slash" ' +
+        'source="project" dir="/repo &amp; work/skill" ' +
+        'args="&quot;a&lt;b&gt;&quot; &amp; notes">\n' +
+        'Target: a&lt;b&gt;\n' +
+        '</kimi-skill-loaded>',
+    )
+  })
+
+  it('rejects malformed directory skills and unsupported activation types', () => {
+    expect(() => runner.parseSkillDocument('no frontmatter')).toThrow(/frontmatter/)
+    expect(() =>
+      runner.parseSkillDocument(
+        '---\nname: hidden\ndescription: Hidden\ntype: internal\n---\nbody',
+      ),
+    ).toThrow(/unsupported type/)
+  })
+})
+
+describe('managed Kimi skill runner — secure invocation', () => {
+  it.each([
+    '../sr-reviewer',
+    '/absolute',
+    'sr-reviewer;touch-pwned',
+    'sr-reviewer$(whoami)',
+    'sr_review',
+    'SR-reviewer',
+  ])('rejects malicious or non-canonical skill id %s', (skill) => {
+    expect(() =>
+      runner.parseRunnerArgs(['--skill', skill, '--model', 'k3']),
+    ).toThrow(/Invalid skill id/)
+  })
+
+  it('retains exact Unicode and multiline args without shell parsing', () => {
+    const parsed = runner.parseRunnerArgs([
+      '--skill',
+      'sr-reviewer',
+      '--model',
+      'company/Kimi-Custom:v2',
+      '--args',
+      'línea uno\n第二行 $(touch should-not-run) 🚀',
+    ])
+    expect(parsed.rawArgs).toBe('línea uno\n第二行 $(touch should-not-run) 🚀')
+    expect(parsed.model).toBe('company/Kimi-Custom:v2')
+  })
+
+  it('trims raw arguments like activateSkill and rejects duplicate empty --args', () => {
+    expect(
+      runner.parseRunnerArgs([
+        '--skill',
+        'sr-reviewer',
+        '--model',
+        'k3',
+        '--args',
+        '  \nreview this\n  ',
+      ]).rawArgs,
+    ).toBe('review this')
+    expect(() =>
+      runner.parseRunnerArgs([
+        '--skill',
+        'sr-reviewer',
+        '--model',
+        'k3',
+        '--args',
+        '',
+        '--args',
+        'second',
+      ]),
+    ).toThrow(/may be supplied once/)
+  })
+
+  it('normalizes only the three managed aliases and preserves custom aliases', () => {
+    expect(runner.normalizeKimiCliModel('k3')).toBe('kimi-code/k3')
+    expect(runner.normalizeKimiCliModel('kimi-for-coding')).toBe(
+      'kimi-code/kimi-for-coding',
+    )
+    expect(runner.normalizeKimiCliModel('kimi-for-coding-highspeed')).toBe(
+      'kimi-code/kimi-for-coding-highspeed',
+    )
+    expect(runner.normalizeKimiCliModel('company/Kimi-Custom:v2')).toBe(
+      'company/Kimi-Custom:v2',
+    )
+    expect(runner.normalizeKimiCliModel('sonnet')).toBe('sonnet')
+  })
+
+  it.each([
+    '',
+    '--yolo',
+    'team model',
+    ' team/model',
+    'team/model ',
+    'team/model\n--yolo',
+    'team/model$HOME',
+    `a${'b'.repeat(128)}`,
+  ])('rejects unsafe model id %j at the helper boundary', (model) => {
+    expect(() => runner.normalizeKimiCliModel(model)).toThrow(/Invalid model id/)
+    expect(() =>
+      runner.parseRunnerArgs([
+        '--skill',
+        'sr-reviewer',
+        '--model',
+        model,
+      ]),
+    ).toThrow(/model/i)
+  })
+
+  it('loads the direct skill, expands it, and builds a shell-free Kimi argv', () => {
+    const providerRoot = writeSkill(
+      'sr-reviewer',
+      'Target: $target\nRaw: $ARGUMENTS\nDir: ${KIMI_SKILL_DIR}\nSession: ${KIMI_SESSION_ID}',
+      ['arguments: [target]'],
+    )
+    const attachment = path.join(tmpDir, 'captura 🚀.png')
+    writeFileLf(attachment, 'png')
+    const prepared = runner.prepareSkillLaunch({
+      providerRoot,
+      skill: 'sr-reviewer',
+      model: 'company/Kimi-Custom:v2',
+      rawArgs: '"src/área crítica.ts"\nsegunda línea',
+      sessionId: 'ses_known',
+      additionalDirs: [path.join(tmpDir, 'repo')],
+      attachmentPaths: [attachment],
+      extraPrompt: 'Keep every finding.',
+    })
+
+    expect(prepared.prompt).toContain(
+      'User activated the skill "sr-reviewer". Follow the loaded skill instructions.',
+    )
+    expect(prepared.prompt).toContain('Target: src/área crítica.ts')
+    expect(prepared.prompt).toContain('Session: ses_known')
+    expect(prepared.prompt).toContain('Keep every finding.')
+    expect(prepared.prompt).toContain(attachment)
+    expect(prepared.prompt).not.toContain('/skill:sr-reviewer')
+    expect(prepared.kimiArgs).toEqual([
+      '--session=ses_known',
+      '--add-dir',
+      path.join(tmpDir, 'repo'),
+      '--add-dir',
+      realpathSync(tmpDir),
+      '-m',
+      'company/Kimi-Custom:v2',
+      '-p',
+      prepared.prompt,
+      '--output-format',
+      'stream-json',
+    ])
+  })
+
+  it('rejects missing, directory, and symlink attachment inputs', () => {
+    const providerRoot = writeSkill('attachment-safety', 'Inspect attachments.')
+    const directory = path.join(tmpDir, 'attachment-directory')
+    const regular = path.join(tmpDir, 'attachment-regular.txt')
+    const linked = path.join(tmpDir, 'attachment-linked.txt')
+    mkdirSync(directory)
+    writeFileLf(regular, 'evidence')
+
+    for (const attachment of [
+      path.join(tmpDir, 'attachment-missing.txt'),
+      directory,
+    ]) {
+      expect(() =>
+        runner.prepareSkillLaunch({
+          providerRoot,
+          skill: 'attachment-safety',
+          model: 'k3',
+          rawArgs: '',
+          additionalDirs: [],
+          attachmentPaths: [attachment],
+        }),
+      ).toThrow(/readable regular non-symlink file/)
+    }
+
+    if (process.platform !== 'win32') {
+      symlinkSync(regular, linked)
+      expect(() =>
+        runner.prepareSkillLaunch({
+          providerRoot,
+          skill: 'attachment-safety',
+          model: 'k3',
+          rawArgs: '',
+          additionalDirs: [],
+          attachmentPaths: [linked],
+        }),
+      ).toThrow(/readable regular non-symlink file/)
+    }
+  })
+
+  it('fails closed for a mismatched frontmatter name', () => {
+    const providerRoot = writeSkill('expected-name', 'body')
+    writeFileLf(
+      path.join(providerRoot, 'skills', 'expected-name', 'SKILL.md'),
+      [
+        '---',
+        'name: different-name',
+        'description: Mismatched',
+        'type: prompt',
+        '---',
+        'body',
+      ].join('\n'),
+    )
+    expect(() =>
+      runner.prepareSkillLaunch({
+        providerRoot,
+        skill: 'expected-name',
+        model: 'k3',
+        rawArgs: '',
+        additionalDirs: [],
+        attachmentPaths: [],
+      }),
+    ).toThrow(/mismatched name/)
+  })
+
+  it('rejects an empty skill body before launching Kimi', () => {
+    const providerRoot = writeSkill('empty-skill', '')
+    expect(() =>
+      runner.prepareSkillLaunch({
+        providerRoot,
+        skill: 'empty-skill',
+        model: 'k3',
+        rawArgs: '',
+        additionalDirs: [],
+        attachmentPaths: [],
+      }),
+    ).toThrow(/empty body/)
+  })
+
+  it('requires a known session before expanding KIMI_SESSION_ID', () => {
+    const providerRoot = writeSkill(
+      'session-aware',
+      'Continue session ${KIMI_SESSION_ID}',
+    )
+    expect(() =>
+      runner.prepareSkillLaunch({
+        providerRoot,
+        skill: 'session-aware',
+        model: 'k3',
+        rawArgs: '',
+        additionalDirs: [],
+        attachmentPaths: [],
+      }),
+    ).toThrow(/only with --session/)
+
+    expect(
+      runner.prepareSkillLaunch({
+        providerRoot,
+        skill: 'session-aware',
+        model: 'k3',
+        rawArgs: '',
+        sessionId: 'ses_known',
+        additionalDirs: [],
+        attachmentPaths: [],
+      }).prompt,
+    ).toContain('Continue session ses_known')
+  })
+
+  it('renders Windows skill directories as uppercase-drive POSIX paths', () => {
+    const providerRoot = writeSkill(
+      'windows-path',
+      'Directory=${KIMI_SKILL_DIR}',
+    )
+    const prepared = runner.prepareSkillLaunch(
+      {
+        providerRoot,
+        skill: 'windows-path',
+        model: 'k3',
+        rawArgs: '',
+        additionalDirs: [],
+        attachmentPaths: [],
+      },
+      {
+        resolvePath: () =>
+          'c:\\Users\\Jane Doe\\repo\\.kimi-code\\skills\\windows-path',
+      },
+    )
+    expect(prepared.skillDir).toBe(
+      'C:/Users/Jane Doe/repo/.kimi-code/skills/windows-path',
+    )
+    expect(prepared.prompt).toContain(
+      'Directory=C:/Users/Jane Doe/repo/.kimi-code/skills/windows-path',
+    )
+  })
+
+  it('uses Kimi-compatible realpaths when a relocated skill is a symlink', () => {
+    const frameworkRoot = writeSkill(
+      'linked-skill',
+      'Directory=${KIMI_SKILL_DIR}',
+    )
+    const workspaceRoot = path.join(tmpDir, 'workspace', '.kimi-code')
+    const linkedDir = path.join(
+      workspaceRoot,
+      'skills',
+      'linked-skill',
+    )
+    mkdirSync(path.dirname(linkedDir), { recursive: true })
+    symlinkSync(
+      path.join(frameworkRoot, 'skills', 'linked-skill'),
+      linkedDir,
+      'dir',
+    )
+
+    const prepared = runner.prepareSkillLaunch({
+      providerRoot: workspaceRoot,
+      skill: 'linked-skill',
+      model: 'k3',
+      rawArgs: '',
+      additionalDirs: [],
+      attachmentPaths: [],
+    })
+    const canonicalDir = realpathSync(
+      path.join(frameworkRoot, 'skills', 'linked-skill'),
+    )
+    expect(prepared.skillDir).toBe(canonicalDir)
+    expect(prepared.prompt).toContain(`Directory=${canonicalDir}`)
+    expect(prepared.prompt).not.toContain(linkedDir)
+  })
+
+  it('spawns directly with shell disabled so hostile args remain prompt text', async () => {
+    const providerRoot = writeSkill(
+      'custom-auditor',
+      'Audit this request: $ARGUMENTS',
+    )
+    const scriptPath = path.join(providerRoot, 'specrails', 'run-skill.mjs')
+    const spawnChild = vi.fn(
+      (
+        _command: string,
+        _args: string[],
+        _options: Record<string, unknown>,
+      ) => {
+        const child = new EventEmitter()
+        queueMicrotask(() => child.emit('exit', 0, null))
+        return child
+      },
+    )
+    const rawArgs = 'uno\n二 $(touch never-created)'
+    await expect(
+      runner.runSkillCli(
+        [
+          '--skill',
+          'custom-auditor',
+          '--model',
+          'k3',
+          '--args',
+          rawArgs,
+        ],
+        {
+          scriptPath,
+          cwd: tmpDir,
+          platform: 'linux',
+          env: {
+            PATH: '/safe/bin',
+            KIMI_CODE_EXPERIMENTAL_FLAG: 'true',
+            kimi_code_experimental_flag: 'v2',
+            kimi_disable_cron: '0',
+            KIMI_CODE_NO_AUTO_UPDATE: '0',
+            KIMI_MODEL_THINKING_EFFORT: 'high',
+            SPECRAILS_SAFE: 'yes',
+          },
+          spawnChild,
+        },
+      ),
+    ).resolves.toBe(0)
+
+    const [command, args, options] = spawnChild.mock.calls[0]
+    expect(command).toBe('kimi')
+    expect(options).toMatchObject({ shell: false, cwd: tmpDir })
+    expect(options.env).toEqual({
+      PATH: '/safe/bin',
+      KIMI_DISABLE_CRON: '1',
+      KIMI_CODE_NO_AUTO_UPDATE: '1',
+      KIMI_MODEL_THINKING_EFFORT: 'high',
+      SPECRAILS_SAFE: 'yes',
+    })
+    expect(args).toContain('kimi-code/k3')
+    expect(args.join('\n')).toContain('$(touch never-created)')
+  })
+
+  it('receives long Unicode plain prompts over runner stdin without changing the turn', async () => {
+    const providerRoot = writeSkill('plain-transport-anchor', 'unused')
+    const scriptPath = path.join(providerRoot, 'specrails', 'run-skill.mjs')
+    const prompt = `Inicio 🚀\n${'第二行 con datos\n'.repeat(5_000)}Fin`
+    let capturedArgs: string[] = []
+
+    await expect(
+      runner.runSkillCli(
+        [
+          '--plain-prompt-stdin',
+          '--model',
+          'k3',
+          '--session=ses_plain',
+          '--add-dir',
+          tmpDir,
+        ],
+        {
+          scriptPath,
+          cwd: tmpDir,
+          tempRoot: tmpDir,
+          platform: 'linux',
+          signalSource: new EventEmitter(),
+          readStdin: () => prompt,
+          spawnChild: (_command, args) => {
+            capturedArgs = args
+            const child = new EventEmitter()
+            queueMicrotask(() => child.emit('exit', 0, null))
+            return child
+          },
+        },
+      ),
+    ).resolves.toBe(0)
+
+    expect(capturedArgs).toContain(prompt)
+    expect(capturedArgs).toContain('--session=ses_plain')
+    expect(capturedArgs).toContain('kimi-code/k3')
+  })
+
+  it('propagates native spawn failure from stdin prompt mode', async () => {
+    const providerRoot = writeSkill('plain-spawn-failure', 'unused')
+    await expect(
+      runner.runSkillCli(
+        ['--plain-prompt-stdin', '--model', 'k3'],
+        {
+          scriptPath: path.join(
+            providerRoot,
+            'specrails',
+            'run-skill.mjs',
+          ),
+          cwd: tmpDir,
+          tempRoot: tmpDir,
+          platform: 'linux',
+          readStdin: () => 'sensitive prompt',
+          spawnChild: () => {
+            throw new Error('simulated spawn failure')
+          },
+        },
+      ),
+    ).rejects.toThrow(/simulated spawn failure/)
+  })
+
+  it('rejects invalid or oversized stdin prompt mode before spawning', async () => {
+    const providerRoot = writeSkill('plain-validation', 'unused')
+    const common = {
+      scriptPath: path.join(providerRoot, 'specrails', 'run-skill.mjs'),
+      cwd: tmpDir,
+      platform: 'linux',
+      spawnChild: vi.fn(() => new EventEmitter()),
+    }
+    expect(() =>
+      runner.parseRunnerArgs([
+        '--plain-prompt-stdin',
+        '--model',
+        'k3',
+        '--skill',
+        'plain-validation',
+      ]),
+    ).toThrow(/cannot be combined/)
+    await expect(
+      runner.runSkillCli(
+        ['--plain-prompt-stdin', '--model', 'k3'],
+        { ...common, readStdin: () => ' \n ' },
+      ),
+    ).rejects.toThrow(/must not be empty/)
+    await expect(
+      runner.runSkillCli(
+        ['--plain-prompt-stdin', '--model', 'k3'],
+        { ...common, readStdin: () => '🚀'.repeat(300_000) },
+      ),
+    ).rejects.toThrow(/exceeds 1048576 UTF-8 bytes/)
+    expect(common.spawnChild).not.toHaveBeenCalled()
+  })
+
+  it('loads a one-shot fixed role request without evaluating hostile context', async () => {
+    const cwd = path.join(tmpDir, 'role-request-e2e')
+    const providerRoot = path.join(cwd, '.kimi-code')
+    writeFileLf(
+      path.join(
+        providerRoot,
+        'skills',
+        'custom-auditor',
+        'SKILL.md',
+      ),
+      [
+        '---',
+        'name: custom-auditor',
+        'description: Request-file security test',
+        'type: prompt',
+        '---',
+        'Audit exactly: $ARGUMENTS',
+      ].join('\n'),
+    )
+    const marker = path.join(cwd, 'shell-injection-marker')
+    const hostileArgs =
+      `"quoted"; $(touch ${marker}) \`touch ${marker}\` <unsafe>`
+    const requestPath = path.join(
+      cwd,
+      '.specrails',
+      'kimi-role-request.json',
+    )
+    writeFileLf(
+      requestPath,
+      JSON.stringify({
+        skill: 'custom-auditor',
+        model: 'k3',
+        args: hostileArgs,
+      }),
+    )
+
+    const fakeBin = path.join(cwd, 'bin')
+    const capturePath = path.join(cwd, 'captured-argv.json')
+    const fakeKimi = path.join(fakeBin, 'kimi')
+    writeFileLf(
+      fakeKimi,
+      [
+        '#!/usr/bin/env node',
+        "const { writeFileSync } = require('node:fs')",
+        'const args = process.argv.slice(2)',
+        'writeFileSync(process.env.SPECRAILS_CAPTURE, JSON.stringify(args))',
+      ].join('\n'),
+    )
+    chmodSync(fakeKimi, 0o755)
+
+    await expect(
+      runner.runSkillCli(
+        [
+          '--request-file',
+          '.specrails/kimi-role-request.json',
+          '--add-dir',
+          cwd,
+        ],
+        {
+          scriptPath: path.join(
+            providerRoot,
+            'specrails',
+            'run-skill.mjs',
+          ),
+          cwd,
+          platform: 'linux',
+          signalSource: new EventEmitter(),
+          env: {
+            PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ''}`,
+            SPECRAILS_CAPTURE: capturePath,
+          },
+          spawnChild: (command, args, options) => {
+            return spawn(
+              command,
+              args,
+              options as Parameters<typeof spawn>[2],
+            )
+          },
+        },
+      ),
+    ).resolves.toBe(0)
+
+    expect(existsSync(marker)).toBe(false)
+    expect(existsSync(requestPath)).toBe(false)
+    const captured = JSON.parse(readFileSync(capturePath, 'utf8')) as string[]
+    const promptIndex = captured.indexOf('-p') + 1
+    expect(promptIndex).toBeGreaterThan(0)
+    expect(captured[promptIndex]).toContain(
+      hostileArgs.replaceAll('<', '&lt;').replaceAll('>', '&gt;'),
+    )
+  })
+
+  it('bounds and cleans fixed role request files and rejects alternate paths', () => {
+    const cwd = path.join(tmpDir, 'role-request-validation')
+    const parsed = runner.parseRunnerArgs([
+      '--request-file',
+      '.specrails/kimi-role-request.json',
+    ])
+    expect(() =>
+      runner.parseRunnerArgs([
+        '--request-file',
+        '.specrails/kimi-role-request.json',
+        '--skill',
+        'sr-reviewer',
+      ]),
+    ).toThrow(/cannot be combined/)
+    expect(() =>
+      runner.loadRoleRequest(
+        {
+          ...parsed,
+          requestFile: 'elsewhere/request.json',
+        },
+        cwd,
+      ),
+    ).toThrow(/must use/)
+
+    const requestPath = path.join(
+      cwd,
+      '.specrails',
+      'kimi-role-request.json',
+    )
+    writeFileLf(requestPath, 'x'.repeat(1_048_577))
+    expect(() => runner.loadRoleRequest(parsed, cwd)).toThrow(/exceeds/)
+    expect(existsSync(requestPath)).toBe(false)
+
+    writeFileLf(requestPath, '{invalid json')
+    expect(() => runner.loadRoleRequest(parsed, cwd)).toThrow(/Invalid role request JSON/)
+    expect(existsSync(requestPath)).toBe(false)
+  })
+
+  it('rejects fixed request state through a symlinked .specrails parent', () => {
+    const cwd = path.join(tmpDir, 'role-request-symlink')
+    const outside = path.join(tmpDir, 'role-request-outside')
+    mkdirSync(cwd, { recursive: true })
+    mkdirSync(outside, { recursive: true })
+    symlinkSync(outside, path.join(cwd, '.specrails'), 'dir')
+    writeFileLf(
+      path.join(outside, 'kimi-role-wave.json'),
+      '{"run":"safe-run","roles":[]}\n',
+    )
+    const parsed = runner.parseRunnerArgs([
+      '--role-wave-file',
+      '.specrails/kimi-role-wave.json',
+    ])
+    expect(() => runner.loadRoleWave(parsed, cwd)).toThrow(
+      /parent must be a real directory/,
+    )
+  })
+
+  it('executes one attributed wave for parallel current-repo roles', async () => {
+    const repo = createWaveRepo('role-wave-current')
+    const providerRoot = writeSkill('wave-a', 'A: $ARGUMENTS')
+    writeSkill('wave-b', 'B: $ARGUMENTS')
+    writeFileLf(
+      path.join(repo, '.specrails', 'profiles', 'rail-fast.json'),
+      '{}\n',
+    )
+    const hostileArgs = '"quoted" $(touch never) `whoami` <unsafe>'
+    writeRoleWave(repo, {
+      run: 'run-current-01',
+      roles: [
+        {
+          key: 'architect-a',
+          skill: 'wave-a',
+          model: 'k3',
+          args: hostileArgs,
+          workspace: 'current',
+        },
+        {
+          key: 'architect-b',
+          skill: 'wave-b',
+          model: 'company/kimi-v2',
+          profile: 'rail-fast',
+          args: 'second role',
+          workspace: 'current',
+        },
+      ],
+    })
+    const calls: Array<{
+      args: string[]
+      options: Record<string, unknown>
+    }> = []
+    const output: string[] = []
+    const currentTempRoot = path.join(tmpDir, 'role-wave-current-temp')
+
+    const code = await runner.runSkillCli(
+      [
+        '--role-wave-file',
+        '.specrails/kimi-role-wave.json',
+        '--add-dir',
+        repo,
+      ],
+      {
+        scriptPath: path.join(providerRoot, 'specrails', 'run-skill.mjs'),
+        cwd: repo,
+        platform: 'linux',
+        env: { PATH: '/safe/bin' },
+        signalSource: new EventEmitter(),
+        tempRoot: currentTempRoot,
+        writeOutput: (line) => output.push(line),
+        spawnChild: (_command, args, options) => {
+          calls.push({ args, options })
+          return createRoleChild(0, {
+            role: calls.length,
+            content: 'ok',
+          })
+        },
+      },
+    )
+
+    expect(code).toBe(0)
+    expect(calls).toHaveLength(2)
+    const executionCwds = calls.map((call) => String(call.options.cwd))
+    expect(new Set(executionCwds).size).toBe(2)
+    for (const call of calls) {
+      expect(call.options).toMatchObject({ shell: false })
+      expect(
+        (call.options.env as Record<string, string>).SPECRAILS_REPO_DIR,
+      ).toBe(realpathSync(repo))
+    }
+    expect(calls[0]?.args.join('\n')).toContain(
+      hostileArgs.replaceAll('<', '&lt;').replaceAll('>', '&gt;'),
+    )
+    expect(
+      (calls[1]?.options.env as Record<string, string>)
+        .SPECRAILS_PROFILE_PATH,
+    ).toBe(path.join(realpathSync(repo), '.specrails', 'profiles', 'rail-fast.json'))
+    expect(
+      existsSync(path.join(repo, '.specrails', 'kimi-role-wave.json')),
+    ).toBe(false)
+    const frames = output
+      .join('')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>)
+    expect(
+      frames.filter((frame) => frame.type === 'specrails.role.workspace'),
+    ).toHaveLength(2)
+    expect(
+      frames.filter((frame) => frame.type === 'specrails.role.event'),
+    ).toHaveLength(2)
+    expect(
+      frames.filter((frame) => frame.type === 'specrails.role.completed'),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ roleKey: 'architect-a', status: 'succeeded' }),
+        expect.objectContaining({ roleKey: 'architect-b', status: 'succeeded' }),
+      ]),
+    )
+    const cleaned = runner.cleanupRoleWave('run-current-01', {
+      cwd: repo,
+      tempRoot: currentTempRoot,
+    })
+    expect(cleaned.removedWorktrees).toBe(0)
+    expect(existsSync(cleaned.manifestPath)).toBe(false)
+    for (const executionCwd of executionCwds) {
+      expect(existsSync(executionCwd)).toBe(false)
+    }
+  })
+
+  it('creates, snapshots, records, and reuses isolated role worktrees', async () => {
+    const repo = createWaveRepo('role-wave-worktrees')
+    const providerRoot = writeSkill('developer-wave', 'Develop $ARGUMENTS')
+    writeSkill('test-wave', 'Test $ARGUMENTS')
+    writeFileLf(path.join(repo, 'tracked.txt'), 'dirty tracked\n')
+    writeFileLf(path.join(repo, 'openspec', 'change.md'), 'untracked spec\n')
+    const tempRoot = path.join(tmpDir, 'role-wave-worktree-temp')
+    const runWave = async (
+      roles: Array<{
+        key: string
+        skill: string
+        model: string
+        args: string
+        workspace: string
+      }>,
+    ) => {
+      writeRoleWave(repo, { run: 'run-isolated-01', roles })
+      const calls: Array<Record<string, unknown>> = []
+      const output: string[] = []
+      const code = await runner.runSkillCli(
+        ['--role-wave-file', '.specrails/kimi-role-wave.json'],
+        {
+          scriptPath: path.join(providerRoot, 'specrails', 'run-skill.mjs'),
+          cwd: repo,
+          platform: 'linux',
+          env: { PATH: '/safe/bin' },
+          signalSource: new EventEmitter(),
+          tempRoot,
+          writeOutput: (line) => output.push(line),
+          spawnChild: (_command, _args, options) => {
+            calls.push(options)
+            return createRoleChild(0, { content: 'done' })
+          },
+        },
+      )
+      return {
+        code,
+        calls,
+        frames: output
+          .join('')
+          .trim()
+          .split('\n')
+          .map((line) => JSON.parse(line) as Record<string, unknown>),
+      }
+    }
+
+    const first = await runWave([
+      {
+        key: 'developer-a',
+        skill: 'developer-wave',
+        model: 'k3',
+        args: 'feature a',
+        workspace: 'worktree:feature-a',
+      },
+      {
+        key: 'developer-b',
+        skill: 'developer-wave',
+        model: 'k3',
+        args: 'feature b',
+        workspace: 'worktree:feature-b',
+      },
+    ])
+    expect(first.code).toBe(0)
+    const workspaceFrames = first.frames.filter(
+      (frame) => frame.type === 'specrails.role.workspace',
+    )
+    const featureA = workspaceFrames.find(
+      (frame) => frame.roleKey === 'developer-a',
+    )!
+    const featureB = workspaceFrames.find(
+      (frame) => frame.roleKey === 'developer-b',
+    )!
+    expect(featureA.repoDir).not.toBe(featureB.repoDir)
+    for (const frame of [featureA, featureB]) {
+      const repoDir = String(frame.repoDir)
+      expect(readFileSync(path.join(repoDir, 'tracked.txt'), 'utf8')).toBe(
+        'dirty tracked\n',
+      )
+      expect(readFileSync(path.join(repoDir, 'openspec', 'change.md'), 'utf8'))
+        .toBe('untracked spec\n')
+      expect(realpathSync(path.join(repoDir, '.kimi-code'))).toBe(
+        realpathSync(providerRoot),
+      )
+    }
+    writeFileLf(path.join(String(featureA.repoDir), 'role-change.txt'), 'kept\n')
+
+    const second = await runWave([
+      {
+        key: 'test-a',
+        skill: 'test-wave',
+        model: 'k3',
+        args: 'feature a',
+        workspace: 'worktree:feature-a',
+      },
+    ])
+    expect(second.code).toBe(0)
+    const reused = second.frames.find(
+      (frame) => frame.type === 'specrails.role.workspace',
+    )!
+    expect(reused.repoDir).toBe(featureA.repoDir)
+    expect(
+      readFileSync(path.join(String(reused.repoDir), 'role-change.txt'), 'utf8'),
+    ).toBe('kept\n')
+
+    const manifest = JSON.parse(
+      readFileSync(String(reused.manifestPath), 'utf8'),
+    ) as {
+      baseCommit: string
+      worktrees: Record<string, string>
+      roles: Record<string, { repoDir: string }>
+    }
+    expect(manifest.baseCommit).toMatch(/^[0-9a-f]{40}$/)
+    expect(manifest.worktrees).toMatchObject({
+      'feature-a': featureA.repoDir,
+      'feature-b': featureB.repoDir,
+    })
+    expect(manifest.roles['developer-a']?.repoDir).toBe(featureA.repoDir)
+    expect(manifest.roles['test-a']?.repoDir).toBe(featureA.repoDir)
+  })
+
+  it('merges A/M/D role deltas without attributing the dirty baseline or provider overlay', async () => {
+    const repo = createWaveRepo('role-wave-merge')
+    const providerRoot = writeSkill('merge-developer', 'Develop $ARGUMENTS')
+    writeFileLf(path.join(repo, 'tracked.txt'), 'dirty baseline\n')
+    writeFileLf(
+      path.join(repo, 'baseline untracked 🚀.txt'),
+      'baseline only\n',
+    )
+    writeRoleWave(repo, {
+      run: 'run-merge-01',
+      roles: [
+        {
+          key: 'developer-feature',
+          skill: 'merge-developer',
+          model: 'k3',
+          args: 'implement safely',
+          workspace: 'worktree:feature-safe',
+        },
+      ],
+    })
+    let spawnedOptions: Record<string, unknown> | undefined
+    const mergeTempRoot = path.join(tmpDir, 'role-wave-merge-temp')
+    await expect(
+      runner.runSkillCli(
+        ['--role-wave-file', '.specrails/kimi-role-wave.json'],
+        {
+          scriptPath: path.join(providerRoot, 'specrails', 'run-skill.mjs'),
+          cwd: repo,
+          platform: 'linux',
+          env: { PATH: '/safe/bin' },
+          signalSource: new EventEmitter(),
+          tempRoot: mergeTempRoot,
+          writeOutput: () => {},
+          spawnChild: (_command, _args, options) => {
+            spawnedOptions = options
+            return createRoleChild(0, { content: 'done' })
+          },
+        },
+      ),
+    ).resolves.toBe(0)
+    const initial = runner.inspectRoleWaveStatus('run-merge-01', {
+      cwd: repo,
+      tempRoot: mergeTempRoot,
+    })
+    expect(initial.worktrees['feature-safe']?.changes).toEqual([])
+
+    const worktree = initial.worktrees['feature-safe']!.repoDir
+    const hostileName = 'src/new $(touch never-created) 🚀.txt'
+    writeFileLf(path.join(worktree, hostileName), 'new role output\n')
+    rmSync(path.join(worktree, 'tracked.txt'))
+    const roleEnv = spawnedOptions!.env as Record<string, string>
+    const gitEnv = { ...roleEnv, PATH: process.env.PATH ?? '' }
+    const staged = spawnSync('git', ['add', '-A'], {
+      cwd: worktree,
+      env: gitEnv,
+      encoding: 'utf8',
+    })
+    expect(staged.status).toBe(0)
+    const providerStatus = spawnSync(
+      'git',
+      ['status', '--porcelain=v1', '--', '.kimi-code'],
+      { cwd: worktree, env: gitEnv, encoding: 'utf8' },
+    )
+    expect(providerStatus.stdout).toBe('')
+    const committed = spawnSync(
+      'git',
+      ['commit', '-qm', 'role delta'],
+      { cwd: worktree, env: gitEnv, encoding: 'utf8' },
+    )
+    expect(committed.status).toBe(0)
+
+    const inventory = runner.inspectRoleWaveStatus('run-merge-01', {
+      cwd: repo,
+      tempRoot: mergeTempRoot,
+    })
+    expect(inventory.worktrees['feature-safe']?.changes).toEqual([
+      { status: 'A', path: hostileName },
+      { status: 'D', path: 'tracked.txt' },
+    ])
+    expect(
+      inventory.worktrees['feature-safe']?.changes.some(
+        (change) => change.path.includes('baseline untracked'),
+      ),
+    ).toBe(false)
+
+    const marker = path.join(repo, 'never-created')
+    writeFileLf(
+      path.join(repo, '.specrails', 'kimi-role-merge.json'),
+      `${JSON.stringify({
+        run: 'run-merge-01',
+        actions: [
+          {
+            worktree: 'feature-safe',
+            path: hostileName,
+            operation: 'copy',
+          },
+          {
+            worktree: 'feature-safe',
+            path: 'tracked.txt',
+            operation: 'delete',
+          },
+        ],
+      })}\n`,
+    )
+    const parsed = runner.parseRunnerArgs([
+      '--role-merge-file',
+      '.specrails/kimi-role-merge.json',
+    ])
+    const merge = runner.loadRoleMerge(parsed, repo)!
+    expect(
+      runner.applyRoleMerge(merge, {
+        cwd: repo,
+        tempRoot: mergeTempRoot,
+      }),
+    ).toMatchObject({
+      run: 'run-merge-01',
+      applied: 2,
+    })
+    expect(readFileSync(path.join(repo, hostileName), 'utf8')).toBe(
+      'new role output\n',
+    )
+    expect(existsSync(path.join(repo, 'tracked.txt'))).toBe(false)
+    expect(existsSync(marker)).toBe(false)
+
+    const cleaned = runner.cleanupRoleWave('run-merge-01', {
+      cwd: repo,
+      tempRoot: mergeTempRoot,
+    })
+    expect(cleaned.removedWorktrees).toBe(1)
+    expect(existsSync(cleaned.manifestPath)).toBe(false)
+    expect(existsSync(worktree)).toBe(false)
+    const privateRefs = spawnSync(
+      'git',
+      ['for-each-ref', '--format=%(refname)', 'refs/specrails/kimi/'],
+      { cwd: repo, encoding: 'utf8' },
+    )
+    expect(privateRefs.status).toBe(0)
+    expect(privateRefs.stdout).toBe('')
+  })
+
+  it('rejects a tampered manifest git oid before invoking a ref-like git argument', async () => {
+    const repo = createWaveRepo('role-wave-tampered-manifest')
+    const providerRoot = writeSkill('tamper-role', 'body')
+    writeRoleWave(repo, {
+      run: 'run-tampered-01',
+      roles: [
+        {
+          key: 'tamper-role',
+          skill: 'tamper-role',
+          model: 'k3',
+          args: '',
+          workspace: 'worktree:feature-tamper',
+        },
+      ],
+    })
+    const tamperedTempRoot = path.join(
+      tmpDir,
+      'role-wave-tampered-temp',
+    )
+    await runner.runSkillCli(
+      ['--role-wave-file', '.specrails/kimi-role-wave.json'],
+      {
+        scriptPath: path.join(providerRoot, 'specrails', 'run-skill.mjs'),
+        cwd: repo,
+        platform: 'linux',
+        env: { PATH: '/safe/bin' },
+        signalSource: new EventEmitter(),
+        tempRoot: tamperedTempRoot,
+        writeOutput: () => {},
+        spawnChild: () => createRoleChild(0, { content: 'done' }),
+      },
+    )
+    const manifestPath = path.join(
+      repo,
+      '.specrails',
+      'kimi-role-worktrees',
+      'run-tampered-01.json',
+    )
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as Record<
+      string,
+      unknown
+    >
+    manifest.baseCommit = '--help'
+    writeFileLf(manifestPath, `${JSON.stringify(manifest)}\n`)
+    expect(() =>
+      runner.inspectRoleWaveStatus('run-tampered-01', {
+        cwd: repo,
+        tempRoot: tamperedTempRoot,
+      }),
+    ).toThrow(/Invalid role wave manifest/)
+  })
+
+  it('rejects registered foreign worktree paths and a retargeted private baseline ref', async () => {
+    const repo = createWaveRepo('role-wave-manifest-integrity')
+    const providerRoot = writeSkill('integrity-role', 'body')
+    const tempRoot = path.join(tmpDir, 'role-wave-integrity-temp')
+    writeRoleWave(repo, {
+      run: 'run-integrity-01',
+      roles: [
+        {
+          key: 'integrity-role',
+          skill: 'integrity-role',
+          model: 'k3',
+          args: '',
+          workspace: 'worktree:feature-integrity',
+        },
+      ],
+    })
+    await runner.runSkillCli(
+      ['--role-wave-file', '.specrails/kimi-role-wave.json'],
+      {
+        scriptPath: path.join(providerRoot, 'specrails', 'run-skill.mjs'),
+        cwd: repo,
+        platform: 'linux',
+        env: { PATH: '/safe/bin' },
+        signalSource: new EventEmitter(),
+        tempRoot,
+        writeOutput: () => {},
+        spawnChild: () => createRoleChild(0, { content: 'done' }),
+      },
+    )
+    const manifestPath = path.join(
+      repo,
+      '.specrails',
+      'kimi-role-worktrees',
+      'run-integrity-01.json',
+    )
+    const original = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+      baseCommit: string
+      worktrees: Record<string, string>
+      roles: Record<
+        string,
+        {
+          executionCwd: string
+          repoDir: string
+          workspace: string
+          gitExcludeFile: string
+        }
+      >
+    }
+    const foreign = path.join(tmpDir, 'foreign-registered-worktree')
+    const added = spawnSync(
+      'git',
+      ['worktree', 'add', '--detach', foreign, 'HEAD'],
+      { cwd: repo, encoding: 'utf8' },
+    )
+    expect(added.status).toBe(0)
+    const tampered = structuredClone(original)
+    tampered.worktrees['feature-integrity'] = realpathSync(foreign)
+    tampered.roles['integrity-role']!.executionCwd = realpathSync(foreign)
+    tampered.roles['integrity-role']!.repoDir = realpathSync(foreign)
+    writeFileLf(manifestPath, `${JSON.stringify(tampered)}\n`)
+
+    expect(() =>
+      runner.inspectRoleWaveStatus('run-integrity-01', {
+        cwd: repo,
+        tempRoot,
+      }),
+    ).toThrow(/worktree path mismatch/)
+    expect(() =>
+      runner.cleanupRoleWave('run-integrity-01', {
+        cwd: repo,
+        tempRoot,
+      }),
+    ).toThrow(/worktree path mismatch/)
+    expect(existsSync(foreign)).toBe(true)
+    const removed = spawnSync(
+      'git',
+      ['worktree', 'remove', '--force', foreign],
+      { cwd: repo, encoding: 'utf8' },
+    )
+    expect(removed.status).toBe(0)
+
+    writeFileLf(manifestPath, `${JSON.stringify(original)}\n`)
+    const privateRef = spawnSync(
+      'git',
+      [
+        'for-each-ref',
+        '--format=%(refname)',
+        'refs/specrails/kimi/',
+      ],
+      { cwd: repo, encoding: 'utf8' },
+    ).stdout.trim()
+    expect(privateRef).toMatch(/^refs\/specrails\/kimi\//)
+    const retargeted = spawnSync(
+      'git',
+      ['update-ref', privateRef, 'HEAD'],
+      { cwd: repo, encoding: 'utf8' },
+    )
+    expect(retargeted.status).toBe(0)
+    expect(() =>
+      runner.inspectRoleWaveStatus('run-integrity-01', {
+        cwd: repo,
+        tempRoot,
+      }),
+    ).toThrow(/private ref does not match/)
+
+    const restored = spawnSync(
+      'git',
+      ['update-ref', privateRef, original.baseCommit],
+      { cwd: repo, encoding: 'utf8' },
+    )
+    expect(restored.status).toBe(0)
+    expect(
+      runner.cleanupRoleWave('run-integrity-01', {
+        cwd: repo,
+        tempRoot,
+      }).removedWorktrees,
+    ).toBe(1)
+  })
+
+  it('waits for the whole wave and reports partial failure', async () => {
+    const repo = createWaveRepo('role-wave-partial')
+    const providerRoot = writeSkill('partial-a', 'A')
+    writeSkill('partial-b', 'B')
+    writeRoleWave(repo, {
+      run: 'run-partial-01',
+      roles: [
+        {
+          key: 'required-a',
+          skill: 'partial-a',
+          model: 'k3',
+          args: '',
+          workspace: 'current',
+        },
+        {
+          key: 'required-b',
+          skill: 'partial-b',
+          model: 'k3',
+          args: '',
+          workspace: 'current',
+        },
+      ],
+    })
+    const output: string[] = []
+    let index = 0
+    const code = await runner.runSkillCli(
+      ['--role-wave-file', '.specrails/kimi-role-wave.json'],
+      {
+        scriptPath: path.join(providerRoot, 'specrails', 'run-skill.mjs'),
+        cwd: repo,
+        platform: 'linux',
+        env: { PATH: '/safe/bin' },
+        signalSource: new EventEmitter(),
+        tempRoot: path.join(tmpDir, 'role-wave-partial-temp'),
+        writeOutput: (line) => output.push(line),
+        spawnChild: () =>
+          createRoleChild(index++ === 0 ? 0 : 7, { content: 'finished' }),
+      },
+    )
+    expect(code).toBe(7)
+    const completed = output
+      .join('')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>)
+      .filter((frame) => frame.type === 'specrails.role.completed')
+    expect(completed).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ roleKey: 'required-a', status: 'succeeded' }),
+        expect.objectContaining({
+          roleKey: 'required-b',
+          status: 'failed',
+          exitCode: 7,
+        }),
+      ]),
+    )
+  })
+
+  it('forwards one cancellation signal to every live role child', async () => {
+    const repo = createWaveRepo('role-wave-cancel')
+    const providerRoot = writeSkill('cancel-a', 'A')
+    writeSkill('cancel-b', 'B')
+    writeRoleWave(repo, {
+      run: 'run-cancel-01',
+      roles: [
+        {
+          key: 'cancel-a',
+          skill: 'cancel-a',
+          model: 'k3',
+          args: '',
+          workspace: 'current',
+        },
+        {
+          key: 'cancel-b',
+          skill: 'cancel-b',
+          model: 'k3',
+          args: '',
+          workspace: 'current',
+        },
+      ],
+    })
+    const signalSource = new EventEmitter()
+    const children: Array<ReturnType<typeof createRoleChild>> = []
+    const codePromise = runner.runSkillCli(
+      ['--role-wave-file', '.specrails/kimi-role-wave.json'],
+      {
+        scriptPath: path.join(providerRoot, 'specrails', 'run-skill.mjs'),
+        cwd: repo,
+        platform: 'linux',
+        env: { PATH: '/safe/bin' },
+        signalSource,
+        tempRoot: path.join(tmpDir, 'role-wave-cancel-temp'),
+        writeOutput: () => {},
+        spawnChild: () => {
+          const child = createRoleChild(0, { content: 'unused' })
+          // Suppress the helper's scheduled normal completion for this test by
+          // returning a fresh child that exits only when killed.
+          const pending = new EventEmitter() as ReturnType<typeof createRoleChild>
+          pending.stdout = new PassThrough()
+          pending.stderr = new PassThrough()
+          pending.stdin = new PassThrough()
+          pending.kill = vi.fn((signal: string) => {
+            pending.stdout.end()
+            pending.stderr.end()
+            queueMicrotask(() => pending.emit('exit', null, signal))
+            return true
+          })
+          child.removeAllListeners()
+          children.push(pending)
+          if (children.length === 2) {
+            queueMicrotask(() => signalSource.emit('SIGTERM'))
+          }
+          return pending
+        },
+      },
+    )
+    await expect(codePromise).resolves.toBe(143)
+    expect(children).toHaveLength(2)
+    for (const child of children) {
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+    }
+  })
+
+  it('falls back to a copied Windows provider overlay without replacing one', () => {
+    const providerRoot = writeSkill('overlay-role', 'body')
+    const workspace = path.join(tmpDir, 'windows-overlay')
+    mkdirSync(workspace, { recursive: true })
+    const createLink = vi.fn(() => {
+      throw new Error('junction privilege unavailable')
+    })
+    const copyTree = vi.fn((source: string, destination: string) => {
+      cpSync(source, destination, {
+        recursive: true,
+        dereference: true,
+        errorOnExist: true,
+      })
+    })
+    runner.ensureProviderOverlay(providerRoot, workspace, 'win32', {
+      symlink: createLink,
+      copyTree,
+    })
+    expect(createLink).toHaveBeenCalledWith(
+      realpathSync(providerRoot),
+      path.join(workspace, '.kimi-code'),
+      'junction',
+    )
+    expect(copyTree).toHaveBeenCalled()
+    expect(
+      readFileSync(
+        path.join(
+          workspace,
+          '.kimi-code',
+          'skills',
+          'overlay-role',
+          'SKILL.md',
+        ),
+        'utf8',
+      ),
+    ).toContain('overlay-role test skill')
+
+    writeFileLf(
+      path.join(
+        workspace,
+        '.kimi-code',
+        'skills',
+        'overlay-role',
+        'SKILL.md',
+      ),
+      'tampered\n',
+    )
+    runner.ensureProviderOverlay(providerRoot, workspace, 'win32', {
+      symlink: createLink,
+      copyTree,
+    })
+    expect(copyTree).toHaveBeenCalledTimes(2)
+    expect(
+      readFileSync(
+        path.join(
+          workspace,
+          '.kimi-code',
+          'skills',
+          'overlay-role',
+          'SKILL.md',
+        ),
+        'utf8',
+      ),
+    ).toContain('overlay-role test skill')
+
+    const owned = path.join(tmpDir, 'windows-overlay-owned')
+    writeFileLf(path.join(owned, '.kimi-code', 'user.txt'), 'preserve\n')
+    const shouldNotLink = vi.fn()
+    expect(() =>
+      runner.ensureProviderOverlay(providerRoot, owned, 'win32', {
+        symlink: shouldNotLink,
+      }),
+    ).toThrow(/unverified worktree provider directory/)
+    expect(shouldNotLink).not.toHaveBeenCalled()
+    expect(
+      readFileSync(path.join(owned, '.kimi-code', 'user.txt'), 'utf8'),
+    ).toBe('preserve\n')
+
+    const wrongLinkWorkspace = path.join(tmpDir, 'windows-overlay-wrong-link')
+    const wrongTarget = path.join(tmpDir, 'wrong-kimi-provider')
+    mkdirSync(wrongTarget, { recursive: true })
+    mkdirSync(wrongLinkWorkspace, { recursive: true })
+    symlinkSync(
+      wrongTarget,
+      path.join(wrongLinkWorkspace, '.kimi-code'),
+      'dir',
+    )
+    expect(() =>
+      runner.ensureProviderOverlay(
+        providerRoot,
+        wrongLinkWorkspace,
+        'win32',
+      ),
+    ).toThrow(/does not target the managed provider/)
+  })
+
+  it('forwards helper termination signals to the Kimi child', () => {
+    const source = new EventEmitter()
+    const child = { kill: vi.fn() }
+    const cleanup = runner.forwardTerminationSignals(child, source)
+    source.emit('SIGINT')
+    source.emit('SIGTERM')
+    expect(child.kill).toHaveBeenNthCalledWith(1, 'SIGINT')
+    expect(child.kill).toHaveBeenNthCalledWith(2, 'SIGTERM')
+    cleanup()
+    source.emit('SIGHUP')
+    expect(child.kill).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects experimental runner flags instead of forwarding them to Kimi', () => {
+    expect(() =>
+      runner.parseRunnerArgs([
+        '--skill',
+        'sr-reviewer',
+        '--model',
+        'k3',
+        '--experimental',
+        'v2',
+      ]),
+    ).toThrow(/Unknown option: --experimental/)
+  })
+
+  it('scopes inherited thinking effort to K3 and removes invalid values', () => {
+    const inherited = {
+      PATH: '/safe/bin',
+      KIMI_MODEL_THINKING_EFFORT: 'max',
+    }
+    expect(runner.stableKimiEnvironment(inherited, 'k3')).toEqual({
+      ...inherited,
+      KIMI_DISABLE_CRON: '1',
+      KIMI_CODE_NO_AUTO_UPDATE: '1',
+    })
+    expect(
+      runner.stableKimiEnvironment(inherited, 'kimi-for-coding'),
+    ).toEqual({
+      PATH: '/safe/bin',
+      KIMI_DISABLE_CRON: '1',
+      KIMI_CODE_NO_AUTO_UPDATE: '1',
+    })
+    expect(
+      runner.stableKimiEnvironment(
+        {
+          PATH: '/safe/bin',
+          KIMI_MODEL_THINKING_EFFORT: 'medium',
+        },
+        'k3',
+      ),
+    ).toEqual({
+      PATH: '/safe/bin',
+      KIMI_DISABLE_CRON: '1',
+      KIMI_CODE_NO_AUTO_UPDATE: '1',
+    })
+  })
+})
+
+describe('managed Kimi skill runner — Windows npm shim', () => {
+  const shim =
+    'C:\\Users\\Jane Doe\\AppData\\Roaming\\npm\\kimi.cmd'
+  const entry =
+    'C:\\Users\\Jane Doe\\AppData\\Roaming\\npm\\node_modules\\@moonshot-ai\\kimi-code\\dist\\main.mjs'
+  const contents =
+    '@ECHO off\r\n"%_prog%"  "%dp0%\\node_modules\\@moonshot-ai\\kimi-code\\dist\\main.mjs" %*\r\n'
+
+  it('extracts the npm JavaScript entry and launches it with Node', () => {
+    expect(runner.parseNpmCmdShimEntry(shim, contents)).toBe(entry)
+    const prompt = 'uno\n二 🚀'
+    const launch = runner.resolveKimiLaunch(
+      ['-p', prompt, '--output-format', 'stream-json'],
+      {
+        platform: 'win32',
+        binary: shim,
+        readFile: () => contents,
+        fileExists: () => false,
+      },
+    )
+    expect(launch.command).toBe('node')
+    expect(launch.stdinText).toBe(prompt)
+    expect(launch.args).toEqual([
+      '-e',
+      runner.WINDOWS_NPM_STDIN_BOOTSTRAP,
+      entry,
+      '-p',
+      runner.WINDOWS_PROMPT_STDIN_TOKEN,
+      '--output-format',
+      'stream-json',
+    ])
+    expect(launch.args).not.toContain(prompt)
+  })
+
+  it('fails the invocation when Windows stdin prompt transport errors', async () => {
+    const providerRoot = writeSkill('stdin-failure', 'Review $ARGUMENTS')
+    const stdin = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback(new Error('simulated broken pipe'))
+      },
+    })
+    const child = new EventEmitter() as EventEmitter & {
+      stdin: Writable
+      kill: ReturnType<typeof vi.fn>
+    }
+    child.stdin = stdin
+    child.kill = vi.fn()
+
+    await expect(
+      runner.runSkillCli(
+        [
+          '--skill',
+          'stdin-failure',
+          '--model',
+          'k3',
+          '--args',
+          'large prompt',
+        ],
+        {
+          scriptPath: path.join(
+            providerRoot,
+            'specrails',
+            'run-skill.mjs',
+          ),
+          cwd: tmpDir,
+          platform: 'win32',
+          binary: shim,
+          readFile: (file) =>
+            file.toLowerCase().endsWith('.cmd')
+              ? contents
+              : readFileSync(file, 'utf8'),
+          fileExists: () => false,
+          signalSource: new EventEmitter(),
+          env: { PATH: 'C:\\npm' },
+          spawnChild: () => child,
+        },
+      ),
+    ).rejects.toThrow(/Cannot transport.*simulated broken pipe/)
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+  })
+
+  it('reconstructs a large Unicode prompt from stdin before importing the npm entry', () => {
+    const fakeEntry = path.join(tmpDir, 'fake-kimi-entry.mjs')
+    writeFileLf(
+      fakeEntry,
+      'process.stdout.write(JSON.stringify(process.argv))\n',
+    )
+    const prompt = `Inicio 🚀\n${'第二行 con datos\n'.repeat(5_000)}Fin`
+    const result = spawnSync(
+      process.execPath,
+      [
+        '-e',
+        runner.WINDOWS_NPM_STDIN_BOOTSTRAP,
+        fakeEntry,
+        '-m',
+        'kimi-code/k3',
+        '-p',
+        runner.WINDOWS_PROMPT_STDIN_TOKEN,
+        '--output-format',
+        'stream-json',
+      ],
+      {
+        encoding: 'utf8',
+        input: prompt,
+      },
+    )
+    expect(result.status).toBe(0)
+    expect(result.stderr).toBe('')
+    expect(JSON.parse(result.stdout)).toEqual([
+      process.execPath,
+      fakeEntry,
+      '-m',
+      'kimi-code/k3',
+      '-p',
+      prompt,
+      '--output-format',
+      'stream-json',
+    ])
+  })
+
+  it('replaces only the -p marker when another argument equals the marker', () => {
+    const fakeEntry = path.join(tmpDir, 'fake-kimi-marker-entry.mjs')
+    writeFileLf(
+      fakeEntry,
+      'process.stdout.write(JSON.stringify(process.argv))\n',
+    )
+    const prompt = 'prompt restored from stdin'
+    const hostileArgument = runner.WINDOWS_PROMPT_STDIN_TOKEN
+    const result = spawnSync(
+      process.execPath,
+      [
+        '-e',
+        runner.WINDOWS_NPM_STDIN_BOOTSTRAP,
+        fakeEntry,
+        hostileArgument,
+        '-p',
+        runner.WINDOWS_PROMPT_STDIN_TOKEN,
+      ],
+      {
+        encoding: 'utf8',
+        input: prompt,
+      },
+    )
+    expect(result.status).toBe(0)
+    expect(JSON.parse(result.stdout)).toEqual([
+      process.execPath,
+      fakeEntry,
+      hostileArgument,
+      '-p',
+      prompt,
+    ])
+  })
+
+  it('binds option-like session ids to the Kimi session option', () => {
+    expect(
+      runner.parseRunnerArgs([
+        '--skill',
+        'session-option',
+        '--model',
+        'k3',
+        '--session=--continue',
+      ]).sessionId,
+    ).toBe('--continue')
+    const providerRoot = writeSkill('session-option', 'hello')
+    const prepared = runner.prepareSkillLaunch({
+      providerRoot,
+      skill: 'session-option',
+      model: 'k3',
+      rawArgs: '',
+      sessionId: '--continue',
+      additionalDirs: [],
+      attachmentPaths: [],
+    })
+    expect(prepared.kimiArgs[0]).toBe('--session=--continue')
+    expect(prepared.kimiArgs).not.toContain('-S')
+  })
+
+  it('rejects unsafe session ids at parse and materialization boundaries', () => {
+    const providerRoot = writeSkill('session-safe', 'hello')
+    for (const sessionId of [
+      '',
+      '.',
+      '..',
+      'session/escape',
+      'session with spaces',
+      ' ses_1',
+      'ses_1 ',
+      'x'.repeat(129),
+    ]) {
+      expect(() =>
+        runner.parseRunnerArgs([
+          '--skill',
+          'session-safe',
+          '--model',
+          'k3',
+          '--session',
+          sessionId,
+        ]),
+      ).toThrow(/session/)
+      expect(() =>
+        runner.prepareSkillLaunch({
+          providerRoot,
+          skill: 'session-safe',
+          model: 'k3',
+          rawArgs: '',
+          sessionId,
+          additionalDirs: [],
+          attachmentPaths: [],
+        }),
+      ).toThrow(/session/)
+    }
+  })
+
+  it('keeps oversized prompts off npm argv and rejects oversized native argv', () => {
+    const prompt = `🚀${'x'.repeat(70_000)}`
+    const npmLaunch = runner.resolveKimiLaunch(
+      ['-m', 'kimi-code/k3', '-p', prompt, '--output-format', 'stream-json'],
+      {
+        platform: 'win32',
+        binary: shim,
+        readFile: () => contents,
+        fileExists: () => false,
+      },
+    )
+    expect(npmLaunch.stdinText).toBe(prompt)
+    expect(npmLaunch.args).not.toContain(prompt)
+    expect(
+      runner.windowsCommandLineLength(npmLaunch.command, npmLaunch.args),
+    ).toBeLessThanOrEqual(30_000)
+
+    expect(() =>
+      runner.resolveKimiLaunch(['-p', prompt], {
+        platform: 'win32',
+        binary: 'C:\\Kimi\\kimi.exe',
+      }),
+    ).toThrow(/above 30000.*standard npm kimi\.cmd/s)
+  })
+
+  it('prefers a native executable and resolves PATH keys case-insensitively', () => {
+    const binary = 'C:\\Kimi\\kimi.EXE'
+    expect(
+      runner.resolveWindowsKimiBinary(
+        { Path: 'C:\\Other;C:\\Kimi', PATHEXT: '.EXE;.CMD' },
+        (candidate) => candidate.toLowerCase() === binary.toLowerCase(),
+      ),
+    ).toBe('C:\\Kimi\\kimi.exe')
+    expect(
+      runner.resolveKimiLaunch(['--version'], {
+        platform: 'win32',
+        binary,
+      }),
+    ).toEqual({ command: binary, args: ['--version'] })
+  })
+
+  it('prefers the npm command shim when its extensionless sibling also exists', () => {
+    const bare = 'C:\\Users\\Jane Doe\\AppData\\Roaming\\npm\\kimi'
+    expect(
+      runner.resolveWindowsKimiBinary(
+        {
+          Path: 'C:\\Users\\Jane Doe\\AppData\\Roaming\\npm',
+          PATHEXT: '.EXE;.CMD;.BAT;.COM',
+        },
+        (candidate) =>
+          candidate.toLowerCase() === bare.toLowerCase() ||
+          candidate.toLowerCase() === shim.toLowerCase(),
+      ),
+    ).toBe('C:\\Users\\Jane Doe\\AppData\\Roaming\\npm\\kimi.cmd')
+  })
+
+  it('rejects PowerShell-only and extensionless Windows installations', () => {
+    expect(() =>
+      runner.resolveWindowsKimiBinary(
+        { Path: 'C:\\Kimi', PATHEXT: '.PS1' },
+        (candidate) =>
+          candidate.toLowerCase() === 'c:\\kimi\\kimi.ps1' ||
+          candidate.toLowerCase() === 'c:\\kimi\\kimi',
+      ),
+    ).toThrow(/No shell-free Kimi executable/)
+  })
+
+  it('fails closed for a non-standard command shim instead of using cmd.exe', () => {
+    expect(() =>
+      runner.resolveKimiLaunch(['-p', 'safe'], {
+        platform: 'win32',
+        binary: shim,
+        readFile: () => '@echo off\r\nsome-custom-launcher %*\r\n',
+      }),
+    ).toThrow(/Refusing to execute non-standard/)
+  })
+})

--- a/src/installer/runtime/kimi.test.ts
+++ b/src/installer/runtime/kimi.test.ts
@@ -70,9 +70,9 @@ describe('Kimi headless invocation', () => {
       'kimi-code/k3',
       '--session=ses_123',
       '--add-dir',
-      '/repo/source',
+      path.resolve('/repo/source'),
       '--add-dir',
-      '/repo/worktree',
+      path.resolve('/repo/worktree'),
     ])
     expect(invocation.args).not.toContain('continue the review')
     expect(invocation.env).toEqual({
@@ -256,7 +256,7 @@ describe('Kimi headless invocation', () => {
       'línea uno\n第二行 🚀',
       '--session=ses_123',
       '--add-dir',
-      '/repo/source',
+      path.resolve('/repo/source'),
     ])
     expect(invocation.args.join('\n')).not.toContain('/skill:')
   })

--- a/src/installer/runtime/kimi.test.ts
+++ b/src/installer/runtime/kimi.test.ts
@@ -1,0 +1,476 @@
+import {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildKimiInvocation,
+  extractKimiSessionHint,
+  KIMI_SKILL_RUNNER_PATH,
+  normalizeKimiCliModel,
+  parseKimiStreamLine,
+} from './kimi.js'
+
+describe('Kimi headless invocation', () => {
+  it('routes skill execution through the managed runner instead of literal /skill text', () => {
+    expect(
+      buildKimiInvocation({
+        model: 'k3',
+        skill: 'specrails-implement',
+        skillArguments: '#42',
+      }),
+    ).toEqual({
+      bin: 'node',
+      args: [
+        '.kimi-code/specrails/run-skill.mjs',
+        '--skill',
+        'specrails-implement',
+        '--model',
+        'k3',
+        '--args',
+        '#42',
+      ],
+      env: {
+        KIMI_CODE_EXPERIMENTAL_FLAG: undefined,
+        KIMI_DISABLE_CRON: '1',
+        KIMI_CODE_NO_AUTO_UPDATE: '1',
+        KIMI_MODEL_THINKING_EFFORT: undefined,
+      },
+      prompt: '',
+    })
+  })
+
+  it('adds a known session and thinking effort without server or skills-dir flags', () => {
+    const invocation = buildKimiInvocation({
+      model: 'kimi-code/k3',
+      prompt: 'continue the review',
+      sessionId: 'ses_123',
+      thinkingEffort: 'high',
+      additionalDirs: ['/repo/source', '/repo/worktree'],
+    })
+    expect(invocation).toMatchObject({
+      bin: 'node',
+      stdinText: 'continue the review',
+      prompt: 'continue the review',
+    })
+    expect(invocation.args).toEqual([
+      '.kimi-code/specrails/run-skill.mjs',
+      '--plain-prompt-stdin',
+      '--model',
+      'kimi-code/k3',
+      '--session=ses_123',
+      '--add-dir',
+      '/repo/source',
+      '--add-dir',
+      '/repo/worktree',
+    ])
+    expect(invocation.args).not.toContain('continue the review')
+    expect(invocation.env).toEqual({
+      KIMI_CODE_EXPERIMENTAL_FLAG: undefined,
+      KIMI_DISABLE_CRON: '1',
+      KIMI_CODE_NO_AUTO_UPDATE: '1',
+      KIMI_MODEL_THINKING_EFFORT: 'high',
+    })
+    expect(invocation.args).not.toContain('--skills-dir')
+    expect(invocation.args).not.toContain('server')
+  })
+
+  it('binds option-like session ids into a single CLI argument', () => {
+    const invocation = buildKimiInvocation({
+      model: 'k3',
+      prompt: 'continue safely',
+      sessionId: '--auto',
+    })
+    expect(invocation.args).toContain('--session=--auto')
+    expect(invocation.args).not.toContain('-S')
+  })
+
+  it('rejects unsafe session ids for both plain prompts and skills', () => {
+    for (const sessionId of [
+      '',
+      '.',
+      '..',
+      'session/escape',
+      'session with spaces',
+      ' ses_1',
+      'ses_1 ',
+      'x'.repeat(129),
+    ]) {
+      expect(() =>
+        buildKimiInvocation({
+          model: 'k3',
+          prompt: 'continue safely',
+          sessionId,
+        }),
+      ).toThrow(/session id/)
+      expect(() =>
+        buildKimiInvocation({
+          model: 'k3',
+          skill: 'sr-reviewer',
+          sessionId,
+        }),
+      ).toThrow(/session id/)
+    }
+  })
+
+  it('emits thinking effort only for raw or prefixed K3', () => {
+    expect(
+      buildKimiInvocation({
+        model: 'k3',
+        prompt: 'think',
+        thinkingEffort: 'max',
+      }).env,
+    ).toEqual({
+      KIMI_CODE_EXPERIMENTAL_FLAG: undefined,
+      KIMI_DISABLE_CRON: '1',
+      KIMI_CODE_NO_AUTO_UPDATE: '1',
+      KIMI_MODEL_THINKING_EFFORT: 'max',
+    })
+    expect(
+      buildKimiInvocation({
+        model: 'kimi-for-coding',
+        prompt: 'think',
+        thinkingEffort: 'max',
+      }).env,
+    ).toEqual({
+      KIMI_CODE_EXPERIMENTAL_FLAG: undefined,
+      KIMI_DISABLE_CRON: '1',
+      KIMI_CODE_NO_AUTO_UPDATE: '1',
+      KIMI_MODEL_THINKING_EFFORT: undefined,
+    })
+    expect(
+      buildKimiInvocation({
+        model: 'company/custom',
+        prompt: 'think',
+        thinkingEffort: 'high',
+      }).env,
+    ).toEqual({
+      KIMI_CODE_EXPERIMENTAL_FLAG: undefined,
+      KIMI_DISABLE_CRON: '1',
+      KIMI_CODE_NO_AUTO_UPDATE: '1',
+      KIMI_MODEL_THINKING_EFFORT: undefined,
+    })
+  })
+
+  it('retains arbitrary provider model ids and normalizes only official short ids', () => {
+    expect(normalizeKimiCliModel('k3')).toBe('kimi-code/k3')
+    expect(normalizeKimiCliModel('kimi-for-coding-highspeed')).toBe(
+      'kimi-code/kimi-for-coding-highspeed',
+    )
+    expect(normalizeKimiCliModel('my-provider/exact-model')).toBe(
+      'my-provider/exact-model',
+    )
+    expect(normalizeKimiCliModel('sonnet')).toBe('sonnet')
+  })
+
+  it.each([
+    '',
+    '--yolo',
+    'team model',
+    ' team/model',
+    'team/model ',
+    'team/model\n--yolo',
+    'team/model\u0001',
+    `a${'b'.repeat(128)}`,
+  ])('rejects unsafe model id %j before building spawn argv', (model) => {
+    expect(() => normalizeKimiCliModel(model)).toThrow(/model id/)
+    expect(() =>
+      buildKimiInvocation({
+        model,
+        skill: 'sr-reviewer',
+      }),
+    ).toThrow(/model id/)
+  })
+
+  it('delegates absolute attachment paths to the managed skill runner', () => {
+    const directory = mkdtempSync(path.join(os.tmpdir(), 'specrails-kimi-attachments-'))
+    try {
+      const report = path.join(directory, 'report.txt')
+      const screenshot = path.join(directory, 'screenshot.png')
+      writeFileSync(report, 'report')
+      writeFileSync(screenshot, 'png')
+      const invocation = buildKimiInvocation({
+        model: 'k3',
+        skill: 'sr-reviewer',
+        attachmentPaths: [report, screenshot],
+      })
+      expect(invocation.bin).toBe('node')
+      expect(invocation.args).toContain('.kimi-code/specrails/run-skill.mjs')
+      expect(invocation.args).toContain('sr-reviewer')
+      expect(invocation.args).toContain(realpathSync(report))
+      expect(invocation.args).toContain(realpathSync(screenshot))
+      expect(invocation.args).not.toContain('/skill:sr-reviewer')
+      expect(invocation.args.filter((arg) => arg === '--attachment')).toHaveLength(2)
+      expect(invocation.args.filter((arg) => arg === '--add-dir')).toHaveLength(1)
+      expect(invocation.args).toContain(realpathSync(directory))
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('exposes attachment parents for plain prompts without duplicate add-dir flags', () => {
+    const directory = mkdtempSync(path.join(os.tmpdir(), 'specrails-kimi-plain-'))
+    try {
+      const attachment = path.join(directory, 'evidence.txt')
+      writeFileSync(attachment, 'evidence')
+      const invocation = buildKimiInvocation({
+        model: 'k3',
+        prompt: 'inspect',
+        attachmentPaths: [attachment],
+        additionalDirs: [directory],
+      })
+      expect(invocation.args.filter((arg) => arg === '--add-dir')).toHaveLength(1)
+      expect(invocation.args).toContain(realpathSync(directory))
+      expect(invocation.prompt).toContain(realpathSync(attachment))
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('preserves custom aliases and multiline Unicode skill arguments as argv', () => {
+    const invocation = buildKimiInvocation({
+      model: 'company/Kimi-Custom:v2',
+      skill: 'custom-auditor',
+      skillArguments: 'línea uno\n第二行 🚀',
+      sessionId: 'ses_123',
+      additionalDirs: ['/repo/source'],
+    })
+    expect(invocation.bin).toBe('node')
+    expect(invocation.args).toEqual([
+      '.kimi-code/specrails/run-skill.mjs',
+      '--skill',
+      'custom-auditor',
+      '--model',
+      'company/Kimi-Custom:v2',
+      '--args',
+      'línea uno\n第二行 🚀',
+      '--session=ses_123',
+      '--add-dir',
+      '/repo/source',
+    ])
+    expect(invocation.args.join('\n')).not.toContain('/skill:')
+  })
+
+  it('rejects relative attachments and malformed skill names', () => {
+    expect(() =>
+      buildKimiInvocation({
+        model: 'k3',
+        prompt: 'inspect',
+        attachmentPaths: ['relative.png'],
+      }),
+    ).toThrow(/must be absolute/)
+    expect(() =>
+      buildKimiInvocation({ model: 'k3', skill: '/skill:specrails-implement' }),
+    ).toThrow(/invalid Kimi skill/)
+  })
+
+  it('rejects missing, directory, symlink, and unreadable attachments', () => {
+    const directory = mkdtempSync(path.join(os.tmpdir(), 'specrails-kimi-invalid-'))
+    const regular = path.join(directory, 'regular.txt')
+    const nestedDirectory = path.join(directory, 'nested')
+    const link = path.join(directory, 'link.txt')
+    writeFileSync(regular, 'secret')
+    mkdirSync(nestedDirectory)
+    try {
+      for (const attachment of [
+        path.join(directory, 'missing.txt'),
+        nestedDirectory,
+      ]) {
+        expect(() =>
+          buildKimiInvocation({
+            model: 'k3',
+            skill: 'sr-reviewer',
+            attachmentPaths: [attachment],
+          }),
+        ).toThrow(/regular non-symlink file/)
+      }
+
+      if (process.platform !== 'win32') {
+        symlinkSync(regular, link)
+        expect(() =>
+          buildKimiInvocation({
+            model: 'k3',
+            skill: 'sr-reviewer',
+            attachmentPaths: [link],
+          }),
+        ).toThrow(/regular non-symlink file/)
+
+        chmodSync(regular, 0o000)
+        expect(() =>
+          buildKimiInvocation({
+            model: 'k3',
+            skill: 'sr-reviewer',
+            attachmentPaths: [regular],
+          }),
+        ).toThrow(/regular non-symlink file/)
+        chmodSync(regular, 0o600)
+      }
+    } finally {
+      try {
+        chmodSync(regular, 0o600)
+      } catch {
+        // The file may already have been removed by a failed setup.
+      }
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('publishes helper argv, never literal slash text, for headless enrich', () => {
+    const contract = JSON.parse(
+      readFileSync(path.join(process.cwd(), 'integration-contract.json'), 'utf8'),
+    ) as {
+      providers: {
+        kimi: {
+          cli: {
+            binary: string
+            skillRunner: string
+            nestedSkillInvocation: string
+            modelIdPattern: string
+            sessionIdPattern: string
+            roleWave: {
+              path: string
+              schema: string
+              maxBytes: number
+              maxRoles: number
+              transport: string
+              workspaces: string
+              manifest: string
+              status: string
+              merge: string
+              cleanup: string
+              output: string
+            }
+            stableEngineEnv: Record<string, string | null>
+            windowsPromptTransport: string
+            initialActivationTelemetry: string
+            cancellation: string
+            enrichArgs: string[]
+            enrichFromConfigArgs: string[]
+          }
+        }
+      }
+    }
+    const cli = contract.providers.kimi.cli
+    expect(cli.binary).toBe('node')
+    expect(cli.skillRunner).toBe(KIMI_SKILL_RUNNER_PATH)
+    expect(cli.nestedSkillInvocation).toContain('built-in Skill tool')
+    expect(cli.nestedSkillInvocation).toContain('{ skill, args }')
+    expect(cli.modelIdPattern).toBe(
+      '^[A-Za-z0-9][A-Za-z0-9._/:-]{0,127}$',
+    )
+    expect(cli.sessionIdPattern).toBe(
+      '^(?!\\.{1,2}$)[A-Za-z0-9._-]{1,128}$',
+    )
+    expect(cli.roleWave.path).toBe(
+      '.specrails/kimi-role-wave.json',
+    )
+    expect(cli.roleWave.maxBytes).toBe(1_048_576)
+    expect(cli.roleWave.maxRoles).toBe(32)
+    expect(cli.roleWave.schema).toContain('profile: "inherit" | safe-id')
+    expect(cli.roleWave.transport).toContain('static foreground --role-wave-file')
+    expect(cli.roleWave.transport).toContain('--role-wave-status')
+    expect(cli.roleWave.workspaces).toContain('detached git worktrees')
+    expect(cli.roleWave.workspaces).toContain('synthetic baseline')
+    expect(cli.roleWave.manifest).toContain('<run>.json')
+    expect(cli.roleWave.manifest).toContain('source head')
+    expect(cli.roleWave.status).toContain('specrails.merge.inventory')
+    expect(cli.roleWave.merge).toContain('.specrails/kimi-role-merge.json')
+    expect(cli.roleWave.merge).toContain('A/M/D')
+    expect(cli.roleWave.cleanup).toContain('--role-wave-cleanup')
+    expect(cli.roleWave.output).toContain('specrails.role.completed')
+    expect(cli.roleWave.output).toContain('specrails.merge.applied')
+    expect(cli.roleWave.output).toContain('specrails.role.cleanup')
+    expect(cli.stableEngineEnv).toEqual({
+      KIMI_CODE_EXPERIMENTAL_FLAG: null,
+      KIMI_DISABLE_CRON: '1',
+      KIMI_CODE_NO_AUTO_UPDATE: '1',
+      KIMI_MODEL_THINKING_EFFORT:
+        "low|high|max only for kimi-code/k3; omitted K3 effort preserves Kimi's documented high default; unset for every other model",
+    })
+    expect(cli.windowsPromptTransport).toContain('prompt bytes travel over stdin')
+    expect(cli.windowsPromptTransport).toContain('30000 UTF-16')
+    expect(cli.initialActivationTelemetry).toContain('cannot emit')
+    expect(cli.cancellation).toContain('forwards SIGINT/SIGTERM/SIGHUP')
+    expect(cli.enrichArgs).toEqual([
+      KIMI_SKILL_RUNNER_PATH,
+      '--skill',
+      'specrails-enrich',
+      '--model',
+      'k3',
+    ])
+    expect(cli.enrichFromConfigArgs).toEqual([
+      ...cli.enrichArgs,
+      '--args',
+      '--from-config',
+    ])
+    expect([...cli.enrichArgs, ...cli.enrichFromConfigArgs].join(' ')).not.toContain(
+      '/skill:',
+    )
+  })
+})
+
+describe('Kimi stream-json parsing', () => {
+  it('parses assistant, tool, meta, unknown, and malformed lines tolerantly', () => {
+    expect(parseKimiStreamLine('{"role":"assistant","content":"done"}')).toMatchObject({
+      kind: 'assistant',
+      content: 'done',
+    })
+    expect(parseKimiStreamLine('{"role":"tool","content":"ok"}')).toMatchObject({
+      kind: 'tool',
+    })
+    expect(parseKimiStreamLine('{"role":"meta","type":"system.version","version":"0.27"}'))
+      .toMatchObject({ kind: 'meta' })
+    expect(parseKimiStreamLine('{"future":"event"}')).toMatchObject({ kind: 'unknown' })
+    expect(parseKimiStreamLine('not-json')).toEqual({ kind: 'invalid', raw: 'not-json' })
+    expect(parseKimiStreamLine('  ')).toEqual({ kind: 'empty' })
+  })
+
+  it('exposes resume only after a session.resume_hint line', () => {
+    const beforeHint = [
+      '{"role":"assistant","content":"partial"}',
+      '{"role":"tool","content":"work"}',
+    ]
+    expect(extractKimiSessionHint(beforeHint, 0)).toBeNull()
+    expect(
+      extractKimiSessionHint([
+        ...beforeHint,
+        '{"role":"meta","type":"session.resume_hint","session_id":"ses_prompt"}',
+      ], 0),
+    ).toBe('ses_prompt')
+  })
+
+  it('trusts only a canonical terminal hint from a zero-exit process', () => {
+    const hint =
+      '{"role":"meta","type":"session.resume_hint","session_id":"ses_prompt"}'
+    expect(extractKimiSessionHint([hint], 7)).toBeNull()
+    expect(extractKimiSessionHint([hint], null)).toBeNull()
+    expect(
+      extractKimiSessionHint([
+        hint,
+        '{"role":"meta","type":"turn.step.retrying"}',
+      ], 0),
+    ).toBeNull()
+    expect(
+      extractKimiSessionHint([
+        '{"role":"meta","type":"session.resume_hint","session_id":"../escape"}',
+      ], 0),
+    ).toBeNull()
+    expect(
+      extractKimiSessionHint([
+        hint,
+        '',
+        '   ',
+      ], 0),
+    ).toBe('ses_prompt')
+  })
+})

--- a/src/installer/runtime/kimi.ts
+++ b/src/installer/runtime/kimi.ts
@@ -1,0 +1,347 @@
+import {
+  accessSync,
+  constants as fsConstants,
+  lstatSync,
+  realpathSync,
+} from 'node:fs'
+import path from 'node:path'
+
+import { InstallerError } from '../util/errors.js'
+
+export type KimiThinkingEffort = 'low' | 'high' | 'max'
+
+export interface KimiInvocationInput {
+  /** Raw profile model id. Official short aliases are normalized at launch. */
+  model: string
+  /** Plain prompt. Required when `skill` is omitted. */
+  prompt?: string
+  /** Safe direct-child skill directory id. Uses the managed runner when set. */
+  skill?: string
+  /** Raw skill argument string expanded with Kimi's native placeholder rules. */
+  skillArguments?: string
+  /** A session id emitted by a prior `session.resume_hint` event. */
+  sessionId?: string
+  thinkingEffort?: KimiThinkingEffort
+  /** Additional source/worktree roots exposed to this independent process. */
+  additionalDirs?: string[]
+  /** Absolute paths only. Kimi prompt mode has no attachment argv flag. */
+  attachmentPaths?: string[]
+  /** Override for callers whose workspace exposes the managed runner elsewhere. */
+  skillRunnerPath?: string
+}
+
+export interface KimiInvocation {
+  bin: 'kimi' | 'node'
+  args: string[]
+  /** Process-environment overlay; no credentials are added or persisted. */
+  env: Record<string, string | undefined>
+  prompt: string
+  /** Text piped to the managed runner; never placed in subprocess argv. */
+  stdinText?: string
+}
+
+export const KIMI_SKILL_RUNNER_PATH = path.join(
+  '.kimi-code',
+  'specrails',
+  'run-skill.mjs',
+)
+
+const OFFICIAL_SHORT_MODEL_IDS = new Set([
+  'k3',
+  'kimi-for-coding',
+  'kimi-for-coding-highspeed',
+])
+const SAFE_MODEL_ID = /^[A-Za-z0-9][A-Za-z0-9._/:-]*$/
+const SAFE_SESSION_ID = /^[A-Za-z0-9._-]+$/
+const MAX_MODEL_ID_LENGTH = 128
+const MAX_SESSION_ID_LENGTH = 128
+
+/**
+ * Profiles retain raw provider ids. At the CLI boundary only the three managed
+ * Kimi aliases gain their documented `kimi-code/` namespace; custom model ids
+ * and already-qualified aliases remain byte-identical.
+ */
+export function normalizeKimiCliModel(model: string): string {
+  const value = validateKimiModelId(model)
+  return OFFICIAL_SHORT_MODEL_IDS.has(value) ? `kimi-code/${value}` : value
+}
+
+/**
+ * Canonical daemon-free Kimi invocation consumed by Desktop and scripts.
+ * Plain prompts cross stdin into Core's managed Node helper so they never
+ * appear in the host-to-helper argv. The helper must pass the exact user turn
+ * through Kimi 0.27's only non-interactive API, `-p <prompt>`: native Kimi
+ * binaries therefore expose it in their own process argv, while supported npm
+ * Windows shims receive it through the exact stdin bootstrap. Skills also
+ * pre-render direct-child SKILL.md because prompt mode treats `/skill:...` as
+ * literal user text.
+ */
+export function buildKimiInvocation(input: KimiInvocationInput): KimiInvocation {
+  if (input.skill) return buildKimiSkillInvocation(input)
+
+  const attachments = validateKimiAttachments(input.attachmentPaths ?? [])
+  const prompt = buildPlainKimiPrompt(input, attachments)
+  const model = normalizeKimiCliModel(input.model)
+  const additionalDirs = Array.from(
+    new Set([
+      ...(input.additionalDirs ?? []).map((dir) =>
+        canonicalizeAdditionalDirectory(
+          requireNonEmpty(dir, 'additional directory'),
+        ),
+      ),
+      ...attachments.map((attachment) => path.dirname(attachment)),
+    ]),
+  )
+  const additionalDirArgs = additionalDirs.flatMap((dir) => [
+    '--add-dir',
+    dir,
+  ])
+  const args = [
+    input.skillRunnerPath?.trim() || KIMI_SKILL_RUNNER_PATH,
+    '--plain-prompt-stdin',
+    '--model',
+    model,
+    ...(input.sessionId !== undefined
+      ? [`--session=${validateKimiSessionId(input.sessionId)}`]
+      : []),
+    ...additionalDirArgs,
+  ]
+  const env: Record<string, string | undefined> = {
+    KIMI_CODE_EXPERIMENTAL_FLAG: undefined,
+    KIMI_DISABLE_CRON: '1',
+    KIMI_CODE_NO_AUTO_UPDATE: '1',
+    KIMI_MODEL_THINKING_EFFORT: undefined,
+  }
+  // KIMI_MODEL_THINKING_EFFORT is documented for K3 only. Custom aliases and
+  // other official models must not inherit an unsupported environment knob.
+  if (input.thinkingEffort && model === 'kimi-code/k3') {
+    env.KIMI_MODEL_THINKING_EFFORT = input.thinkingEffort
+  }
+  return { bin: 'node', args, env, prompt, stdinText: prompt }
+}
+
+function buildPlainKimiPrompt(
+  input: KimiInvocationInput,
+  attachments: string[],
+): string {
+  let prompt = requireNonEmpty(input.prompt, 'prompt')
+  if (attachments.length > 0) {
+    prompt += [
+      '',
+      '',
+      'Attached files (absolute paths):',
+      ...attachments.map((attachment) => `- ${attachment}`),
+      '',
+      'Read textual files with ReadFile. For images or other media, use',
+      'ReadMediaFile on the exact path. Kimi prompt mode has no attachment flag.',
+    ].join('\n')
+  }
+  return prompt
+}
+
+function buildKimiSkillInvocation(input: KimiInvocationInput): KimiInvocation {
+  const skill = input.skill!
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(skill)) {
+    throw new InstallerError(`invalid Kimi skill name: ${skill}`, 40)
+  }
+  const model = validateKimiModelId(input.model)
+  const attachments = validateKimiAttachments(input.attachmentPaths ?? [])
+  const additionalDirs = Array.from(
+    new Set([
+      ...(input.additionalDirs ?? []).map((dir) =>
+        canonicalizeAdditionalDirectory(
+          requireNonEmpty(dir, 'additional directory'),
+        ),
+      ),
+      ...attachments.map((attachment) => path.dirname(attachment)),
+    ]),
+  )
+  const args = [
+    input.skillRunnerPath?.trim() || KIMI_SKILL_RUNNER_PATH,
+    '--skill',
+    skill,
+    '--model',
+    model,
+    ...(input.skillArguments !== undefined
+      ? ['--args', input.skillArguments]
+      : []),
+    ...(input.sessionId !== undefined
+      ? [`--session=${validateKimiSessionId(input.sessionId)}`]
+      : []),
+    ...additionalDirs.flatMap((dir) => [
+      '--add-dir',
+      dir,
+    ]),
+    ...(input.prompt?.trim() ? ['--prompt', input.prompt.trim()] : []),
+  ]
+
+  for (const attachment of attachments) {
+    args.push('--attachment', attachment)
+  }
+
+  const env: Record<string, string | undefined> = {
+    KIMI_CODE_EXPERIMENTAL_FLAG: undefined,
+    KIMI_DISABLE_CRON: '1',
+    KIMI_CODE_NO_AUTO_UPDATE: '1',
+    KIMI_MODEL_THINKING_EFFORT: undefined,
+  }
+  if (
+    input.thinkingEffort &&
+    normalizeKimiCliModel(model) === 'kimi-code/k3'
+  ) {
+    env.KIMI_MODEL_THINKING_EFFORT = input.thinkingEffort
+  }
+  return {
+    bin: 'node',
+    args,
+    env,
+    prompt: input.prompt?.trim() ?? '',
+  }
+}
+
+function validateKimiAttachments(attachments: string[]): string[] {
+  return attachments.map((attachment) => {
+    if (!path.isAbsolute(attachment)) {
+      throw new InstallerError(
+        `Kimi attachment paths must be absolute: ${attachment}`,
+        40,
+      )
+    }
+    try {
+      const metadata = lstatSync(attachment)
+      if (!metadata.isFile() || metadata.isSymbolicLink()) {
+        throw new Error('not a regular non-symlink file')
+      }
+      const canonical = realpathSync(attachment)
+      accessSync(canonical, fsConstants.R_OK)
+      return canonical
+    } catch (error) {
+      throw new InstallerError(
+        `Kimi attachment must be a readable regular non-symlink file: ` +
+          `${attachment} (${(error as Error).message})`,
+        40,
+      )
+    }
+  })
+}
+
+function canonicalizeAdditionalDirectory(directory: string): string {
+  const absolute = path.resolve(directory)
+  try {
+    return realpathSync(absolute)
+  } catch {
+    return absolute
+  }
+}
+
+function requireNonEmpty(value: string | undefined, label: string): string {
+  const normalized = value?.trim()
+  if (!normalized) throw new InstallerError(`Kimi ${label} must not be empty`, 40)
+  return normalized
+}
+
+function validateKimiModelId(value: string | undefined): string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > MAX_MODEL_ID_LENGTH ||
+    !SAFE_MODEL_ID.test(value)
+  ) {
+    throw new InstallerError(
+      'Kimi model id must be 1-128 characters and match ' +
+        '[A-Za-z0-9][A-Za-z0-9._/:-]*',
+      40,
+    )
+  }
+  return value
+}
+
+function validateKimiSessionId(value: string | undefined): string {
+  if (!isValidKimiSessionId(value)) {
+    throw new InstallerError(
+      'Kimi session id must be 1-128 characters matching ' +
+        '[A-Za-z0-9._-]+, excluding "." and ".."',
+      40,
+    )
+  }
+  return value
+}
+
+function isValidKimiSessionId(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= MAX_SESSION_ID_LENGTH &&
+    SAFE_SESSION_ID.test(value) &&
+    value !== '.' &&
+    value !== '..'
+  )
+}
+
+export type KimiStreamEvent =
+  | { kind: 'empty' }
+  | { kind: 'invalid'; raw: string }
+  | { kind: 'assistant'; content: string; raw: Record<string, unknown> }
+  | { kind: 'tool'; raw: Record<string, unknown> }
+  | { kind: 'resume_hint'; sessionId: string; raw: Record<string, unknown> }
+  | { kind: 'meta'; raw: Record<string, unknown> }
+  | { kind: 'unknown'; raw: Record<string, unknown> }
+
+/**
+ * Tolerant JSONL parser for Kimi 0.27. Unknown and malformed lines are surfaced
+ * to the caller rather than terminating the run. Kimi emits no structured USD
+ * cost, so this parser intentionally exposes no fabricated cost field.
+ */
+export function parseKimiStreamLine(line: string): KimiStreamEvent {
+  const trimmed = line.trim()
+  if (!trimmed) return { kind: 'empty' }
+  let value: unknown
+  try {
+    value = JSON.parse(trimmed)
+  } catch {
+    return { kind: 'invalid', raw: line }
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return { kind: 'invalid', raw: line }
+  }
+  const raw = value as Record<string, unknown>
+  if (
+    raw.role === 'meta' &&
+    raw.type === 'session.resume_hint' &&
+    isValidKimiSessionId(raw.session_id)
+  ) {
+    return { kind: 'resume_hint', sessionId: raw.session_id, raw }
+  }
+  if (raw.role === 'assistant') {
+    return {
+      kind: 'assistant',
+      content: typeof raw.content === 'string' ? raw.content : '',
+      raw,
+    }
+  }
+  if (raw.role === 'tool') return { kind: 'tool', raw }
+  if (raw.role === 'meta') return { kind: 'meta', raw }
+  return { kind: 'unknown', raw }
+}
+
+/**
+ * Returns a resumable id only when Kimi exited successfully and its final
+ * non-empty JSONL record is a canonical `session.resume_hint`. Kimi may emit a
+ * hint before assigning a non-zero process exit status (for example an
+ * incomplete headless goal), so callers must supply the observed child exit
+ * code rather than treating the record alone as proof of success.
+ */
+export function extractKimiSessionHint(
+  lines: Iterable<string>,
+  exitCode: number | null,
+): string | null {
+  if (exitCode !== 0) return null
+  let terminalEvent: KimiStreamEvent = { kind: 'empty' }
+  for (const line of lines) {
+    const event = parseKimiStreamLine(line)
+    if (event.kind !== 'empty') terminalEvent = event
+  }
+  return terminalEvent.kind === 'resume_hint'
+    ? terminalEvent.sessionId
+    : null
+}

--- a/src/installer/runtime/kimi.ts
+++ b/src/installer/runtime/kimi.ts
@@ -40,11 +40,11 @@ export interface KimiInvocation {
   stdinText?: string
 }
 
-export const KIMI_SKILL_RUNNER_PATH = path.join(
-  '.kimi-code',
-  'specrails',
-  'run-skill.mjs',
-)
+// This is both a Node argv path and a published wire-contract value. Forward
+// slashes are accepted by Node on Windows and keep the contract byte-identical
+// across hosts instead of leaking the build machine's path separator.
+export const KIMI_SKILL_RUNNER_PATH =
+  '.kimi-code/specrails/run-skill.mjs'
 
 const OFFICIAL_SHORT_MODEL_IDS = new Set([
   'k3',

--- a/src/installer/tui-kimi-config.test.ts
+++ b/src/installer/tui-kimi-config.test.ts
@@ -1,0 +1,169 @@
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { execFileSync, spawnSync } from 'node:child_process'
+import os from 'node:os'
+import path from 'node:path'
+
+import yaml from 'js-yaml'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+describe('TUI Kimi default config', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'specrails-tui-kimi-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+  })
+
+  it('renders provider-native k3 identifiers instead of Claude aliases', () => {
+    const binDir = path.join(tmpDir, 'bin')
+    const target = path.join(tmpDir, 'project')
+    const fakeKimi =
+      process.platform === 'win32'
+        ? path.join(binDir, 'kimi.cmd')
+        : path.join(binDir, 'kimi')
+    mkdirSync(binDir, { recursive: true })
+    writeFileSync(
+      fakeKimi,
+      process.platform === 'win32'
+        ? '@echo off\r\necho kimi 0.27.0\r\n'
+        : '#!/bin/sh\nprintf "kimi 0.27.0\\n"\n',
+    )
+    if (process.platform !== 'win32') chmodSync(fakeKimi, 0o755)
+
+    execFileSync(
+      process.execPath,
+      [
+        path.join(process.cwd(), 'bin', 'tui-installer.mjs'),
+        target,
+        '--yes',
+        '--provider',
+        'kimi',
+        '--with-profiles',
+      ],
+      {
+        env: {
+          ...process.env,
+          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+        },
+        stdio: 'pipe',
+      },
+    )
+
+    const raw = readFileSync(
+      path.join(target, '.specrails', 'install-config.yaml'),
+      'utf8',
+    )
+    const config = yaml.load(raw) as {
+      provider: string
+      models: {
+        preset: string
+        defaults: { model: string }
+        overrides: Record<string, string>
+      }
+    }
+    expect(config.provider).toBe('kimi')
+    expect(config.models).toEqual({
+      preset: 'balanced',
+      defaults: { model: 'k3' },
+      overrides: {},
+    })
+    expect(raw).not.toMatch(/\b(?:sonnet|opus|haiku)\b/)
+
+    const profile = JSON.parse(
+      readFileSync(
+        path.join(target, '.specrails', 'profiles', 'kimi-default.json'),
+        'utf8',
+      ),
+    ) as { name: string; provider: string; orchestrator: { model: string } }
+    expect(profile).toMatchObject({
+      name: 'kimi-default',
+      provider: 'kimi',
+      orchestrator: { model: 'k3' },
+    })
+    expect(() =>
+      readFileSync(
+        path.join(target, '.specrails', 'profiles', 'project-default.json'),
+        'utf8',
+      ),
+    ).toThrow()
+  })
+
+  it.each([
+    ['--provider', 'unknown'],
+    ['--provider=unknown'],
+    ['--provider'],
+  ])('rejects an explicit invalid provider instead of opening the picker: %j', (...providerArgs) => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        path.join(process.cwd(), 'bin', 'tui-installer.mjs'),
+        tmpDir,
+        '--yes',
+        ...providerArgs,
+      ],
+      {
+        env: { ...process.env, PATH: '' },
+        encoding: 'utf8',
+      },
+    )
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toMatch(/--provider/)
+    expect(result.stderr).toMatch(/claude, codex, gemini, kimi/)
+  })
+
+  it('bounds a hung provider version probe', () => {
+    const binDir = path.join(tmpDir, 'hung-bin')
+    const target = path.join(tmpDir, 'hung-project')
+    const fakeKimi =
+      process.platform === 'win32'
+        ? path.join(binDir, 'kimi.cmd')
+        : path.join(binDir, 'kimi')
+    mkdirSync(binDir, { recursive: true })
+    writeFileSync(
+      fakeKimi,
+      process.platform === 'win32'
+        ? '@echo off\r\n%SystemRoot%\\System32\\ping.exe -n 20 127.0.0.1 >nul\r\necho kimi 0.27.0\r\n'
+        : '#!/bin/sh\n/bin/sleep 10\nprintf "kimi 0.27.0\\n"\n',
+    )
+    if (process.platform !== 'win32') chmodSync(fakeKimi, 0o755)
+
+    const started = Date.now()
+    const result = spawnSync(
+      process.execPath,
+      [
+        path.join(process.cwd(), 'bin', 'tui-installer.mjs'),
+        target,
+        '--yes',
+        '--provider',
+        'kimi',
+      ],
+      {
+        env: {
+          ...process.env,
+          PATH: binDir,
+          SPECRAILS_PROVIDER_PROBE_TIMEOUT_MS: '100',
+        },
+        encoding: 'utf8',
+        timeout: 5_000,
+      },
+    )
+
+    expect(result.error).toBeUndefined()
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain(
+      '--provider kimi requested but Kimi Code is not installed',
+    )
+    expect(Date.now() - started).toBeLessThan(3_000)
+  })
+})

--- a/src/installer/util/paths.test.ts
+++ b/src/installer/util/paths.test.ts
@@ -15,6 +15,8 @@ describe('paths', () => {
     it('contains the documented reserved prefixes', () => {
       expect(RESERVED_PATHS).toContain('.specrails/profiles/')
       expect(RESERVED_PATHS).toContain('.claude/agents/custom-')
+      expect(RESERVED_PATHS).toContain('.kimi-code/skills/custom-')
+      expect(RESERVED_PATHS).toContain('.kimi-code/skills/rails/custom-')
     })
   })
 
@@ -27,10 +29,21 @@ describe('paths', () => {
     it('matches custom-* agent files', () => {
       expect(isReservedPath('.claude/agents/custom-foo.md')).toBe(true)
       expect(isReservedPath('.claude\\agents\\custom-bar.md')).toBe(true)
+      expect(isReservedPath('.kimi-code/skills/custom-auditor/SKILL.md')).toBe(true)
+      expect(isReservedPath('.kimi-code\\skills\\custom-auditor\\SKILL.md')).toBe(true)
+      expect(isReservedPath('.kimi-code/skills/rails/custom-auditor/SKILL.md')).toBe(true)
+      expect(isReservedPath('.kimi-code\\skills\\rails\\custom-auditor\\SKILL.md')).toBe(true)
     })
 
     it('does not match bundled sr-* agents', () => {
       expect(isReservedPath('.claude/agents/sr-architect.md')).toBe(false)
+      expect(isReservedPath('.kimi-code/skills/sr-architect/SKILL.md')).toBe(false)
+      expect(isReservedPath('.kimi-code/specrails/run-skill.mjs')).toBe(false)
+      expect(
+        isReservedPath(
+          '.kimi-code/specrails/vendor/js-yaml/js-yaml.mjs',
+        ),
+      ).toBe(false)
     })
 
     it('does not match other .specrails subtrees', () => {

--- a/src/installer/util/paths.ts
+++ b/src/installer/util/paths.ts
@@ -22,6 +22,20 @@ export const RESERVED_PATHS = [
    * them.
    */
   '.claude/agents/custom-',
+
+  /**
+   * `.kimi-code/skills/custom-<id>/...` — user-authored Kimi role skills.
+   * Kimi discovers skills only one directory below `skills/`, so custom roles
+   * share the flat namespace with managed `sr-*` and workflow skills.
+   */
+  '.kimi-code/skills/custom-',
+
+  /**
+   * Pre-release compatibility: preserve a legacy nested custom role until the
+   * installer can atomically migrate it to the flat path. A destination
+   * collision is never overwritten or deleted automatically.
+   */
+  '.kimi-code/skills/rails/custom-',
 ] as const
 
 /**

--- a/src/installer/util/registry.test.ts
+++ b/src/installer/util/registry.test.ts
@@ -36,6 +36,34 @@ import {
 
 let home: string
 
+function validEntry(
+  repoPath: string,
+  slug: string,
+  overrides: Partial<ProjectEntry> = {},
+): ProjectEntry {
+  const canon = canonicalizeRepoPath(repoPath)
+  return {
+    ...workspaceLayout(home, slug, canon),
+    providers: ['claude'],
+    primaryProvider: 'claude',
+    source: 'desktop',
+    ...overrides,
+  }
+}
+
+function writeRegistryProjects(projects: Record<string, unknown>): void {
+  writeFileSync(
+    registryPath(home),
+    JSON.stringify({
+      schemaVersion: REGISTRY_SCHEMA_VERSION,
+      generator: 'specrails-desktop@test',
+      updatedAt: '2026-07-20T00:00:00.000Z',
+      projects,
+    }),
+    'utf8',
+  )
+}
+
 beforeEach(() => {
   home = mkdtempSync(path.join(os.tmpdir(), 'specrails-registry-test-'))
   // The `.specrails` dir is created lazily by the module's writers; tests that
@@ -102,6 +130,11 @@ describe('workspaceLayout', () => {
     expect(l.backlogConfigPath).toBe(path.join(l.workspaceDir, '.specrails', 'backlog-config.json'))
     expect(l.profilesDir).toBe(path.join(l.workspaceDir, '.specrails', 'profiles'))
   })
+
+  it('uses the primary provider mutable-state directory for Kimi', () => {
+    const layout = workspaceLayout(home, 'acme', '/repo/acme', 'kimi')
+    expect(layout.stateDir).toBe(path.join(layout.workspaceDir, '.kimi-code'))
+  })
 })
 
 describe('legacyResolution', () => {
@@ -153,12 +186,150 @@ describe('readRegistryOrEmpty (fail-open)', () => {
   })
 
   it('parses a valid registry', () => {
-    writeFileSync(
-      registryPath(home),
-      JSON.stringify({ schemaVersion: 1, projects: { '/x': { slug: 'x' } } }),
-      'utf8',
+    const repo = path.join(home, 'repos', 'desktop-project')
+    mkdirSync(repo, { recursive: true })
+    const key = normalizeKey(canonicalizeRepoPath(repo))
+    const entry = validEntry(repo, 'desktop-project', {
+      // Desktop historically persisted `.claude` as the state base even when
+      // another provider was primary. Subpaths remain writer-owned as long as
+      // they stay inside the verified workspace.
+      providers: ['codex', 'kimi'],
+      primaryProvider: 'codex',
+    }) as ProjectEntry & { updatedAt: string }
+    entry.updatedAt = '2026-07-20T00:00:00.000Z'
+    writeRegistryProjects({ [key]: entry })
+
+    const parsed = readRegistryOrEmpty(home)
+    expect(parsed.projects[key]).toEqual(entry)
+    expect(parsed.generator).toBe('specrails-desktop@test')
+    expect((parsed.projects[key] as ProjectEntry & { updatedAt?: string }).updatedAt).toBe(
+      entry.updatedAt,
     )
-    expect(readRegistryOrEmpty(home).projects['/x']).toBeDefined()
+  })
+
+  it('filters malformed entries individually while preserving a valid Desktop entry', () => {
+    const validRepo = path.join(home, 'repos', 'valid')
+    const invalidRepo = path.join(home, 'repos', 'invalid')
+    mkdirSync(validRepo, { recursive: true })
+    mkdirSync(invalidRepo, { recursive: true })
+    const validKey = normalizeKey(canonicalizeRepoPath(validRepo))
+    const invalidKey = normalizeKey(canonicalizeRepoPath(invalidRepo))
+    const valid = validEntry(validRepo, 'valid')
+    const base = validEntry(invalidRepo, 'invalid')
+    const outside = path.join(home, 'outside')
+
+    const invalidRows: Array<[string, unknown, string]> = [
+      ['null row', null, invalidKey],
+      ['array row', [], invalidKey],
+      ['wrong field type', { ...base, repoPath: 42 }, invalidKey],
+      ['unknown source', { ...base, source: 'attacker' }, invalidKey],
+      ['providers is not an array', { ...base, providers: 'claude' }, invalidKey],
+      ['empty providers', { ...base, providers: [] }, invalidKey],
+      ['unknown provider', { ...base, providers: ['claude', 'unknown'] }, invalidKey],
+      ['duplicate provider', { ...base, providers: ['claude', 'claude'] }, invalidKey],
+      [
+        'primary does not match first provider',
+        { ...base, providers: ['claude', 'kimi'], primaryProvider: 'kimi' },
+        invalidKey,
+      ],
+      ['unsafe slug', { ...base, slug: '../outside' }, invalidKey],
+      ['relative path', { ...base, ticketsPath: 'relative/tickets.json' }, invalidKey],
+      ['NUL path', { ...base, profilesDir: `${base.workspaceDir}\0/escape` }, invalidKey],
+      ['workspace escape', { ...base, workspaceDir: outside }, invalidKey],
+      ['artifact escape', { ...base, artifactRoot: outside }, invalidKey],
+      ['nested path escape', { ...base, ticketsPath: path.join(outside, 'tickets.json') }, invalidKey],
+      ['code root mismatch', { ...base, codeRoot: validRepo }, invalidKey],
+      [
+        'map key mismatch',
+        base,
+        normalizeKey(path.join(home, 'repos', 'different-key')),
+      ],
+    ]
+
+    for (const [label, invalid, storedKey] of invalidRows) {
+      writeRegistryProjects({ [validKey]: valid, [storedKey]: invalid })
+      const parsed = readRegistryOrEmpty(home)
+      expect(Object.keys(parsed.projects), label).toEqual([validKey])
+      expect(parsed.projects[validKey], label).toEqual(valid)
+    }
+  })
+
+  it('filters every entry involved in a duplicate-slug workspace collision', () => {
+    const a = path.join(home, 'repos', 'a')
+    const b = path.join(home, 'repos', 'b')
+    const c = path.join(home, 'repos', 'c')
+    mkdirSync(a, { recursive: true })
+    mkdirSync(b, { recursive: true })
+    mkdirSync(c, { recursive: true })
+    const aKey = normalizeKey(canonicalizeRepoPath(a))
+    const bKey = normalizeKey(canonicalizeRepoPath(b))
+    const cKey = normalizeKey(canonicalizeRepoPath(c))
+    writeRegistryProjects({
+      [aKey]: validEntry(a, 'shared'),
+      [bKey]: validEntry(b, 'shared'),
+      [cKey]: validEntry(c, 'unique'),
+    })
+
+    const parsed = readRegistryOrEmpty(home)
+    expect(parsed.projects[aKey]).toBeUndefined()
+    expect(parsed.projects[bKey]).toBeUndefined()
+    expect(parsed.projects[cKey]).toBeDefined()
+  })
+
+  it('rejects a workspace symlink that escapes its immutable slug root', () => {
+    const repo = path.join(home, 'repos', 'symlink-workspace')
+    mkdirSync(repo, { recursive: true })
+    const key = normalizeKey(canonicalizeRepoPath(repo))
+    const entry = validEntry(repo, 'symlink-workspace')
+    const outside = path.join(home, 'outside-workspace')
+    mkdirSync(path.dirname(entry.workspaceDir), { recursive: true })
+    mkdirSync(outside, { recursive: true })
+    symlinkSync(
+      outside,
+      entry.workspaceDir,
+      process.platform === 'win32' ? 'junction' : 'dir',
+    )
+    writeRegistryProjects({ [key]: entry })
+
+    expect(readRegistryOrEmpty(home).projects).toEqual({})
+  })
+
+  it('rejects a managed projects root symlink that escapes the registry home', () => {
+    const repo = path.join(home, 'repos', 'projects-root-symlink')
+    mkdirSync(repo, { recursive: true })
+    const key = normalizeKey(canonicalizeRepoPath(repo))
+    const entry = validEntry(repo, 'projects-root-symlink')
+    const outside = mkdtempSync(path.join(os.tmpdir(), 'specrails-projects-escape-'))
+    symlinkSync(
+      outside,
+      path.join(home, '.specrails', 'projects'),
+      process.platform === 'win32' ? 'junction' : 'dir',
+    )
+    writeRegistryProjects({ [key]: entry })
+
+    try {
+      expect(readRegistryOrEmpty(home).projects).toEqual({})
+    } finally {
+      rmSync(outside, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a nested symlink that redirects an artifact path outside the workspace', () => {
+    const repo = path.join(home, 'repos', 'nested-symlink')
+    mkdirSync(repo, { recursive: true })
+    const key = normalizeKey(canonicalizeRepoPath(repo))
+    const entry = validEntry(repo, 'nested-symlink')
+    const outside = path.join(home, 'outside-specrails')
+    mkdirSync(entry.workspaceDir, { recursive: true })
+    mkdirSync(outside, { recursive: true })
+    symlinkSync(
+      outside,
+      path.join(entry.workspaceDir, '.specrails'),
+      process.platform === 'win32' ? 'junction' : 'dir',
+    )
+    writeRegistryProjects({ [key]: entry })
+
+    expect(readRegistryOrEmpty(home).projects).toEqual({})
   })
 })
 
@@ -321,5 +492,74 @@ describe('resolveArtifacts', () => {
     expect(entry.desktopProjectId).toBe('uuid-123')
     expect(entry.coreVersion).toBe('4.9.0')
     rmSync(repo, { recursive: true, force: true })
+  })
+
+  it('allocates Kimi state and unions later providers without changing the primary', () => {
+    const repo = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'kimi-registry-')))
+    const first = resolveArtifacts(repo, {
+      home,
+      allocate: true,
+      providers: ['kimi'],
+      now: '2026-01-01T00:00:00.000Z',
+    })
+    expect(first.providers).toEqual(['kimi'])
+    expect(first.primaryProvider).toBe('kimi')
+    expect(first.stateDir).toBe(path.join(first.workspaceDir, '.kimi-code'))
+
+    const second = resolveArtifacts(repo, {
+      home,
+      allocate: true,
+      providers: ['claude'],
+      now: '2026-01-02T00:00:00.000Z',
+    })
+    expect(second.providers).toEqual(['kimi', 'claude'])
+    expect(second.primaryProvider).toBe('kimi')
+    const persisted = readRegistryOrEmpty(home).projects[second.key]!
+    expect(persisted.providers).toEqual(['kimi', 'claude'])
+    rmSync(repo, { recursive: true, force: true })
+  })
+
+  it('never resolves or writes through an invalid registry destination', () => {
+    const repo = path.join(home, 'repos', 'poisoned')
+    mkdirSync(repo, { recursive: true })
+    const key = normalizeKey(canonicalizeRepoPath(repo))
+    const poisoned = validEntry(repo, 'poisoned', {
+      workspaceDir: path.join(home, 'attacker-controlled'),
+      artifactRoot: path.join(home, 'attacker-controlled'),
+    })
+    writeRegistryProjects({ [key]: poisoned })
+
+    const readOnly = resolveArtifacts(repo, { home, allocate: false })
+    expect(readOnly.isLegacy).toBe(true)
+    expect(readOnly.artifactRoot).toBe(canonicalizeRepoPath(repo))
+    expect(existsSync(path.join(home, 'attacker-controlled'))).toBe(false)
+
+    const allocated = resolveArtifacts(repo, {
+      home,
+      allocate: true,
+      providers: ['kimi'],
+    })
+    expect(allocated.isLegacy).toBe(false)
+    expect(allocated.artifactRoot).toBe(
+      path.join(home, '.specrails', 'projects', allocated.slug, 'workspace'),
+    )
+    expect(existsSync(path.join(home, 'attacker-controlled'))).toBe(false)
+    expect(readRegistryOrEmpty(home).projects[key]?.artifactRoot).toBe(
+      allocated.artifactRoot,
+    )
+  })
+
+  it('rejects unsupported providers before persisting a registry entry', () => {
+    const repo = path.join(home, 'repos', 'unsupported-provider')
+    mkdirSync(repo, { recursive: true })
+
+    expect(() =>
+      resolveArtifacts(repo, {
+        home,
+        allocate: true,
+        providers: ['kimi', 'not-a-provider'],
+      }),
+    ).toThrow(/Unsupported registry provider/)
+    expect(existsSync(registryPath(home))).toBe(false)
   })
 })

--- a/src/installer/util/registry.ts
+++ b/src/installer/util/registry.ts
@@ -21,6 +21,7 @@ import {
   closeSync,
   existsSync,
   fsyncSync,
+  lstatSync,
   mkdirSync,
   openSync,
   readFileSync,
@@ -125,6 +126,197 @@ export interface ResolveOptions {
   now?: string
 }
 
+const SUPPORTED_PROVIDERS = new Set(['claude', 'codex', 'gemini', 'kimi'])
+const SAFE_SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+const REQUIRED_ENTRY_PATHS = [
+  'workspaceDir',
+  'artifactRoot',
+  'stateDir',
+  'ticketsPath',
+  'backlogConfigPath',
+  'profilesDir',
+  'pluginsStateDir',
+  'fileSummariesDir',
+] as const satisfies ReadonlyArray<keyof ProjectEntry>
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && !value.includes('\0')
+}
+
+function isOptionalString(value: unknown): boolean {
+  return value === undefined || isNonEmptyString(value)
+}
+
+function isSupportedProvider(value: unknown): boolean {
+  return typeof value === 'string' && SUPPORTED_PROVIDERS.has(value)
+}
+
+function samePath(left: string, right: string): boolean {
+  return normalizeKey(path.resolve(left)) === normalizeKey(path.resolve(right))
+}
+
+function isPathContained(root: string, candidate: string, allowRoot = true): boolean {
+  const relative = path.relative(path.resolve(root), path.resolve(candidate))
+  if (relative === '') return allowRoot
+  return (
+    relative !== '..' &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  )
+}
+
+/**
+ * Resolve every existing prefix while retaining a not-yet-created suffix.
+ * Unlike `realpathSafe`, a dangling symlink or an existing non-directory parent
+ * is invalid: treating either lexically would hide a later filesystem escape.
+ */
+function resolveForContainment(candidate: string): string | undefined {
+  let cursor = path.resolve(candidate)
+  const missingSuffix: string[] = []
+  for (;;) {
+    try {
+      const metadata = lstatSync(cursor)
+      if (missingSuffix.length > 0) {
+        let followed
+        try {
+          followed = statSync(cursor)
+        } catch {
+          return undefined
+        }
+        if (!followed.isDirectory()) return undefined
+      } else if (!metadata.isFile() && !metadata.isDirectory() && !metadata.isSymbolicLink()) {
+        return undefined
+      }
+      let realPrefix: string
+      try {
+        realPrefix = realpathSync(cursor)
+      } catch {
+        return undefined
+      }
+      return path.resolve(realPrefix, ...missingSuffix)
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code
+      if (code !== 'ENOENT' && code !== 'ENOTDIR') return undefined
+      const parent = path.dirname(cursor)
+      if (parent === cursor) return undefined
+      missingSuffix.unshift(path.basename(cursor))
+      cursor = parent
+    }
+  }
+}
+
+function hasValidProviderSet(entry: Record<string, unknown>): boolean {
+  if (!Array.isArray(entry.providers) || entry.providers.length === 0) return false
+  if (!entry.providers.every(isSupportedProvider)) return false
+  if (new Set(entry.providers).size !== entry.providers.length) return false
+  return (
+    isSupportedProvider(entry.primaryProvider) &&
+    entry.primaryProvider === entry.providers[0]
+  )
+}
+
+/**
+ * Validate one untrusted registry row before it can influence resolution or a
+ * subsequent read-modify-write. The registry stores derived subpaths
+ * explicitly so Desktop's layout remains authoritative; Core only requires
+ * that those opaque paths stay lexically and physically inside the immutable
+ * per-slug workspace.
+ */
+function isValidProjectEntry(
+  key: string,
+  value: unknown,
+  home: string | undefined,
+): value is ProjectEntry {
+  if (!isRecord(value)) return false
+  if (
+    !isNonEmptyString(value.repoPath) ||
+    !path.isAbsolute(value.repoPath) ||
+    !isNonEmptyString(value.codeRoot) ||
+    !path.isAbsolute(value.codeRoot) ||
+    !isNonEmptyString(value.slug) ||
+    !SAFE_SLUG.test(value.slug) ||
+    (value.source !== 'desktop' && value.source !== 'core-standalone') ||
+    !hasValidProviderSet(value) ||
+    !isOptionalString(value.coreVersion) ||
+    !isOptionalString(value.createdAt) ||
+    !isOptionalString(value.lastInstallAt) ||
+    !isOptionalString(value.desktopProjectId) ||
+    !isOptionalString(value.updatedAt)
+  ) {
+    return false
+  }
+
+  for (const field of REQUIRED_ENTRY_PATHS) {
+    const candidate = value[field]
+    if (!isNonEmptyString(candidate) || !path.isAbsolute(candidate)) return false
+  }
+  const validatedPaths = value as Record<
+    (typeof REQUIRED_ENTRY_PATHS)[number],
+    string
+  >
+
+  const canonicalRepo = canonicalizeRepoPath(value.repoPath)
+  if (
+    !samePath(value.repoPath, canonicalRepo) ||
+    normalizeKey(canonicalRepo) !== key ||
+    !samePath(value.codeRoot, canonicalRepo) ||
+    !samePath(value.codeRoot, canonicalizeRepoPath(value.codeRoot))
+  ) {
+    return false
+  }
+
+  const lexicalHome = path.resolve(resolveHome(home))
+  const lexicalSpecrailsRoot = path.join(lexicalHome, '.specrails')
+  const lexicalProjectsRoot = path.join(lexicalSpecrailsRoot, 'projects')
+  const lexicalWorkspace = path.join(
+    lexicalProjectsRoot,
+    value.slug,
+    'workspace',
+  )
+  if (
+    !samePath(validatedPaths.workspaceDir, lexicalWorkspace) ||
+    !samePath(validatedPaths.artifactRoot, lexicalWorkspace)
+  ) {
+    return false
+  }
+
+  const realHome = resolveForContainment(lexicalHome)
+  const realSpecrailsRoot = resolveForContainment(lexicalSpecrailsRoot)
+  const realProjectsRoot = resolveForContainment(lexicalProjectsRoot)
+  const realWorkspace = resolveForContainment(lexicalWorkspace)
+  if (
+    realHome === undefined ||
+    realSpecrailsRoot === undefined ||
+    realProjectsRoot === undefined ||
+    realWorkspace === undefined ||
+    !isPathContained(realHome, realSpecrailsRoot, false) ||
+    !samePath(realProjectsRoot, path.join(realSpecrailsRoot, 'projects')) ||
+    !samePath(
+      realWorkspace,
+      path.join(realProjectsRoot, value.slug, 'workspace'),
+    )
+  ) {
+    return false
+  }
+
+  for (const field of REQUIRED_ENTRY_PATHS) {
+    const candidate = validatedPaths[field]
+    const realCandidate = resolveForContainment(candidate)
+    if (
+      !isPathContained(lexicalWorkspace, candidate) ||
+      realCandidate === undefined ||
+      !isPathContained(realWorkspace, realCandidate)
+    ) {
+      return false
+    }
+  }
+  return true
+}
+
 /**
  * Slug derivation — byte-identical to specrails-desktop's `slugify`
  * (`server/desktop-router.ts`). Do not "improve" it; parity is the contract.
@@ -187,7 +379,12 @@ export function canonicalizeRepoPath(repoPathInput: string): string {
 
 /** The per-project sub-path layout under a workspace dir. Single source of the
  *  layout so writer and (allocation) reader never disagree. */
-export function workspaceLayout(home: string, slug: string, canon: string): Omit<
+export function workspaceLayout(
+  home: string,
+  slug: string,
+  canon: string,
+  primaryProvider: string = 'claude',
+): Omit<
   ProjectEntry,
   'providers' | 'primaryProvider' | 'coreVersion' | 'createdAt' | 'lastInstallAt' | 'source' | 'desktopProjectId'
 > {
@@ -199,13 +396,20 @@ export function workspaceLayout(home: string, slug: string, canon: string): Omit
     workspaceDir,
     artifactRoot: workspaceDir,
     codeRoot: canon,
-    stateDir: path.join(workspaceDir, '.claude'),
+    stateDir: path.join(workspaceDir, providerStateDirectory(primaryProvider)),
     ticketsPath: path.join(specrailsDir, 'local-tickets.json'),
     backlogConfigPath: path.join(specrailsDir, 'backlog-config.json'),
     profilesDir: path.join(specrailsDir, 'profiles'),
     pluginsStateDir: path.join(specrailsDir, 'plugins'),
     fileSummariesDir: path.join(specrailsDir, 'file-summaries'),
   }
+}
+
+function providerStateDirectory(provider: string): string {
+  if (provider === 'codex') return '.codex'
+  if (provider === 'gemini') return '.gemini'
+  if (provider === 'kimi') return '.kimi-code'
+  return '.claude'
 }
 
 /** The in-repo layout, used when there is no registry entry (legacy fallback). */
@@ -265,18 +469,37 @@ export function readRegistryOrEmpty(home?: string): RegistryFile {
   const p = registryPath(home)
   if (!existsSync(p)) return empty
   try {
-    const parsed = JSON.parse(readFileSync(p, 'utf8')) as RegistryFile
+    const parsed = JSON.parse(readFileSync(p, 'utf8')) as unknown
     if (
-      !parsed ||
-      typeof parsed !== 'object' ||
-      typeof parsed.schemaVersion !== 'number' ||
-      parsed.schemaVersion > REGISTRY_SCHEMA_VERSION ||
-      typeof parsed.projects !== 'object' ||
-      parsed.projects === null
+      !isRecord(parsed) ||
+      parsed.schemaVersion !== REGISTRY_SCHEMA_VERSION ||
+      !isRecord(parsed.projects)
     ) {
       return empty
     }
-    return parsed
+
+    const candidates: Array<[string, ProjectEntry]> = []
+    const slugCounts = new Map<string, number>()
+    for (const [key, entry] of Object.entries(parsed.projects)) {
+      if (!isValidProjectEntry(key, entry, home)) continue
+      candidates.push([key, entry])
+      slugCounts.set(entry.slug, (slugCounts.get(entry.slug) ?? 0) + 1)
+    }
+
+    const projects: Record<string, ProjectEntry> = {}
+    for (const [key, entry] of candidates) {
+      // Two repos must never resolve to the same writable workspace. Treat
+      // every side of an ambiguous slug as absent instead of choosing a winner.
+      if (slugCounts.get(entry.slug) === 1) projects[key] = entry
+    }
+
+    const result: RegistryFile = {
+      schemaVersion: REGISTRY_SCHEMA_VERSION,
+      projects,
+    }
+    if (typeof parsed.generator === 'string') result.generator = parsed.generator
+    if (typeof parsed.updatedAt === 'string') result.updatedAt = parsed.updatedAt
+    return result
   } catch {
     return empty
   }
@@ -403,9 +626,9 @@ function buildEntry(
   slug: string,
   opts: ResolveOptions,
 ): ProjectEntry {
-  const providers = opts.providers && opts.providers.length > 0 ? opts.providers : ['claude']
+  const providers = validateProvidersForWrite(opts.providers, true)
   const now = opts.now ?? new Date().toISOString()
-  const layout = workspaceLayout(home, slug, canon)
+  const layout = workspaceLayout(home, slug, canon, providers[0])
   const entry: ProjectEntry = {
     ...layout,
     providers,
@@ -419,6 +642,21 @@ function buildEntry(
   return entry
 }
 
+function validateProvidersForWrite(
+  providers: string[] | undefined,
+  useDefault: boolean,
+): string[] {
+  if (providers === undefined || providers.length === 0) {
+    return useDefault ? ['claude'] : []
+  }
+  if (!providers.every(isSupportedProvider)) {
+    throw new Error(
+      `Unsupported registry provider: ${providers.find((provider) => !isSupportedProvider(provider)) ?? ''}`,
+    )
+  }
+  return [...new Set(providers)]
+}
+
 /**
  * The shared resolver both tools run. Given a repo path, returns where that
  * repo's artifacts live. With `allocate:true`, creates + persists an entry when
@@ -429,11 +667,31 @@ export function resolveArtifacts(repoPathInput: string, opts: ResolveOptions = {
   const home = opts.home
   const canon = canonicalizeRepoPath(repoPathInput)
   const key = normalizeKey(canon)
+  const requestedProviders = validateProvidersForWrite(opts.providers, false)
 
   // Fast path: lock-free read for a pure lookup.
   const reg = readRegistryOrEmpty(home)
   const existing = reg.projects[key]
-  if (existing) return entryToResolution(key, existing)
+  if (existing) {
+    const needsProviderMerge =
+      opts.allocate === true &&
+      existing.source === 'core-standalone' &&
+      requestedProviders.some((provider) => !existing.providers.includes(provider))
+    if (!needsProviderMerge) return entryToResolution(key, existing)
+    return withFileLock(home, () => {
+      const fresh = readRegistryOrEmpty(home)
+      const current = fresh.projects[key]
+      if (!current) return legacyResolution(canon)
+      const providers = [...new Set([...current.providers, ...requestedProviders])]
+      current.providers = providers
+      current.primaryProvider = current.primaryProvider || providers[0] || 'claude'
+      current.lastInstallAt = opts.now ?? new Date().toISOString()
+      if (opts.coreVersion) current.coreVersion = opts.coreVersion
+      fresh.updatedAt = current.lastInstallAt
+      atomicWrite(registryPath(home), JSON.stringify(fresh, null, 2) + '\n')
+      return entryToResolution(key, current)
+    })
+  }
 
   if (!opts.allocate) return legacyResolution(canon)
 

--- a/templates/kimi/specrails/run-skill.mjs
+++ b/templates/kimi/specrails/run-skill.mjs
@@ -891,10 +891,32 @@ export function prepareSkillLaunch(options, dependencies = {}) {
 
 function canonicalizeExistingPath(value) {
   try {
-    return realpathSync(value)
+    return canonicalRealpath(value)
   } catch {
     return path.resolve(value)
   }
+}
+
+/**
+ * Node's legacy realpath implementation can preserve an input's Windows 8.3
+ * spelling while Git reports the same directory with its long name (or vice
+ * versa). Use the native resolver and a case-folded identity for comparisons;
+ * callers still lstat the recomputed managed path so a symlink alias cannot
+ * satisfy an ownership check.
+ */
+function canonicalRealpath(value) {
+  const resolved =
+    typeof realpathSync.native === 'function'
+      ? realpathSync.native(value)
+      : realpathSync(value)
+  return path.resolve(resolved)
+}
+
+function existingPathIdentity(value) {
+  const canonical = canonicalRealpath(value)
+  return process.platform === 'win32'
+    ? canonical.toLowerCase()
+    : canonical
 }
 
 function validateAttachmentPaths(attachmentPaths = [], dependencies = {}) {
@@ -1009,19 +1031,23 @@ export function resolveKimiLaunch(kimiArgs, options = {}) {
 }
 
 export function materializeRoleWaveWorkspaces(wave, options = {}) {
-  const initialCwd = realpathSync(options.cwd ?? process.cwd())
+  const initialCwd = canonicalRealpath(options.cwd ?? process.cwd())
   const git = options.spawnSync ?? spawnSync
   const gitBinary = options.gitBinary ?? 'git'
   const tempRoot = ensureManagedTempRoot(options.tempRoot ?? os.tmpdir())
-  const providerRoot = realpathSync(options.providerRoot)
+  const providerRoot = canonicalRealpath(options.providerRoot)
   const runGit = (cwd, args, input, extraEnv = {}) => {
-    const result = git(gitBinary, ['-C', cwd, ...args], {
-      encoding: 'utf8',
-      env: { ...process.env, ...extraEnv },
-      input,
-      maxBuffer: 256 * 1024 * 1024,
-      shell: false,
-    })
+    const result = git(
+      gitBinary,
+      ['-C', cwd, '-c', 'core.autocrlf=false', ...args],
+      {
+        encoding: 'utf8',
+        env: { ...process.env, ...extraEnv },
+        input,
+        maxBuffer: 256 * 1024 * 1024,
+        shell: false,
+      },
+    )
     if (result.error || result.status !== 0) {
       const detail =
         errorMessage(result.error ?? '').trim() ||
@@ -1034,7 +1060,7 @@ export function materializeRoleWaveWorkspaces(wave, options = {}) {
     return String(result.stdout ?? '')
   }
 
-  const baseRepo = realpathSync(
+  const baseRepo = canonicalRealpath(
     runGit(initialCwd, ['rev-parse', '--show-toplevel']).trim(),
   )
   const manifestPath = path.join(
@@ -1052,7 +1078,8 @@ export function materializeRoleWaveWorkspaces(wave, options = {}) {
     existingManifest &&
     (
       existingManifest.run !== wave.run ||
-      realpathSync(existingManifest.baseRepo) !== baseRepo
+      existingPathIdentity(existingManifest.baseRepo) !==
+        existingPathIdentity(baseRepo)
     )
   ) {
     throw new RunnerUsageError(
@@ -1175,7 +1202,7 @@ export function materializeRoleWaveWorkspaces(wave, options = {}) {
         )
       }
       const registeredTarget = existsSync(target)
-        ? realpathSync(target)
+        ? existingPathIdentity(target)
         : path.resolve(target)
       if (!listed.has(registeredTarget)) {
         if (existsSync(target)) {
@@ -1266,7 +1293,7 @@ function parseGitWorktreeList(source) {
       const candidate = field.slice('worktree '.length)
       paths.add(
         existsSync(candidate)
-          ? realpathSync(candidate)
+          ? existingPathIdentity(candidate)
           : path.resolve(candidate),
       )
     }
@@ -1438,7 +1465,7 @@ function assertManagedPathParents(root, file, label) {
 
 function ensureRealDirectoryTree(root, directory) {
   const lexicalRoot = path.resolve(root)
-  const absoluteRoot = realpathSync(lexicalRoot)
+  const absoluteRoot = canonicalRealpath(lexicalRoot)
   const lexicalTarget = path.resolve(directory)
   const relative = path.relative(lexicalRoot, lexicalTarget)
   if (
@@ -1475,12 +1502,12 @@ function ensureManagedTempRoot(candidate) {
         `Managed temp root must be a real directory: ${absolute}`,
       )
     }
-    return realpathSync(absolute)
+    return canonicalRealpath(absolute)
   }
   const parent = path.dirname(absolute)
-  const realParent = realpathSync(parent)
+  const realParent = canonicalRealpath(parent)
   ensureRealDirectoryTree(realParent, path.join(realParent, path.basename(absolute)))
-  return realpathSync(path.join(realParent, path.basename(absolute)))
+  return canonicalRealpath(path.join(realParent, path.basename(absolute)))
 }
 
 export function ensureProviderOverlay(
@@ -1492,7 +1519,7 @@ export function ensureProviderOverlay(
   const createLink = dependencies.symlink ?? symlinkSync
   const copyTree = dependencies.copyTree ?? cpSync
   const removeTree = dependencies.removeTree ?? rmSync
-  const expectedRoot = realpathSync(providerRoot)
+  const expectedRoot = canonicalRealpath(providerRoot)
   const contentSha256 = hashManagedDirectoryTree(expectedRoot)
   const markerValue = {
     schemaVersion: 2,
@@ -1506,7 +1533,10 @@ export function ensureProviderOverlay(
   if (existsSync(destination)) {
     const destinationMetadata = lstatSync(destination)
     if (destinationMetadata.isSymbolicLink()) {
-      if (realpathSync(destination) !== expectedRoot) {
+      if (
+        existingPathIdentity(destination) !==
+        existingPathIdentity(expectedRoot)
+      ) {
         throw new RunnerUsageError(
           `Worktree provider link does not target the managed provider: ${destination}`,
         )
@@ -2004,7 +2034,7 @@ function resolveRoleWaveState(
     nonEmptyString(sourceEnv.SPECRAILS_REPO_DIR) ??
     dependencies.cwd ??
     process.cwd()
-  const baseRepo = realpathSync(
+  const baseRepo = canonicalRealpath(
     runRoleGit(cwd, ['rev-parse', '--show-toplevel'], dependencies).trim(),
   )
   const manifestPath = path.join(
@@ -2017,7 +2047,8 @@ function resolveRoleWaveState(
   if (
     manifest === undefined ||
     manifest.run !== run ||
-    realpathSync(manifest.baseRepo) !== baseRepo ||
+    existingPathIdentity(manifest.baseRepo) !==
+      existingPathIdentity(baseRepo) ||
     (options.requireIsolated && manifest.baseCommit === null)
   ) {
     throw new RunnerUsageError(
@@ -2067,7 +2098,8 @@ function resolveRoleWaveState(
 function validateRoleWaveManifestIntegrity(manifest, context) {
   if (
     manifest.run !== context.run ||
-    path.resolve(manifest.baseRepo) !== context.baseRepo
+    existingPathIdentity(manifest.baseRepo) !==
+      existingPathIdentity(context.baseRepo)
   ) {
     throw new RunnerUsageError(
       `Role wave manifest identity mismatch for ${context.run}`,
@@ -2130,8 +2162,9 @@ function validateRoleWaveManifestIntegrity(manifest, context) {
     }
     if (
       !existsSync(expected) ||
-      realpathSync(expected) !== expected ||
-      !context.registered.has(expected)
+      lstatSync(expected).isSymbolicLink() ||
+      !lstatSync(expected).isDirectory() ||
+      !context.registered.has(existingPathIdentity(expected))
     ) {
       throw new RunnerUsageError(
         `Role wave worktree is not the expected registered path: ${worktree}`,
@@ -2196,13 +2229,17 @@ function validateRoleWaveManifestIntegrity(manifest, context) {
 function runRoleGit(cwd, args, dependencies = {}, input) {
   const command = dependencies.gitBinary ?? 'git'
   const execute = dependencies.spawnSync ?? spawnSync
-  const result = execute(command, ['-C', cwd, ...args], {
-    encoding: 'utf8',
-    env: { ...process.env, ...(dependencies.env ?? {}) },
-    input,
-    maxBuffer: 256 * 1024 * 1024,
-    shell: false,
-  })
+  const result = execute(
+    command,
+    ['-C', cwd, '-c', 'core.autocrlf=false', ...args],
+    {
+      encoding: 'utf8',
+      env: { ...process.env, ...(dependencies.env ?? {}) },
+      input,
+      maxBuffer: 256 * 1024 * 1024,
+      shell: false,
+    },
+  )
   if (result.error || result.status !== 0) {
     const detail =
       errorMessage(result.error ?? '').trim() ||
@@ -2439,9 +2476,11 @@ async function runRoleWave(wave, dependencies) {
                         `${role.profile}.json`,
                       ),
                     }),
-                GIT_CONFIG_COUNT: '1',
+                GIT_CONFIG_COUNT: '2',
                 GIT_CONFIG_KEY_0: 'core.excludesFile',
                 GIT_CONFIG_VALUE_0: role.gitExcludeFile,
+                GIT_CONFIG_KEY_1: 'core.autocrlf',
+                GIT_CONFIG_VALUE_1: 'false',
               },
               captureRoleKey: role.key,
               writeOutput,

--- a/templates/kimi/specrails/run-skill.mjs
+++ b/templates/kimi/specrails/run-skill.mjs
@@ -1,0 +1,2966 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto'
+import { spawn, spawnSync } from 'node:child_process'
+import {
+  accessSync,
+  copyFileSync,
+  cpSync,
+  chmodSync,
+  constants as fsConstants,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { StringDecoder } from 'node:string_decoder'
+import { fileURLToPath } from 'node:url'
+
+import { load as loadYaml } from './vendor/js-yaml/js-yaml.mjs'
+
+const SAFE_SKILL_ID = /^[a-z0-9][a-z0-9-]*$/
+const SAFE_MODEL_ID = /^[A-Za-z0-9][A-Za-z0-9._/:-]*$/
+const SAFE_SESSION_ID = /^[A-Za-z0-9._-]+$/
+const SAFE_WAVE_ID = /^[a-z0-9][a-z0-9-]{0,63}$/
+const SAFE_GIT_OID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/
+const MAX_MODEL_ID_LENGTH = 128
+const MAX_SESSION_ID_LENGTH = 128
+const MAX_ROLE_REQUEST_BYTES = 1_048_576
+const MAX_ROLE_WAVE_SIZE = 32
+const ROLE_REQUEST_RELATIVE_PATH = path.join(
+  '.specrails',
+  'kimi-role-request.json',
+)
+const ROLE_WAVE_RELATIVE_PATH = path.join(
+  '.specrails',
+  'kimi-role-wave.json',
+)
+const ROLE_MERGE_RELATIVE_PATH = path.join(
+  '.specrails',
+  'kimi-role-merge.json',
+)
+const ROLE_WORKTREE_MANIFEST_DIR = path.join(
+  '.specrails',
+  'kimi-role-worktrees',
+)
+const WINDOWS_COMMAND_LINE_BUDGET = 30_000
+const MAX_MANAGED_PROMPT_BYTES = 1_048_576
+const PLAIN_PROMPT_STDIN_FLAG = '--plain-prompt-stdin'
+export const WINDOWS_PROMPT_STDIN_TOKEN =
+  '__SPECRAILS_KIMI_PROMPT_FROM_STDIN__'
+export const WINDOWS_NPM_STDIN_BOOTSTRAP = [
+  "const {readFileSync}=require('node:fs');",
+  "const {pathToFileURL}=require('node:url');",
+  '(async()=>{',
+  'const entry=process.argv[1];',
+  `const marker=${JSON.stringify(WINDOWS_PROMPT_STDIN_TOKEN)};`,
+  "const promptFlag=process.argv.lastIndexOf('-p');",
+  'const index=promptFlag+1;',
+  "if(promptFlag<2||process.argv[index]!==marker)throw new Error('SpecRails Kimi prompt marker missing');",
+  "process.argv[index]=readFileSync(0,'utf8');",
+  'await import(pathToFileURL(entry).href);',
+  "})().catch(error=>{console.error(error);process.exitCode=1})",
+].join('')
+const KNOWN_SKILL_TYPES = new Set(['prompt', 'inline', 'flow', 'reference'])
+const OFFICIAL_SHORT_MODEL_IDS = new Set([
+  'k3',
+  'kimi-for-coding',
+  'kimi-for-coding-highspeed',
+])
+
+const VALUE_FLAGS = new Set([
+  '--skill',
+  '--model',
+  '--args',
+  '--session',
+  '--add-dir',
+  '--attachment',
+  '--prompt',
+  '--request-file',
+  '--role-wave-file',
+  '--role-wave-status',
+  '--role-wave-cleanup',
+  '--role-merge-file',
+])
+
+export class RunnerUsageError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'RunnerUsageError'
+  }
+}
+
+export function normalizeKimiCliModel(model) {
+  const value = requireSafeModelId(model)
+  return OFFICIAL_SHORT_MODEL_IDS.has(value) ? `kimi-code/${value}` : value
+}
+
+export function tokenizeSkillArguments(raw) {
+  const out = []
+  let current = ''
+  let quote
+  let hasContent = false
+
+  for (const char of raw) {
+    if (quote !== undefined) {
+      if (char === quote) {
+        quote = undefined
+      } else {
+        current += char
+        hasContent = true
+      }
+      continue
+    }
+    if (char === '"' || char === "'") {
+      quote = char
+      hasContent = true
+      continue
+    }
+    if (/\s/.test(char)) {
+      if (hasContent) {
+        out.push(current)
+        current = ''
+        hasContent = false
+      }
+      continue
+    }
+    current += char
+    hasContent = true
+  }
+
+  if (hasContent) out.push(current)
+  return out
+}
+
+export function expandSkillParameters(body, rawArgs, context) {
+  const tokens = tokenizeSkillArguments(rawArgs)
+  let content = body
+
+  for (let index = 0; index < (context.argumentNames?.length ?? 0); index++) {
+    const name = context.argumentNames[index]
+    if (name === undefined) continue
+    const escaped = escapeRegExp(name)
+    content = content.replace(
+      new RegExp(`\\$${escaped}(?![\\[\\w])`, 'g'),
+      escapeXmlTags(tokens[index] ?? ''),
+    )
+  }
+
+  content = content
+    .replace(/\$ARGUMENTS\[(\d+)\]/g, (_match, indexText) => {
+      const index = Number.parseInt(indexText, 10)
+      return escapeXmlTags(tokens[index] ?? '')
+    })
+    .replace(/\$(\d+)(?!\w)/g, (_match, indexText) => {
+      const index = Number.parseInt(indexText, 10)
+      return escapeXmlTags(tokens[index] ?? '')
+    })
+    .split('$ARGUMENTS')
+    .join(escapeXmlTags(rawArgs))
+
+  const hasArgumentPlaceholder = content !== body
+  content = content
+    .split('${KIMI_SKILL_DIR}')
+    .join(context.skillDir)
+    .split('${KIMI_SESSION_ID}')
+    .join(context.sessionId ?? '')
+
+  if (!hasArgumentPlaceholder && rawArgs.length > 0) {
+    return `${content}\n\nARGUMENTS: ${escapeXmlTags(rawArgs)}`
+  }
+  return content
+}
+
+export function renderUserSlashSkillPrompt(input) {
+  return [
+    `User activated the skill "${escapeXml(input.skillName)}". Follow the loaded skill instructions.`,
+    '',
+    `<kimi-skill-loaded name="${escapeXml(input.skillName)}" trigger="user-slash" source="project" dir="${escapeXml(input.skillDir)}" args="${escapeXml(input.skillArgs)}">`,
+    input.skillContent,
+    '</kimi-skill-loaded>',
+  ].join('\n')
+}
+
+export function parseSkillDocument(text, options = {}) {
+  const lines = text.split(/\r?\n/)
+  if (lines[0]?.trim() !== '---') {
+    throw new RunnerUsageError(
+      `Skill ${options.skillId ?? ''} is missing required frontmatter`.trim(),
+    )
+  }
+  const close = lines.findIndex((line, index) => index > 0 && line.trim() === '---')
+  if (close === -1) {
+    throw new RunnerUsageError(
+      `Skill ${options.skillId ?? ''} has no closing frontmatter fence`.trim(),
+    )
+  }
+
+  const yamlText = lines.slice(1, close).join('\n').trim()
+  let frontmatter
+  try {
+    frontmatter = yamlText === '' ? {} : (loadYaml(yamlText) ?? {})
+  } catch (error) {
+    throw new RunnerUsageError(
+      `Invalid frontmatter in skill ${options.skillId ?? ''}: ${errorMessage(error)}`.trim(),
+    )
+  }
+  if (!isRecord(frontmatter)) {
+    throw new RunnerUsageError(
+      `Frontmatter in skill ${options.skillId ?? ''} must be a mapping`.trim(),
+    )
+  }
+
+  const name = nonEmptyString(frontmatter.name)
+  const description = nonEmptyString(frontmatter.description)
+  const hasType = Object.prototype.hasOwnProperty.call(frontmatter, 'type')
+  if (
+    hasType &&
+    (typeof frontmatter.type !== 'string' || frontmatter.type.trim() === '')
+  ) {
+    throw new RunnerUsageError(
+      `Skill ${options.skillId ?? ''} has an invalid type`.trim(),
+    )
+  }
+  const type = nonEmptyString(frontmatter.type)
+  if (name === undefined) {
+    throw new RunnerUsageError(`Skill ${options.skillId ?? ''} has no valid name`.trim())
+  }
+  if (description === undefined) {
+    throw new RunnerUsageError(
+      `Skill ${options.skillId ?? ''} has no valid description`.trim(),
+    )
+  }
+  if (type !== undefined && !KNOWN_SKILL_TYPES.has(type)) {
+    throw new RunnerUsageError(`Skill "${name}" has unsupported type "${type}"`)
+  }
+  if (type === 'reference') {
+    throw new RunnerUsageError(
+      `Skill "${name}" has type "reference" and cannot be activated by the user`,
+    )
+  }
+
+  return {
+    name,
+    description,
+    type,
+    argumentNames: skillArgumentNames(frontmatter.arguments),
+    body: lines.slice(close + 1).join('\n').trim(),
+  }
+}
+
+export function parseRunnerArgs(argv) {
+  const parsed = {
+    skill: undefined,
+    model: undefined,
+    rawArgs: '',
+    sessionId: undefined,
+    additionalDirs: [],
+    attachmentPaths: [],
+    extraPrompt: undefined,
+    requestFile: undefined,
+    roleWaveFile: undefined,
+    roleWaveStatus: undefined,
+    roleWaveCleanup: undefined,
+    roleMergeFile: undefined,
+    plainPromptStdin: false,
+  }
+  let positionalArgs
+  const seenSingleValueFlags = new Set()
+
+  for (let index = 0; index < argv.length; index++) {
+    const token = argv[index]
+    if (token === '--') {
+      positionalArgs = argv.slice(index + 1).join(' ')
+      break
+    }
+    if (token.startsWith('--session=')) {
+      if (seenSingleValueFlags.has('--session')) {
+        throw new RunnerUsageError('--session may be supplied once')
+      }
+      const value = token.slice('--session='.length)
+      assertNoNul(value, '--session')
+      seenSingleValueFlags.add('--session')
+      parsed.sessionId = value
+      continue
+    }
+    if (token === PLAIN_PROMPT_STDIN_FLAG) {
+      if (parsed.plainPromptStdin) {
+        throw new RunnerUsageError(
+          `${PLAIN_PROMPT_STDIN_FLAG} may be supplied once`,
+        )
+      }
+      parsed.plainPromptStdin = true
+      continue
+    }
+    if (!VALUE_FLAGS.has(token)) {
+      throw new RunnerUsageError(`Unknown option: ${token}`)
+    }
+    if (index + 1 >= argv.length) {
+      throw new RunnerUsageError(`${token} requires a value`)
+    }
+    const value = argv[++index]
+    assertNoNul(value, token)
+    if (token === '--add-dir') {
+      parsed.additionalDirs.push(path.resolve(requireNonEmpty(value, token)))
+    } else if (token === '--attachment') {
+      if (!path.isAbsolute(value)) {
+        throw new RunnerUsageError(`Attachment path must be absolute: ${value}`)
+      }
+      parsed.attachmentPaths.push(value)
+    } else {
+      if (seenSingleValueFlags.has(token)) {
+        throw new RunnerUsageError(`${token} may be supplied once`)
+      }
+      seenSingleValueFlags.add(token)
+      if (token === '--skill') {
+        parsed.skill = value
+      } else if (token === '--model') {
+        parsed.model = value
+      } else if (token === '--args') {
+        parsed.rawArgs = value
+      } else if (token === '--session') {
+        parsed.sessionId = value
+      } else if (token === '--prompt') {
+        parsed.extraPrompt = value
+      } else if (token === '--request-file') {
+        parsed.requestFile = value
+      } else if (token === '--role-wave-file') {
+        parsed.roleWaveFile = value
+      } else if (token === '--role-wave-status') {
+        parsed.roleWaveStatus = value
+      } else if (token === '--role-wave-cleanup') {
+        parsed.roleWaveCleanup = value
+      } else if (token === '--role-merge-file') {
+        parsed.roleMergeFile = value
+      }
+    }
+  }
+
+  if (positionalArgs !== undefined) {
+    if (seenSingleValueFlags.has('--args')) {
+      throw new RunnerUsageError('Use either --args or positional arguments after --, not both')
+    }
+    parsed.rawArgs = positionalArgs
+  }
+
+  if (
+    parsed.requestFile !== undefined ||
+    parsed.roleWaveFile !== undefined ||
+    parsed.roleWaveStatus !== undefined ||
+    parsed.roleWaveCleanup !== undefined ||
+    parsed.roleMergeFile !== undefined
+  ) {
+    const modes = [
+      parsed.requestFile !== undefined,
+      parsed.roleWaveFile !== undefined,
+      parsed.roleWaveStatus !== undefined,
+      parsed.roleWaveCleanup !== undefined,
+      parsed.roleMergeFile !== undefined,
+    ].filter(Boolean).length
+    if (modes !== 1) {
+      throw new RunnerUsageError(
+        'Use only one request, role-wave, status, or merge mode',
+      )
+    }
+    const requestFlag =
+      parsed.roleWaveFile !== undefined
+        ? '--role-wave-file'
+        : parsed.roleWaveStatus !== undefined
+          ? '--role-wave-status'
+          : parsed.roleWaveCleanup !== undefined
+            ? '--role-wave-cleanup'
+          : parsed.roleMergeFile !== undefined
+            ? '--role-merge-file'
+            : '--request-file'
+    for (const flag of [
+      '--skill',
+      '--model',
+      '--args',
+      '--session',
+      '--prompt',
+    ]) {
+      if (seenSingleValueFlags.has(flag)) {
+        throw new RunnerUsageError(
+          `${requestFlag} cannot be combined with ${flag}`,
+        )
+      }
+    }
+    if (positionalArgs !== undefined) {
+      throw new RunnerUsageError(
+        `${requestFlag} cannot be combined with positional arguments`,
+      )
+    }
+    if (parsed.plainPromptStdin) {
+      throw new RunnerUsageError(
+        `${requestFlag} cannot be combined with ${PLAIN_PROMPT_STDIN_FLAG}`,
+      )
+    }
+    if (parsed.requestFile !== undefined) {
+      parsed.requestFile = requireNonEmpty(
+        parsed.requestFile,
+        'request file',
+      )
+    } else if (parsed.roleWaveFile !== undefined) {
+      parsed.roleWaveFile = requireNonEmpty(
+        parsed.roleWaveFile,
+        'role wave file',
+      )
+    } else if (parsed.roleWaveStatus !== undefined) {
+      parsed.roleWaveStatus = requireSafeWaveId(
+        parsed.roleWaveStatus,
+        'role wave status run',
+      )
+    } else if (parsed.roleWaveCleanup !== undefined) {
+      parsed.roleWaveCleanup = requireSafeWaveId(
+        parsed.roleWaveCleanup,
+        'role wave cleanup run',
+      )
+    } else {
+      parsed.roleMergeFile = requireNonEmpty(
+        parsed.roleMergeFile,
+        'role merge file',
+      )
+    }
+  } else if (parsed.plainPromptStdin) {
+    for (const flag of ['--skill', '--args', '--prompt', '--attachment']) {
+      if (
+        seenSingleValueFlags.has(flag) ||
+        (flag === '--attachment' && parsed.attachmentPaths.length > 0)
+      ) {
+        throw new RunnerUsageError(
+          `${PLAIN_PROMPT_STDIN_FLAG} cannot be combined with ${flag}`,
+        )
+      }
+    }
+    if (positionalArgs !== undefined) {
+      throw new RunnerUsageError(
+        `${PLAIN_PROMPT_STDIN_FLAG} cannot be combined with positional arguments`,
+      )
+    }
+    parsed.model = requireSafeModelId(parsed.model)
+    if (parsed.sessionId !== undefined) {
+      parsed.sessionId = requireSafeSessionId(parsed.sessionId)
+    }
+  } else {
+    parsed.skill = requireSafeSkillId(parsed.skill)
+    parsed.model = requireSafeModelId(parsed.model)
+    parsed.rawArgs = parsed.rawArgs.trim()
+    if (parsed.sessionId !== undefined) {
+      parsed.sessionId = requireSafeSessionId(parsed.sessionId)
+    }
+  }
+  return parsed
+}
+
+export function loadRoleRequest(parsed, cwd) {
+  if (parsed.requestFile === undefined) return parsed
+  const requestPath = path.resolve(cwd, parsed.requestFile)
+  const expectedPath = path.resolve(cwd, ROLE_REQUEST_RELATIVE_PATH)
+  if (requestPath !== expectedPath) {
+    throw new RunnerUsageError(
+      `Role request must use ${ROLE_REQUEST_RELATIVE_PATH}`,
+    )
+  }
+  assertManagedPathParents(cwd, requestPath, 'role request')
+
+  let metadata
+  try {
+    metadata = lstatSync(requestPath)
+  } catch (error) {
+    throw new RunnerUsageError(
+      `Cannot inspect role request ${requestPath}: ${errorMessage(error)}`,
+    )
+  }
+  if (!metadata.isFile() || metadata.isSymbolicLink()) {
+    throw new RunnerUsageError(
+      `Role request must be a regular non-symlink file: ${requestPath}`,
+    )
+  }
+  if (metadata.size > MAX_ROLE_REQUEST_BYTES) {
+    unlinkSync(requestPath)
+    throw new RunnerUsageError(
+      `Role request exceeds ${MAX_ROLE_REQUEST_BYTES} bytes`,
+    )
+  }
+
+  let source
+  try {
+    source = readFileSync(requestPath, 'utf8')
+  } finally {
+    // The fixed request is one-shot. Removing it before spawn prevents stale
+    // context from being reused by a later role invocation.
+    unlinkSync(requestPath)
+  }
+  if (Buffer.byteLength(source, 'utf8') > MAX_ROLE_REQUEST_BYTES) {
+    throw new RunnerUsageError(
+      `Role request exceeds ${MAX_ROLE_REQUEST_BYTES} bytes`,
+    )
+  }
+
+  let request
+  try {
+    request = JSON.parse(source)
+  } catch (error) {
+    throw new RunnerUsageError(
+      `Invalid role request JSON: ${errorMessage(error)}`,
+    )
+  }
+  if (!isRecord(request)) {
+    throw new RunnerUsageError('Role request must be a JSON object')
+  }
+  const keys = Object.keys(request).sort()
+  if (
+    keys.length !== 3 ||
+    keys[0] !== 'args' ||
+    keys[1] !== 'model' ||
+    keys[2] !== 'skill'
+  ) {
+    throw new RunnerUsageError(
+      'Role request must contain exactly skill, model, and args',
+    )
+  }
+  if (typeof request.args !== 'string') {
+    throw new RunnerUsageError('Role request args must be a string')
+  }
+  assertNoNul(request.args, 'role request args')
+
+  return {
+    ...parsed,
+    skill: requireSafeSkillId(request.skill),
+    model: requireSafeModelId(request.model),
+    rawArgs: request.args.trim(),
+    requestFile: undefined,
+  }
+}
+
+export function loadRoleWave(parsed, cwd) {
+  if (parsed.roleWaveFile === undefined) return undefined
+  const requestPath = path.resolve(cwd, parsed.roleWaveFile)
+  const expectedPath = path.resolve(cwd, ROLE_WAVE_RELATIVE_PATH)
+  if (requestPath !== expectedPath) {
+    throw new RunnerUsageError(
+      `Role wave must use ${ROLE_WAVE_RELATIVE_PATH}`,
+    )
+  }
+  assertManagedPathParents(cwd, requestPath, 'role wave')
+
+  let metadata
+  try {
+    metadata = lstatSync(requestPath)
+  } catch (error) {
+    throw new RunnerUsageError(
+      `Cannot inspect role wave ${requestPath}: ${errorMessage(error)}`,
+    )
+  }
+  if (!metadata.isFile() || metadata.isSymbolicLink()) {
+    throw new RunnerUsageError(
+      `Role wave must be a regular non-symlink file: ${requestPath}`,
+    )
+  }
+  if (metadata.size > MAX_ROLE_REQUEST_BYTES) {
+    unlinkSync(requestPath)
+    throw new RunnerUsageError(
+      `Role wave exceeds ${MAX_ROLE_REQUEST_BYTES} bytes`,
+    )
+  }
+
+  let source
+  try {
+    source = readFileSync(requestPath, 'utf8')
+  } finally {
+    // A whole wave is one-shot. Deleting before any worktree or process is
+    // created prevents stale context and removes the parallel WriteFile race.
+    unlinkSync(requestPath)
+  }
+  if (Buffer.byteLength(source, 'utf8') > MAX_ROLE_REQUEST_BYTES) {
+    throw new RunnerUsageError(
+      `Role wave exceeds ${MAX_ROLE_REQUEST_BYTES} bytes`,
+    )
+  }
+
+  let request
+  try {
+    request = JSON.parse(source)
+  } catch (error) {
+    throw new RunnerUsageError(
+      `Invalid role wave JSON: ${errorMessage(error)}`,
+    )
+  }
+  if (!isRecord(request)) {
+    throw new RunnerUsageError('Role wave must be a JSON object')
+  }
+  const requestKeys = Object.keys(request).sort()
+  if (
+    requestKeys.length !== 2 ||
+    requestKeys[0] !== 'roles' ||
+    requestKeys[1] !== 'run'
+  ) {
+    throw new RunnerUsageError(
+      'Role wave must contain exactly run and roles',
+    )
+  }
+  const run = requireSafeWaveId(request.run, 'run')
+  if (
+    !Array.isArray(request.roles) ||
+    request.roles.length === 0 ||
+    request.roles.length > MAX_ROLE_WAVE_SIZE
+  ) {
+    throw new RunnerUsageError(
+      `Role wave roles must contain 1-${MAX_ROLE_WAVE_SIZE} entries`,
+    )
+  }
+
+  const seenKeys = new Set()
+  const seenWorktrees = new Set()
+  const roles = request.roles.map((value, index) => {
+    if (!isRecord(value)) {
+      throw new RunnerUsageError(
+        `Role wave entry ${index} must be a JSON object`,
+      )
+    }
+    const keys = Object.keys(value).sort()
+    if (
+      keys.length !== 6 ||
+      keys[0] !== 'args' ||
+      keys[1] !== 'key' ||
+      keys[2] !== 'model' ||
+      keys[3] !== 'profile' ||
+      keys[4] !== 'skill' ||
+      keys[5] !== 'workspace'
+    ) {
+      throw new RunnerUsageError(
+        `Role wave entry ${index} must contain exactly ` +
+          'key, skill, model, profile, args, and workspace',
+      )
+    }
+    const key = requireSafeWaveId(value.key, `role key ${index}`)
+    if (seenKeys.has(key)) {
+      throw new RunnerUsageError(`Duplicate role wave key: ${key}`)
+    }
+    seenKeys.add(key)
+    if (typeof value.args !== 'string') {
+      throw new RunnerUsageError(`Role wave entry ${key} args must be a string`)
+    }
+    assertNoNul(value.args, `role wave entry ${key} args`)
+    if (typeof value.workspace !== 'string') {
+      throw new RunnerUsageError(
+        `Role wave entry ${key} workspace must be a string`,
+      )
+    }
+    let workspace = value.workspace
+    if (workspace !== 'current') {
+      if (!workspace.startsWith('worktree:')) {
+        throw new RunnerUsageError(
+          `Role wave entry ${key} workspace must be current or worktree:<id>`,
+        )
+      }
+      const worktreeId = requireSafeWaveId(
+        workspace.slice('worktree:'.length),
+        `worktree id for ${key}`,
+      )
+      workspace = `worktree:${worktreeId}`
+      if (seenWorktrees.has(workspace)) {
+        throw new RunnerUsageError(
+          `Concurrent roles cannot share workspace ${workspace}`,
+        )
+      }
+      seenWorktrees.add(workspace)
+    }
+    return {
+      key,
+      skill: requireSafeSkillId(value.skill),
+      model: requireSafeModelId(value.model),
+      profile:
+        value.profile === 'inherit'
+          ? 'inherit'
+          : requireSafeWaveId(value.profile, `profile for ${key}`),
+      rawArgs: value.args.trim(),
+      workspace,
+    }
+  })
+
+  return {
+    run,
+    roles,
+    additionalDirs: parsed.additionalDirs,
+  }
+}
+
+export function loadRoleMerge(parsed, cwd) {
+  if (parsed.roleMergeFile === undefined) return undefined
+  const requestPath = path.resolve(cwd, parsed.roleMergeFile)
+  const expectedPath = path.resolve(cwd, ROLE_MERGE_RELATIVE_PATH)
+  if (requestPath !== expectedPath) {
+    throw new RunnerUsageError(
+      `Role merge must use ${ROLE_MERGE_RELATIVE_PATH}`,
+    )
+  }
+  assertManagedPathParents(cwd, requestPath, 'role merge')
+  let metadata
+  try {
+    metadata = lstatSync(requestPath)
+  } catch (error) {
+    throw new RunnerUsageError(
+      `Cannot inspect role merge ${requestPath}: ${errorMessage(error)}`,
+    )
+  }
+  if (
+    !metadata.isFile() ||
+    metadata.isSymbolicLink() ||
+    metadata.size > MAX_ROLE_REQUEST_BYTES
+  ) {
+    if (metadata.isFile() && !metadata.isSymbolicLink()) {
+      unlinkSync(requestPath)
+    }
+    throw new RunnerUsageError(
+      `Role merge must be a regular file at most ${MAX_ROLE_REQUEST_BYTES} bytes`,
+    )
+  }
+  let source
+  try {
+    source = readFileSync(requestPath, 'utf8')
+  } finally {
+    unlinkSync(requestPath)
+  }
+  let request
+  try {
+    request = JSON.parse(source)
+  } catch (error) {
+    throw new RunnerUsageError(
+      `Invalid role merge JSON: ${errorMessage(error)}`,
+    )
+  }
+  if (
+    !isRecord(request) ||
+    Object.keys(request).sort().join(',') !== 'actions,run'
+  ) {
+    throw new RunnerUsageError(
+      'Role merge must contain exactly run and actions',
+    )
+  }
+  const run = requireSafeWaveId(request.run, 'role merge run')
+  if (
+    !Array.isArray(request.actions) ||
+    request.actions.length === 0 ||
+    request.actions.length > 4_096
+  ) {
+    throw new RunnerUsageError(
+      'Role merge actions must contain 1-4096 entries',
+    )
+  }
+  const targets = new Set()
+  const actions = request.actions.map((value, index) => {
+    if (
+      !isRecord(value) ||
+      Object.keys(value).sort().join(',') !==
+        'operation,path,worktree'
+    ) {
+      throw new RunnerUsageError(
+        `Role merge action ${index} must contain exactly ` +
+          'worktree, path, and operation',
+      )
+    }
+    const worktree = requireSafeWaveId(
+      value.worktree,
+      `role merge worktree ${index}`,
+    )
+    const relativePath = requireSafeRelativePath(
+      value.path,
+      `role merge path ${index}`,
+    )
+    if (value.operation !== 'copy' && value.operation !== 'delete') {
+      throw new RunnerUsageError(
+        `Role merge action ${index} operation must be copy or delete`,
+      )
+    }
+    if (targets.has(relativePath)) {
+      throw new RunnerUsageError(
+        `Role merge contains duplicate target path: ${relativePath}`,
+      )
+    }
+    targets.add(relativePath)
+    return {
+      worktree,
+      path: relativePath,
+      operation: value.operation,
+    }
+  })
+  return { run, actions }
+}
+
+export function prepareSkillLaunch(options, dependencies = {}) {
+  const readFile = dependencies.readFile ?? ((file) => readFileSync(file, 'utf8'))
+  const resolvePath = dependencies.resolvePath ?? realpathSync
+  const stat = dependencies.stat ?? statSync
+  const attachments = validateAttachmentPaths(
+    options.attachmentPaths,
+    dependencies,
+  )
+  const skillId = requireSafeSkillId(options.skill)
+  const sessionId =
+    options.sessionId === undefined
+      ? undefined
+      : requireSafeSessionId(options.sessionId)
+  const skillDirCandidate = path.join(options.providerRoot, 'skills', skillId)
+  const skillPathCandidate = path.join(skillDirCandidate, 'SKILL.md')
+
+  let text
+  try {
+    if (!stat(skillPathCandidate).isFile()) {
+      throw new Error('not a regular file')
+    }
+    text = readFile(skillPathCandidate)
+  } catch (error) {
+    throw new RunnerUsageError(
+      `Cannot read skill "${skillId}" at ${skillPathCandidate}: ${errorMessage(error)}`,
+    )
+  }
+
+  // Kimi's scanner canonicalizes each discovered skill root. Use the same
+  // real path for context placeholders and the activation envelope.
+  const skillDir = toPromptPath(resolvePath(skillDirCandidate))
+  const parsed = parseSkillDocument(text, { skillId })
+  if (parsed.name.toLowerCase() !== skillId.toLowerCase()) {
+    throw new RunnerUsageError(
+      `Skill directory "${skillId}" declares mismatched name "${parsed.name}"`,
+    )
+  }
+  if (parsed.body.length === 0) {
+    throw new RunnerUsageError(`Skill "${skillId}" has an empty body`)
+  }
+  if (sessionId === undefined && parsed.body.includes('${KIMI_SESSION_ID}')) {
+    throw new RunnerUsageError(
+      `Skill "${skillId}" requires KIMI_SESSION_ID; start it only with --session=<id>`,
+    )
+  }
+  const expanded = expandSkillParameters(parsed.body, options.rawArgs, {
+    skillDir,
+    sessionId,
+    argumentNames: parsed.argumentNames,
+  })
+  let prompt = renderUserSlashSkillPrompt({
+    skillName: parsed.name,
+    skillArgs: options.rawArgs,
+    skillContent: expanded,
+    skillDir,
+  })
+
+  if (options.extraPrompt?.trim()) {
+    prompt += `\n\n${options.extraPrompt.trim()}`
+  }
+  if (attachments.length > 0) {
+    prompt += [
+      '',
+      '',
+      'Attached files (absolute paths):',
+      ...attachments.map((attachment) => `- ${attachment}`),
+      '',
+      'Read textual files with ReadFile. For images or other media, use',
+      'ReadMediaFile on the exact path. Kimi prompt mode has no attachment flag.',
+    ].join('\n')
+  }
+
+  const kimiArgs = [
+    ...(sessionId ? [`--session=${sessionId}`] : []),
+    ...Array.from(
+      new Set([
+        ...options.additionalDirs.map(canonicalizeExistingPath),
+        ...attachments.map((attachment) => path.dirname(attachment)),
+      ]),
+    ).flatMap((dir) => ['--add-dir', dir]),
+    '-m',
+    normalizeKimiCliModel(options.model),
+    '-p',
+    prompt,
+    '--output-format',
+    'stream-json',
+  ]
+  return { prompt, kimiArgs, skillDir, skillName: parsed.name }
+}
+
+function canonicalizeExistingPath(value) {
+  try {
+    return realpathSync(value)
+  } catch {
+    return path.resolve(value)
+  }
+}
+
+function validateAttachmentPaths(attachmentPaths = [], dependencies = {}) {
+  const inspect = dependencies.lstat ?? lstatSync
+  const resolvePath = dependencies.resolvePath ?? realpathSync
+  const assertReadable =
+    dependencies.access ??
+    ((file) => {
+      accessSync(file, fsConstants.R_OK)
+    })
+  return attachmentPaths.map((attachment) => {
+    if (!path.isAbsolute(attachment)) {
+      throw new RunnerUsageError(
+        `Attachment path must be absolute: ${attachment}`,
+      )
+    }
+    try {
+      const metadata = inspect(attachment)
+      if (!metadata.isFile() || metadata.isSymbolicLink()) {
+        throw new Error('not a regular non-symlink file')
+      }
+      const canonical = resolvePath(attachment)
+      assertReadable(canonical)
+      return canonical
+    } catch (error) {
+      throw new RunnerUsageError(
+        `Attachment must be a readable regular non-symlink file: ` +
+          `${attachment}: ${errorMessage(error)}`,
+      )
+    }
+  })
+}
+
+export function parseNpmCmdShimEntry(shimPath, contents) {
+  const match = contents.match(
+    /%dp0%[\\/]([^"\r\n]*?\.(?:mjs|cjs|js))["']?\s+%\*/i,
+  )
+  if (!match?.[1]) return null
+  return path.win32.join(path.win32.dirname(shimPath), match[1])
+}
+
+export function resolveWindowsKimiBinary(env = process.env, fileExists = existsSync) {
+  const pathValue = getEnvCaseInsensitive(env, 'PATH') ?? ''
+  // npm installs three siblings on Windows: `kimi`, `kimi.cmd`, and
+  // `kimi.ps1`. The extensionless sibling is a POSIX shell script and cannot
+  // be passed to CreateProcess, while PowerShell scripts cannot be spawned
+  // directly with shell:false. Probe only executable-safe forms, with the npm
+  // command shim first so large prompts can use the stdin bootstrap.
+  const names = ['kimi.cmd', 'kimi.bat', 'kimi.exe', 'kimi.com']
+
+  for (const rawEntry of pathValue.split(';')) {
+    const entry = rawEntry.trim().replace(/^"(.*)"$/, '$1')
+    if (entry === '') continue
+    for (const name of names) {
+      const candidate = path.win32.join(entry, name)
+      if (fileExists(candidate)) return candidate
+    }
+  }
+  throw new RunnerUsageError(
+    'No shell-free Kimi executable (.cmd, .bat, .exe, or .com) was found on PATH',
+  )
+}
+
+export function resolveKimiLaunch(kimiArgs, options = {}) {
+  const platform = options.platform ?? process.platform
+  if (platform !== 'win32') {
+    return { command: 'kimi', args: kimiArgs }
+  }
+
+  const fileExists = options.fileExists ?? existsSync
+  const readFile = options.readFile ?? ((file) => readFileSync(file, 'utf8'))
+  const binary = options.binary ?? resolveWindowsKimiBinary(options.env, fileExists)
+  const extension = path.win32.extname(binary).toLowerCase()
+  if (extension !== '.cmd' && extension !== '.bat') {
+    assertWindowsCommandLineBudget(binary, kimiArgs)
+    return { command: binary, args: kimiArgs }
+  }
+
+  let entry
+  try {
+    entry = parseNpmCmdShimEntry(binary, readFile(binary))
+  } catch (error) {
+    throw new RunnerUsageError(
+      `Cannot read the Kimi Windows shim ${binary}: ${errorMessage(error)}`,
+    )
+  }
+  if (entry === null) {
+    throw new RunnerUsageError(
+      `Refusing to execute non-standard Kimi Windows shim through cmd.exe: ${binary}`,
+    )
+  }
+  const localNode = path.win32.join(path.win32.dirname(binary), 'node.exe')
+  const nodeBinary = fileExists(localNode) ? localNode : 'node'
+  const promptFlag = kimiArgs.indexOf('-p')
+  if (promptFlag === -1 || promptFlag + 1 >= kimiArgs.length) {
+    const args = [entry, ...kimiArgs]
+    assertWindowsCommandLineBudget(nodeBinary, args)
+    return { command: nodeBinary, args }
+  }
+
+  const transportedArgs = [...kimiArgs]
+  const prompt = transportedArgs[promptFlag + 1]
+  transportedArgs[promptFlag + 1] = WINDOWS_PROMPT_STDIN_TOKEN
+  const args = [
+    '-e',
+    WINDOWS_NPM_STDIN_BOOTSTRAP,
+    entry,
+    ...transportedArgs,
+  ]
+  assertWindowsCommandLineBudget(nodeBinary, args)
+  return { command: nodeBinary, args, stdinText: prompt }
+}
+
+export function materializeRoleWaveWorkspaces(wave, options = {}) {
+  const initialCwd = realpathSync(options.cwd ?? process.cwd())
+  const git = options.spawnSync ?? spawnSync
+  const gitBinary = options.gitBinary ?? 'git'
+  const tempRoot = ensureManagedTempRoot(options.tempRoot ?? os.tmpdir())
+  const providerRoot = realpathSync(options.providerRoot)
+  const runGit = (cwd, args, input, extraEnv = {}) => {
+    const result = git(gitBinary, ['-C', cwd, ...args], {
+      encoding: 'utf8',
+      env: { ...process.env, ...extraEnv },
+      input,
+      maxBuffer: 256 * 1024 * 1024,
+      shell: false,
+    })
+    if (result.error || result.status !== 0) {
+      const detail =
+        errorMessage(result.error ?? '').trim() ||
+        String(result.stderr ?? '').trim() ||
+        `exit ${String(result.status)}`
+      throw new RunnerUsageError(
+        `git ${args.join(' ')} failed in ${cwd}: ${detail}`,
+      )
+    }
+    return String(result.stdout ?? '')
+  }
+
+  const baseRepo = realpathSync(
+    runGit(initialCwd, ['rev-parse', '--show-toplevel']).trim(),
+  )
+  const manifestPath = path.join(
+    baseRepo,
+    ROLE_WORKTREE_MANIFEST_DIR,
+    `${wave.run}.json`,
+  )
+  ensureRealDirectoryTree(baseRepo, path.dirname(manifestPath))
+  const existingManifest = readRoleWaveManifest(manifestPath)
+  const head = requireGitOid(
+    runGit(baseRepo, ['rev-parse', 'HEAD']).trim(),
+    'repository HEAD',
+  )
+  if (
+    existingManifest &&
+    (
+      existingManifest.run !== wave.run ||
+      realpathSync(existingManifest.baseRepo) !== baseRepo
+    )
+  ) {
+    throw new RunnerUsageError(
+      `Role wave manifest does not belong to ${wave.run} in ${baseRepo}`,
+    )
+  }
+  const worktrees = { ...(existingManifest?.worktrees ?? {}) }
+  const repoKey = createHash('sha256')
+    .update(baseRepo)
+    .digest('hex')
+    .slice(0, 16)
+  const needsWorktrees = wave.roles.some(
+    (role) => role.workspace !== 'current',
+  )
+  let baseCommit = existingManifest?.baseCommit ?? null
+  let sourceHead = existingManifest?.sourceHead ?? null
+  let createdBaseline = false
+  if (baseCommit !== null) {
+    baseCommit = requireGitOid(baseCommit, 'role wave base commit')
+    runGit(baseRepo, ['cat-file', '-e', `${baseCommit}^{commit}`])
+  } else if (needsWorktrees) {
+    sourceHead = head
+    baseCommit = createSyntheticBaselineCommit({
+      baseRepo,
+      head,
+      repoKey,
+      run: wave.run,
+      tempRoot,
+      runGit,
+    })
+    createdBaseline = true
+  }
+  const worktreeRoot = path.join(
+    tempRoot,
+    'specrails-kimi-worktrees',
+    repoKey,
+    wave.run,
+  )
+  const executionRoot = path.join(
+    tempRoot,
+    'specrails-kimi-execution',
+    repoKey,
+    wave.run,
+  )
+  ensureRealDirectoryTree(tempRoot, worktreeRoot)
+  ensureRealDirectoryTree(tempRoot, executionRoot)
+  const gitExcludeDirectory = path.join(
+    tempRoot,
+    'specrails-kimi-git-excludes',
+    repoKey,
+  )
+  ensureRealDirectoryTree(tempRoot, gitExcludeDirectory)
+  const gitExcludeFile = writeRoleGitExclude(
+    path.join(gitExcludeDirectory, `${wave.run}.txt`),
+  )
+
+  const listed = parseGitWorktreeList(
+    runGit(baseRepo, ['worktree', 'list', '--porcelain', '-z']),
+  )
+  if (existingManifest) {
+    validateRoleWaveManifestIntegrity(existingManifest, {
+      baseRepo,
+      run: wave.run,
+      tempRoot,
+      repoKey,
+      registered: listed,
+      runGit: (args) => runGit(baseRepo, args),
+    })
+  }
+  const createdThisCall = []
+  try {
+    const roles = wave.roles.map((role) => {
+      if (role.profile !== 'inherit') {
+        const profilePath = path.join(
+          baseRepo,
+          '.specrails',
+          'profiles',
+          `${role.profile}.json`,
+        )
+        assertWorkspaceParentSafety(baseRepo, profilePath)
+        let profileMetadata
+        try {
+          profileMetadata = lstatSync(profilePath)
+        } catch (error) {
+          throw new RunnerUsageError(
+            `Cannot read role profile ${role.profile}: ${errorMessage(error)}`,
+          )
+        }
+        if (!profileMetadata.isFile() || profileMetadata.isSymbolicLink()) {
+          throw new RunnerUsageError(
+            `Role profile must be a regular non-symlink file: ${profilePath}`,
+          )
+        }
+      }
+      if (role.workspace === 'current') {
+        const executionCwd = path.join(executionRoot, role.key)
+        ensureExecutionWorkspace(
+          executionCwd,
+          providerRoot,
+          {
+            run: wave.run,
+            roleKey: role.key,
+            repoDir: baseRepo,
+          },
+          options.platform ?? process.platform,
+        )
+        return {
+          ...role,
+          cwd: executionCwd,
+          repoDir: baseRepo,
+          gitExcludeFile,
+        }
+      }
+      const worktreeId = role.workspace.slice('worktree:'.length)
+      const target = path.join(worktreeRoot, worktreeId)
+      const recorded = worktrees[worktreeId]
+      if (recorded !== undefined && path.resolve(recorded) !== target) {
+        throw new RunnerUsageError(
+          `Role worktree mapping changed for ${worktreeId}`,
+        )
+      }
+      const registeredTarget = existsSync(target)
+        ? realpathSync(target)
+        : path.resolve(target)
+      if (!listed.has(registeredTarget)) {
+        if (existsSync(target)) {
+          throw new RunnerUsageError(
+            `Unregistered path blocks role worktree ${worktreeId}: ${target}`,
+          )
+        }
+        mkdirSync(path.dirname(target), { recursive: true })
+        runGit(baseRepo, [
+          'worktree',
+          'add',
+          '--detach',
+          target,
+          requireGitOid(baseCommit, 'role wave base commit'),
+        ])
+        createdThisCall.push(target)
+      }
+      ensureProviderOverlay(
+        providerRoot,
+        target,
+        options.platform ?? process.platform,
+      )
+      worktrees[worktreeId] = target
+      return {
+        ...role,
+        cwd: target,
+        repoDir: target,
+        gitExcludeFile,
+      }
+    })
+
+    writeRoleWaveManifest(manifestPath, {
+      schemaVersion: 1,
+      run: wave.run,
+      baseRepo,
+      baseCommit,
+      sourceHead,
+      worktrees,
+      roles: {
+        ...(existingManifest?.roles ?? {}),
+        ...Object.fromEntries(
+          roles.map((role) => [
+            role.key,
+            {
+              executionCwd: role.cwd,
+              repoDir: role.repoDir,
+              workspace: role.workspace,
+              gitExcludeFile: role.gitExcludeFile ?? null,
+            },
+          ]),
+        ),
+      },
+    })
+    return {
+      run: wave.run,
+      roles,
+      baseRepo,
+      baseCommit,
+      manifestPath,
+    }
+  } catch (error) {
+    for (const target of createdThisCall.reverse()) {
+      try {
+        runGit(baseRepo, ['worktree', 'remove', '--force', target])
+      } catch {
+        rmSync(target, { recursive: true, force: true })
+      }
+    }
+    if (createdBaseline) {
+      try {
+        runGit(
+          baseRepo,
+          ['update-ref', '-d', `refs/specrails/kimi/${repoKey}/${wave.run}`],
+        )
+      } catch {
+        // Preserve the original setup error. A stale private ref is harmless
+        // and can be pruned by a later successful cleanup.
+      }
+    }
+    throw error
+  }
+}
+
+function parseGitWorktreeList(source) {
+  const paths = new Set()
+  for (const field of source.split('\0')) {
+    if (field.startsWith('worktree ')) {
+      const candidate = field.slice('worktree '.length)
+      paths.add(
+        existsSync(candidate)
+          ? realpathSync(candidate)
+          : path.resolve(candidate),
+      )
+    }
+  }
+  return paths
+}
+
+function createSyntheticBaselineCommit({
+  baseRepo,
+  head,
+  repoKey,
+  run,
+  tempRoot,
+  runGit,
+}) {
+  mkdirSync(tempRoot, { recursive: true })
+  const indexDirectory = path.join(
+    tempRoot,
+    'specrails-kimi-indexes',
+    repoKey,
+  )
+  ensureRealDirectoryTree(tempRoot, indexDirectory)
+  const indexPath = path.join(indexDirectory, `${run}.index`)
+  if (existsSync(indexPath)) {
+    const metadata = lstatSync(indexPath)
+    if (!metadata.isFile() || metadata.isSymbolicLink()) {
+      throw new RunnerUsageError(
+        `Invalid synthetic baseline index: ${indexPath}`,
+      )
+    }
+    unlinkSync(indexPath)
+  }
+  const indexEnv = { GIT_INDEX_FILE: indexPath }
+  try {
+    runGit(baseRepo, ['read-tree', head], undefined, indexEnv)
+    runGit(
+      baseRepo,
+      [
+        'add',
+        '-A',
+        '--',
+        '.',
+        ':(exclude).kimi-code',
+        ':(exclude).kimi-code/**',
+        `:(exclude)${ROLE_WAVE_RELATIVE_PATH.split(path.sep).join('/')}`,
+        `:(exclude)${ROLE_REQUEST_RELATIVE_PATH.split(path.sep).join('/')}`,
+        `:(exclude)${ROLE_MERGE_RELATIVE_PATH.split(path.sep).join('/')}`,
+        `:(exclude)${ROLE_WORKTREE_MANIFEST_DIR.split(path.sep).join('/')}/**`,
+      ],
+      undefined,
+      indexEnv,
+    )
+    const tree = requireGitOid(
+      runGit(baseRepo, ['write-tree'], undefined, indexEnv).trim(),
+      'synthetic baseline tree',
+    )
+    const identityEnv = {
+      ...indexEnv,
+      GIT_AUTHOR_NAME: 'SpecRails Kimi',
+      GIT_AUTHOR_EMAIL: 'kimi-baseline@specrails.local',
+      GIT_COMMITTER_NAME: 'SpecRails Kimi',
+      GIT_COMMITTER_EMAIL: 'kimi-baseline@specrails.local',
+    }
+    const commit = requireGitOid(
+      runGit(
+        baseRepo,
+        ['commit-tree', tree, '-p', head],
+        `SpecRails Kimi baseline ${run}\n`,
+        identityEnv,
+      ).trim(),
+      'synthetic baseline commit',
+    )
+    runGit(
+      baseRepo,
+      ['update-ref', `refs/specrails/kimi/${repoKey}/${run}`, commit],
+    )
+    return commit
+  } finally {
+    rmSync(indexPath, { force: true })
+  }
+}
+
+function writeRoleGitExclude(file) {
+  const contents = roleGitExcludeContents()
+  mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 })
+  if (existsSync(file)) {
+    const metadata = lstatSync(file)
+    if (
+      !metadata.isFile() ||
+      metadata.isSymbolicLink() ||
+      readFileSync(file, 'utf8') !== contents
+    ) {
+      throw new RunnerUsageError(`Invalid role git exclude file: ${file}`)
+    }
+    return file
+  }
+  writeFileSync(file, contents, {
+    encoding: 'utf8',
+    flag: 'wx',
+    mode: 0o600,
+  })
+  return file
+}
+
+function roleGitExcludeContents() {
+  return [
+    '/.kimi-code',
+    '/.kimi-code/',
+    '/.specrails/kimi-role-wave.json',
+    '/.specrails/kimi-role-request.json',
+    '/.specrails/kimi-role-merge.json',
+    '/.specrails/kimi-role-worktrees/',
+    '',
+  ].join('\n')
+}
+
+function safeWorkspacePath(root, relative) {
+  if (path.isAbsolute(relative) || relative.includes('\0')) {
+    throw new RunnerUsageError(`Unsafe git workspace path: ${relative}`)
+  }
+  const resolved = path.resolve(root, relative)
+  const prefix = root.endsWith(path.sep) ? root : `${root}${path.sep}`
+  if (!resolved.startsWith(prefix)) {
+    throw new RunnerUsageError(`Git workspace path escapes its root: ${relative}`)
+  }
+  return resolved
+}
+
+function isManagedRolePath(relative) {
+  return (
+    relative === '.kimi-code' ||
+    relative.startsWith('.kimi-code/') ||
+    relative === '.specrails/kimi-role-wave.json' ||
+    relative === '.specrails/kimi-role-request.json' ||
+    relative === '.specrails/kimi-role-merge.json' ||
+    relative.startsWith('.specrails/kimi-role-worktrees/')
+  )
+}
+
+function assertManagedPathParents(root, file, label) {
+  const absoluteRoot = path.resolve(root)
+  const parent = path.dirname(path.resolve(file))
+  const relative = path.relative(absoluteRoot, parent)
+  if (
+    relative === '..' ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
+    throw new RunnerUsageError(`${label} escapes its working directory`)
+  }
+  let cursor = absoluteRoot
+  for (const component of relative.split(path.sep).filter(Boolean)) {
+    cursor = path.join(cursor, component)
+    let metadata
+    try {
+      metadata = lstatSync(cursor)
+    } catch (error) {
+      throw new RunnerUsageError(
+        `Cannot inspect ${label} parent ${cursor}: ${errorMessage(error)}`,
+      )
+    }
+    if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+      throw new RunnerUsageError(
+        `${label} parent must be a real directory: ${cursor}`,
+      )
+    }
+  }
+}
+
+function ensureRealDirectoryTree(root, directory) {
+  const lexicalRoot = path.resolve(root)
+  const absoluteRoot = realpathSync(lexicalRoot)
+  const lexicalTarget = path.resolve(directory)
+  const relative = path.relative(lexicalRoot, lexicalTarget)
+  if (
+    relative === '..' ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
+    throw new RunnerUsageError(
+      `Managed directory escapes its root: ${directory}`,
+    )
+  }
+  let cursor = absoluteRoot
+  for (const component of relative.split(path.sep).filter(Boolean)) {
+    cursor = path.join(cursor, component)
+    if (!existsSync(cursor)) {
+      mkdirSync(cursor, { mode: 0o700 })
+      continue
+    }
+    const metadata = lstatSync(cursor)
+    if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+      throw new RunnerUsageError(
+        `Managed directory component must not be a symlink: ${cursor}`,
+      )
+    }
+  }
+}
+
+function ensureManagedTempRoot(candidate) {
+  const absolute = path.resolve(candidate)
+  if (existsSync(absolute)) {
+    const metadata = lstatSync(absolute)
+    if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+      throw new RunnerUsageError(
+        `Managed temp root must be a real directory: ${absolute}`,
+      )
+    }
+    return realpathSync(absolute)
+  }
+  const parent = path.dirname(absolute)
+  const realParent = realpathSync(parent)
+  ensureRealDirectoryTree(realParent, path.join(realParent, path.basename(absolute)))
+  return realpathSync(path.join(realParent, path.basename(absolute)))
+}
+
+export function ensureProviderOverlay(
+  providerRoot,
+  workspace,
+  platform,
+  dependencies = {},
+) {
+  const createLink = dependencies.symlink ?? symlinkSync
+  const copyTree = dependencies.copyTree ?? cpSync
+  const removeTree = dependencies.removeTree ?? rmSync
+  const expectedRoot = realpathSync(providerRoot)
+  const contentSha256 = hashManagedDirectoryTree(expectedRoot)
+  const markerValue = {
+    schemaVersion: 2,
+    providerRoot: expectedRoot,
+    runnerSha256: createHash('sha256')
+      .update(readFileSync(path.join(expectedRoot, 'specrails', 'run-skill.mjs')))
+      .digest('hex'),
+    contentSha256,
+  }
+  const destination = path.join(workspace, '.kimi-code')
+  if (existsSync(destination)) {
+    const destinationMetadata = lstatSync(destination)
+    if (destinationMetadata.isSymbolicLink()) {
+      if (realpathSync(destination) !== expectedRoot) {
+        throw new RunnerUsageError(
+          `Worktree provider link does not target the managed provider: ${destination}`,
+        )
+      }
+      return
+    }
+    if (!destinationMetadata.isDirectory()) {
+      throw new RunnerUsageError(
+        `Worktree provider path is not a directory: ${destination}`,
+      )
+    }
+    const markerPath = path.join(
+      destination,
+      '.specrails-managed-overlay.json',
+    )
+    if (!existsSync(markerPath) || lstatSync(markerPath).isSymbolicLink()) {
+      throw new RunnerUsageError(
+        `Refusing unverified worktree provider directory: ${destination}`,
+      )
+    }
+    let marker
+    try {
+      marker = JSON.parse(readFileSync(markerPath, 'utf8'))
+    } catch (error) {
+      throw new RunnerUsageError(
+        `Cannot verify worktree provider overlay: ${errorMessage(error)}`,
+      )
+    }
+    const isOwnedMarker =
+      isRecord(marker) &&
+      (marker.schemaVersion === 1 || marker.schemaVersion === 2) &&
+      marker.providerRoot === expectedRoot &&
+      typeof marker.runnerSha256 === 'string' &&
+      /^[0-9a-f]{64}$/.test(marker.runnerSha256) &&
+      (
+        marker.schemaVersion === 1 ||
+        (
+          typeof marker.contentSha256 === 'string' &&
+          /^[0-9a-f]{64}$/.test(marker.contentSha256)
+        )
+      )
+    if (!isOwnedMarker) {
+      throw new RunnerUsageError(
+        `Worktree provider overlay does not match the managed provider: ${destination}`,
+      )
+    }
+    const actualContentSha256 = hashManagedDirectoryTree(destination, {
+      ignoredRelativePath: '.specrails-managed-overlay.json',
+    })
+    if (
+      JSON.stringify(marker) === JSON.stringify(markerValue) &&
+      actualContentSha256 === contentSha256
+    ) {
+      return
+    }
+    // A valid ownership marker lets us repair stale/corrupt copied overlays.
+    // Unmarked directories remain user-owned and are never removed.
+    removeTree(destination, { recursive: true, force: true })
+  }
+  try {
+    createLink(
+      expectedRoot,
+      destination,
+      platform === 'win32' ? 'junction' : 'dir',
+    )
+  } catch {
+    removeTree(destination, { recursive: true, force: true })
+    copyTree(providerRoot, destination, {
+      recursive: true,
+      dereference: true,
+      errorOnExist: true,
+    })
+    const copiedContentSha256 = hashManagedDirectoryTree(destination)
+    if (copiedContentSha256 !== contentSha256) {
+      removeTree(destination, { recursive: true, force: true })
+      throw new RunnerUsageError(
+        `Copied worktree provider overlay failed content verification: ${destination}`,
+      )
+    }
+    writeFileSync(
+      path.join(destination, '.specrails-managed-overlay.json'),
+      `${JSON.stringify(markerValue)}\n`,
+      { encoding: 'utf8', flag: 'wx', mode: 0o600 },
+    )
+  }
+}
+
+function hashManagedDirectoryTree(
+  root,
+  options = { ignoredRelativePath: undefined },
+) {
+  const hash = createHash('sha256')
+  const walk = (directory, prefix) => {
+    const names = readdirSync(directory).sort()
+    for (const name of names) {
+      const relative = prefix === '' ? name : `${prefix}/${name}`
+      if (relative === options.ignoredRelativePath) continue
+      const entry = path.join(directory, name)
+      const metadata = lstatSync(entry)
+      if (metadata.isSymbolicLink()) {
+        throw new RunnerUsageError(
+          `Managed provider tree must not contain symlinks: ${entry}`,
+        )
+      }
+      if (metadata.isDirectory()) {
+        hash.update(`D\0${relative}\0`)
+        walk(entry, relative)
+      } else if (metadata.isFile()) {
+        hash.update(`F\0${relative}\0${metadata.mode & 0o111}\0`)
+        hash.update(readFileSync(entry))
+        hash.update('\0')
+      } else {
+        throw new RunnerUsageError(
+          `Managed provider tree has unsupported entry: ${entry}`,
+        )
+      }
+    }
+  }
+  walk(root, '')
+  return hash.digest('hex')
+}
+
+function ensureExecutionWorkspace(
+  executionCwd,
+  providerRoot,
+  identity,
+  platform,
+) {
+  mkdirSync(executionCwd, { recursive: true, mode: 0o700 })
+  const metadata = lstatSync(executionCwd)
+  if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+    throw new RunnerUsageError(
+      `Role execution workspace must be a real directory: ${executionCwd}`,
+    )
+  }
+  const marker = path.join(executionCwd, '.specrails-role-workspace.json')
+  if (existsSync(marker)) {
+    const markerMetadata = lstatSync(marker)
+    if (!markerMetadata.isFile() || markerMetadata.isSymbolicLink()) {
+      throw new RunnerUsageError(
+        `Invalid role execution workspace marker: ${marker}`,
+      )
+    }
+    let existing
+    try {
+      existing = JSON.parse(readFileSync(marker, 'utf8'))
+    } catch (error) {
+      throw new RunnerUsageError(
+        `Cannot parse role execution workspace marker: ${errorMessage(error)}`,
+      )
+    }
+    if (JSON.stringify(existing) !== JSON.stringify(identity)) {
+      throw new RunnerUsageError(
+        `Role execution workspace belongs to another run: ${executionCwd}`,
+      )
+    }
+  } else {
+    writeFileSync(marker, `${JSON.stringify(identity)}\n`, {
+      encoding: 'utf8',
+      flag: 'wx',
+      mode: 0o600,
+    })
+  }
+  ensureProviderOverlay(providerRoot, executionCwd, platform)
+}
+
+function readRoleWaveManifest(manifestPath) {
+  if (!existsSync(manifestPath)) return undefined
+  const metadata = lstatSync(manifestPath)
+  if (
+    !metadata.isFile() ||
+    metadata.isSymbolicLink() ||
+    metadata.size > MAX_ROLE_REQUEST_BYTES
+  ) {
+    throw new RunnerUsageError(
+      `Invalid role wave manifest: ${manifestPath}`,
+    )
+  }
+  let value
+  try {
+    value = JSON.parse(readFileSync(manifestPath, 'utf8'))
+  } catch (error) {
+    throw new RunnerUsageError(
+      `Cannot parse role wave manifest ${manifestPath}: ${errorMessage(error)}`,
+    )
+  }
+  if (!isRecord(value)) {
+    throw new RunnerUsageError(`Invalid role wave manifest: ${manifestPath}`)
+  }
+  const keys = Object.keys(value).sort()
+  if (
+    keys.join(',') !==
+      'baseCommit,baseRepo,roles,run,schemaVersion,sourceHead,worktrees' ||
+    value.schemaVersion !== 1 ||
+    typeof value.baseRepo !== 'string' ||
+    !(
+      value.baseCommit === null ||
+      (
+        typeof value.baseCommit === 'string' &&
+        SAFE_GIT_OID.test(value.baseCommit)
+      )
+    ) ||
+    !(
+      value.sourceHead === null ||
+      (
+        typeof value.sourceHead === 'string' &&
+        SAFE_GIT_OID.test(value.sourceHead)
+      )
+    ) ||
+    !SAFE_WAVE_ID.test(value.run) ||
+    !isRecord(value.worktrees) ||
+    !isRecord(value.roles)
+  ) {
+    throw new RunnerUsageError(`Invalid role wave manifest: ${manifestPath}`)
+  }
+  const worktrees = {}
+  for (const [key, target] of Object.entries(value.worktrees)) {
+    requireSafeWaveId(key, 'manifest worktree id')
+    if (typeof target !== 'string' || !path.isAbsolute(target)) {
+      throw new RunnerUsageError(`Invalid role wave manifest: ${manifestPath}`)
+    }
+    worktrees[key] = target
+  }
+  const roles = {}
+  for (const [key, role] of Object.entries(value.roles)) {
+    requireSafeWaveId(key, 'manifest role key')
+    if (
+      !isRecord(role) ||
+      Object.keys(role).sort().join(',') !==
+        'executionCwd,gitExcludeFile,repoDir,workspace' ||
+      typeof role.executionCwd !== 'string' ||
+      !path.isAbsolute(role.executionCwd) ||
+      typeof role.repoDir !== 'string' ||
+      !path.isAbsolute(role.repoDir) ||
+      !(
+        role.gitExcludeFile === null ||
+        (
+          typeof role.gitExcludeFile === 'string' &&
+          path.isAbsolute(role.gitExcludeFile)
+        )
+      ) ||
+      typeof role.workspace !== 'string'
+    ) {
+      throw new RunnerUsageError(`Invalid role wave manifest: ${manifestPath}`)
+    }
+    roles[key] = role
+  }
+  return { ...value, worktrees, roles }
+}
+
+function writeRoleWaveManifest(manifestPath, value) {
+  const directory = path.dirname(manifestPath)
+  ensureRealDirectoryTree(value.baseRepo, directory)
+  const metadata = lstatSync(directory)
+  if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+    throw new RunnerUsageError(
+      `Role worktree manifest directory must not be a symlink: ${directory}`,
+    )
+  }
+  if (existsSync(manifestPath) && lstatSync(manifestPath).isSymbolicLink()) {
+    throw new RunnerUsageError(
+      `Role wave manifest must not be a symlink: ${manifestPath}`,
+    )
+  }
+  const temporary = `${manifestPath}.${process.pid}.${Date.now()}.tmp`
+  try {
+    writeFileSync(
+      temporary,
+      `${JSON.stringify(value, null, 2)}\n`,
+      { encoding: 'utf8', flag: 'wx', mode: 0o600 },
+    )
+    renameSync(temporary, manifestPath)
+  } finally {
+    rmSync(temporary, { force: true })
+  }
+}
+
+export function inspectRoleWaveStatus(run, dependencies = {}) {
+  const state = resolveRoleWaveState(run, dependencies)
+  const worktrees = {}
+  for (const [worktree, repoDir] of Object.entries(state.manifest.worktrees)) {
+    const changes = new Map()
+    const tracked = runRoleGit(
+      repoDir,
+      [
+        'diff',
+        '--name-status',
+        '-z',
+        '--no-renames',
+        state.manifest.baseCommit,
+        '--',
+      ],
+      dependencies,
+    ).split('\0')
+    for (let index = 0; index + 1 < tracked.length; index += 2) {
+      const rawStatus = tracked[index]
+      const relative = tracked[index + 1]
+      if (!rawStatus || !relative || isManagedRolePath(relative)) continue
+      const status =
+        rawStatus.startsWith('A')
+          ? 'A'
+          : rawStatus.startsWith('D')
+            ? 'D'
+            : 'M'
+      changes.set(relative, { status, path: relative })
+    }
+    const untracked = runRoleGit(
+      repoDir,
+      ['ls-files', '--others', '--exclude-standard', '-z'],
+      dependencies,
+    ).split('\0')
+    for (const relative of untracked) {
+      if (
+        relative === '' ||
+        isManagedRolePath(relative) ||
+        changes.has(relative)
+      ) {
+        continue
+      }
+      changes.set(relative, { status: 'A', path: relative })
+    }
+    worktrees[worktree] = {
+      repoDir,
+      changes: Array.from(changes.values()).sort((left, right) =>
+        left.path.localeCompare(right.path),
+      ),
+    }
+  }
+  return {
+    run,
+    baseRepo: state.baseRepo,
+    baseCommit: state.manifest.baseCommit,
+    manifestPath: state.manifestPath,
+    worktrees,
+  }
+}
+
+export function applyRoleMerge(merge, dependencies = {}) {
+  const state = resolveRoleWaveState(merge.run, dependencies)
+  const prepared = merge.actions.map((action) => {
+    const workspace = state.manifest.worktrees[action.worktree]
+    if (workspace === undefined) {
+      throw new RunnerUsageError(
+        `Unknown role merge worktree: ${action.worktree}`,
+      )
+    }
+    const source = safeWorkspacePath(workspace, action.path)
+    const target = safeWorkspacePath(state.baseRepo, action.path)
+    if (action.operation === 'copy') {
+      let metadata
+      try {
+        metadata = lstatSync(source)
+      } catch (error) {
+        throw new RunnerUsageError(
+          `Cannot copy missing role output ${action.path}: ${errorMessage(error)}`,
+        )
+      }
+      if (!metadata.isFile() && !metadata.isSymbolicLink()) {
+        throw new RunnerUsageError(
+          `Role merge copy source must be a file or symlink: ${action.path}`,
+        )
+      }
+      assertWorkspaceParentSafety(state.baseRepo, target)
+      return { ...action, source, target, metadata }
+    }
+    if (existsSync(source)) {
+      throw new RunnerUsageError(
+        `Role merge deletion source still exists: ${action.path}`,
+      )
+    }
+    assertWorkspaceParentSafety(state.baseRepo, target)
+    return { ...action, source, target }
+  })
+
+  for (const action of prepared) {
+    ensureWorkspaceParentDirectories(state.baseRepo, action.target)
+    if (action.operation === 'delete') {
+      if (existsSync(action.target) || lstatExists(action.target)) {
+        const metadata = lstatSync(action.target)
+        if (metadata.isDirectory() && !metadata.isSymbolicLink()) {
+          throw new RunnerUsageError(
+            `Role merge refuses to delete directory path: ${action.path}`,
+          )
+        }
+        unlinkSync(action.target)
+      }
+      continue
+    }
+    const existing = lstatExists(action.target)
+      ? lstatSync(action.target)
+      : undefined
+    if (existing?.isDirectory() && !existing.isSymbolicLink()) {
+      throw new RunnerUsageError(
+        `Role merge refuses to replace directory path: ${action.path}`,
+      )
+    }
+    if (action.metadata.isSymbolicLink()) {
+      if (existing) unlinkSync(action.target)
+      symlinkSync(readlinkSync(action.source), action.target)
+      continue
+    }
+    const temporary = path.join(
+      path.dirname(action.target),
+      `.${path.basename(action.target)}.specrails-${process.pid}.tmp`,
+    )
+    try {
+      copyFileSync(action.source, temporary)
+      chmodSync(temporary, action.metadata.mode & 0o777)
+      if (existing) unlinkSync(action.target)
+      renameSync(temporary, action.target)
+    } finally {
+      rmSync(temporary, { force: true })
+    }
+  }
+  return {
+    run: merge.run,
+    baseRepo: state.baseRepo,
+    applied: prepared.length,
+  }
+}
+
+export function cleanupRoleWave(run, dependencies = {}) {
+  const state = resolveRoleWaveState(run, dependencies, {
+    requireIsolated: false,
+  })
+  const repoKey = state.repoKey
+  const failures = []
+  for (const [worktree, target] of Object.entries(state.manifest.worktrees)) {
+    try {
+      runRoleGit(
+        state.baseRepo,
+        ['worktree', 'remove', '--force', target],
+        dependencies,
+      )
+    } catch (error) {
+      failures.push(`${worktree}: ${errorMessage(error)}`)
+    }
+  }
+  if (failures.length > 0) {
+    throw new RunnerUsageError(
+      `Role wave cleanup failed; manifest retained: ${failures.join('; ')}`,
+    )
+  }
+  if (state.manifest.baseCommit !== null) {
+    runRoleGit(
+      state.baseRepo,
+      ['update-ref', '-d', `refs/specrails/kimi/${repoKey}/${run}`],
+      dependencies,
+    )
+  }
+  unlinkSync(state.manifestPath)
+
+  const tempRoot = state.tempRoot
+  for (const directory of [
+    path.join(
+      tempRoot,
+      'specrails-kimi-worktrees',
+      repoKey,
+      run,
+    ),
+    path.join(
+      tempRoot,
+      'specrails-kimi-execution',
+      repoKey,
+      run,
+    ),
+  ]) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+  rmSync(
+    path.join(
+      tempRoot,
+      'specrails-kimi-git-excludes',
+      repoKey,
+      `${run}.txt`,
+    ),
+    { force: true },
+  )
+  runRoleGit(state.baseRepo, ['worktree', 'prune'], dependencies)
+  return {
+    run,
+    baseRepo: state.baseRepo,
+    removedWorktrees: Object.keys(state.manifest.worktrees).length,
+    manifestPath: state.manifestPath,
+  }
+}
+
+function resolveRoleWaveState(
+  run,
+  dependencies,
+  options = { requireIsolated: true },
+) {
+  const sourceEnv = dependencies.env ?? process.env
+  const cwd =
+    nonEmptyString(sourceEnv.SPECRAILS_REPO_DIR) ??
+    dependencies.cwd ??
+    process.cwd()
+  const baseRepo = realpathSync(
+    runRoleGit(cwd, ['rev-parse', '--show-toplevel'], dependencies).trim(),
+  )
+  const manifestPath = path.join(
+    baseRepo,
+    ROLE_WORKTREE_MANIFEST_DIR,
+    `${requireSafeWaveId(run, 'role wave run')}.json`,
+  )
+  assertManagedPathParents(baseRepo, manifestPath, 'role wave manifest')
+  const manifest = readRoleWaveManifest(manifestPath)
+  if (
+    manifest === undefined ||
+    manifest.run !== run ||
+    realpathSync(manifest.baseRepo) !== baseRepo ||
+    (options.requireIsolated && manifest.baseCommit === null)
+  ) {
+    throw new RunnerUsageError(
+      `No isolated role wave state exists for ${run}`,
+    )
+  }
+  if (manifest.baseCommit !== null) {
+    const baseCommit = requireGitOid(
+      manifest.baseCommit,
+      'role wave base commit',
+    )
+    runRoleGit(
+      baseRepo,
+      ['cat-file', '-e', `${baseCommit}^{commit}`],
+      dependencies,
+    )
+  } else if (Object.keys(manifest.worktrees).length > 0) {
+    throw new RunnerUsageError(
+      `Role wave ${run} has worktrees without an isolated base commit`,
+    )
+  }
+  const registered = parseGitWorktreeList(
+    runRoleGit(
+      baseRepo,
+      ['worktree', 'list', '--porcelain', '-z'],
+      dependencies,
+    ),
+  )
+  const tempRoot = ensureManagedTempRoot(
+    dependencies.tempRoot ?? os.tmpdir(),
+  )
+  const repoKey = createHash('sha256')
+    .update(baseRepo)
+    .digest('hex')
+    .slice(0, 16)
+  validateRoleWaveManifestIntegrity(manifest, {
+    baseRepo,
+    run,
+    tempRoot,
+    repoKey,
+    registered,
+    runGit: (args) => runRoleGit(baseRepo, args, dependencies),
+  })
+  return { baseRepo, manifestPath, manifest, tempRoot, repoKey }
+}
+
+function validateRoleWaveManifestIntegrity(manifest, context) {
+  if (
+    manifest.run !== context.run ||
+    path.resolve(manifest.baseRepo) !== context.baseRepo
+  ) {
+    throw new RunnerUsageError(
+      `Role wave manifest identity mismatch for ${context.run}`,
+    )
+  }
+  const worktreeRoot = path.join(
+    context.tempRoot,
+    'specrails-kimi-worktrees',
+    context.repoKey,
+    context.run,
+  )
+  const executionRoot = path.join(
+    context.tempRoot,
+    'specrails-kimi-execution',
+    context.repoKey,
+    context.run,
+  )
+  const expectedGitExclude = path.join(
+    context.tempRoot,
+    'specrails-kimi-git-excludes',
+    context.repoKey,
+    `${context.run}.txt`,
+  )
+  let excludeValidated = false
+  const validateExclude = (actual) => {
+    if (path.resolve(actual) !== expectedGitExclude) {
+      throw new RunnerUsageError(
+        `Role wave manifest has an unexpected git exclude path`,
+      )
+    }
+    if (!excludeValidated) {
+      let metadata
+      try {
+        metadata = lstatSync(expectedGitExclude)
+      } catch (error) {
+        throw new RunnerUsageError(
+          `Cannot verify role git exclude file: ${errorMessage(error)}`,
+        )
+      }
+      if (
+        !metadata.isFile() ||
+        metadata.isSymbolicLink() ||
+        readFileSync(expectedGitExclude, 'utf8') !== roleGitExcludeContents()
+      ) {
+        throw new RunnerUsageError(
+          `Invalid role git exclude file: ${expectedGitExclude}`,
+        )
+      }
+      excludeValidated = true
+    }
+  }
+
+  for (const [worktree, target] of Object.entries(manifest.worktrees)) {
+    requireSafeWaveId(worktree, 'manifest worktree id')
+    const expected = path.join(worktreeRoot, worktree)
+    if (path.resolve(target) !== expected) {
+      throw new RunnerUsageError(
+        `Role wave manifest worktree path mismatch: ${worktree}`,
+      )
+    }
+    if (
+      !existsSync(expected) ||
+      realpathSync(expected) !== expected ||
+      !context.registered.has(expected)
+    ) {
+      throw new RunnerUsageError(
+        `Role wave worktree is not the expected registered path: ${worktree}`,
+      )
+    }
+  }
+
+  for (const [roleKey, role] of Object.entries(manifest.roles)) {
+    requireSafeWaveId(roleKey, 'manifest role key')
+    validateExclude(role.gitExcludeFile)
+    if (role.workspace === 'current') {
+      if (
+        path.resolve(role.executionCwd) !==
+          path.join(executionRoot, roleKey) ||
+        path.resolve(role.repoDir) !== context.baseRepo
+      ) {
+        throw new RunnerUsageError(
+          `Role wave manifest current workspace mismatch: ${roleKey}`,
+        )
+      }
+      continue
+    }
+    if (!role.workspace.startsWith('worktree:')) {
+      throw new RunnerUsageError(
+        `Role wave manifest has invalid workspace: ${roleKey}`,
+      )
+    }
+    const worktree = requireSafeWaveId(
+      role.workspace.slice('worktree:'.length),
+      'manifest role worktree id',
+    )
+    const expected = manifest.worktrees[worktree]
+    if (
+      expected === undefined ||
+      path.resolve(role.executionCwd) !== expected ||
+      path.resolve(role.repoDir) !== expected
+    ) {
+      throw new RunnerUsageError(
+        `Role wave manifest isolated workspace mismatch: ${roleKey}`,
+      )
+    }
+  }
+
+  if (manifest.baseCommit !== null) {
+    const baseCommit = requireGitOid(
+      manifest.baseCommit,
+      'role wave base commit',
+    )
+    const ref = `refs/specrails/kimi/${context.repoKey}/${context.run}`
+    const refCommit = requireGitOid(
+      context.runGit(['rev-parse', '--verify', ref]).trim(),
+      'role wave private ref',
+    )
+    if (refCommit !== baseCommit) {
+      throw new RunnerUsageError(
+        `Role wave private ref does not match its baseline: ${context.run}`,
+      )
+    }
+  }
+}
+
+function runRoleGit(cwd, args, dependencies = {}, input) {
+  const command = dependencies.gitBinary ?? 'git'
+  const execute = dependencies.spawnSync ?? spawnSync
+  const result = execute(command, ['-C', cwd, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, ...(dependencies.env ?? {}) },
+    input,
+    maxBuffer: 256 * 1024 * 1024,
+    shell: false,
+  })
+  if (result.error || result.status !== 0) {
+    const detail =
+      errorMessage(result.error ?? '').trim() ||
+      String(result.stderr ?? '').trim() ||
+      `exit ${String(result.status)}`
+    throw new RunnerUsageError(
+      `git ${args.join(' ')} failed in ${cwd}: ${detail}`,
+    )
+  }
+  return String(result.stdout ?? '')
+}
+
+function lstatExists(file) {
+  try {
+    lstatSync(file)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function assertWorkspaceParentSafety(root, file) {
+  let cursor = realpathSync(root)
+  const relative = path.relative(path.resolve(root), path.dirname(file))
+  for (const component of relative.split(path.sep).filter(Boolean)) {
+    cursor = path.join(cursor, component)
+    if (!existsSync(cursor) && !lstatExists(cursor)) break
+    const metadata = lstatSync(cursor)
+    if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+      throw new RunnerUsageError(
+        `Role merge target parent must not be a symlink: ${cursor}`,
+      )
+    }
+  }
+}
+
+function ensureWorkspaceParentDirectories(root, file) {
+  const parent = path.dirname(file)
+  const relative = path.relative(path.resolve(root), parent)
+  let cursor = realpathSync(root)
+  for (const component of relative.split(path.sep).filter(Boolean)) {
+    cursor = path.join(cursor, component)
+    if (!existsSync(cursor) && !lstatExists(cursor)) {
+      mkdirSync(cursor)
+      continue
+    }
+    const metadata = lstatSync(cursor)
+    if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+      throw new RunnerUsageError(
+        `Role merge target parent must not be a symlink: ${cursor}`,
+      )
+    }
+  }
+}
+
+export async function runSkillCli(argv, dependencies = {}) {
+  const cwd = dependencies.cwd ?? process.cwd()
+  const parsedArgs = parseRunnerArgs(argv)
+  const scriptPath = dependencies.scriptPath ?? process.argv[1]
+  const providerRoot = resolveProviderRoot(scriptPath)
+  const writeOutput =
+    dependencies.writeOutput ??
+    ((line) => {
+      process.stdout.write(line)
+    })
+  if (parsedArgs.roleWaveStatus !== undefined) {
+    emitRoleFrame(
+      writeOutput,
+      {
+        type: 'specrails.merge.inventory',
+        ...inspectRoleWaveStatus(parsedArgs.roleWaveStatus, {
+          ...dependencies,
+          cwd,
+        }),
+      },
+    )
+    return 0
+  }
+  if (parsedArgs.roleWaveCleanup !== undefined) {
+    emitRoleFrame(
+      writeOutput,
+      {
+        type: 'specrails.role.cleanup',
+        ...cleanupRoleWave(parsedArgs.roleWaveCleanup, {
+          ...dependencies,
+          cwd,
+        }),
+      },
+    )
+    return 0
+  }
+  if (parsedArgs.roleMergeFile !== undefined) {
+    const merge = loadRoleMerge(parsedArgs, cwd)
+    emitRoleFrame(
+      writeOutput,
+      {
+        type: 'specrails.merge.applied',
+        ...applyRoleMerge(merge, {
+          ...dependencies,
+          cwd,
+        }),
+      },
+    )
+    return 0
+  }
+  if (parsedArgs.roleWaveFile !== undefined) {
+    const wave = loadRoleWave(parsedArgs, cwd)
+    return runRoleWave(wave, {
+      ...dependencies,
+      cwd,
+      providerRoot,
+    })
+  }
+  if (parsedArgs.plainPromptStdin) {
+    const readStdin =
+      dependencies.readStdin ??
+      (() => readFileSync(0, 'utf8'))
+    const prompt = String(readStdin())
+    assertManagedPrompt(prompt)
+    const kimiArgs = [
+      ...(parsedArgs.sessionId
+        ? [`--session=${parsedArgs.sessionId}`]
+        : []),
+      ...parsedArgs.additionalDirs.flatMap((dir) => ['--add-dir', dir]),
+      '-m',
+      normalizeKimiCliModel(parsedArgs.model),
+      '-p',
+      prompt,
+      '--output-format',
+      'stream-json',
+    ]
+    return runPreparedPrompt(kimiArgs, prompt, {
+      ...dependencies,
+      cwd,
+      model: parsedArgs.model,
+    })
+  }
+  const parsed = loadRoleRequest(parsedArgs, cwd)
+  return runPreparedSkill(parsed, {
+    ...dependencies,
+    cwd,
+    providerRoot,
+  })
+}
+
+async function runRoleWave(wave, dependencies) {
+  const sourceEnv = dependencies.env ?? process.env
+  const repositoryCwd =
+    nonEmptyString(sourceEnv.SPECRAILS_REPO_DIR) ?? dependencies.cwd
+  const inheritedProfile = nonEmptyString(
+    sourceEnv.SPECRAILS_PROFILE_PATH,
+  )
+  const materialized = materializeRoleWaveWorkspaces(wave, {
+    cwd: repositoryCwd,
+    providerRoot: dependencies.providerRoot,
+    platform: dependencies.platform,
+    spawnSync: dependencies.spawnSync,
+    gitBinary: dependencies.gitBinary,
+    tempRoot: dependencies.tempRoot,
+  })
+  const writeOutput =
+    dependencies.writeOutput ??
+    ((line) => {
+      process.stdout.write(line)
+    })
+  const children = new Set()
+  const aggregateChild = {
+    kill(signal) {
+      for (const child of children) child.kill?.(signal)
+    },
+  }
+  const removeSignalForwarding = forwardTerminationSignals(
+    aggregateChild,
+    dependencies.signalSource ?? process,
+  )
+
+  try {
+    const results = await Promise.all(
+      materialized.roles.map(async (role) => {
+        emitRoleFrame(writeOutput, {
+          type: 'specrails.role.workspace',
+          run: materialized.run,
+          roleKey: role.key,
+          workspace: role.workspace,
+          executionCwd: role.cwd,
+          repoDir: role.repoDir,
+          baseCommit: materialized.baseCommit,
+          manifestPath: materialized.manifestPath,
+        })
+        try {
+          const code = await runPreparedSkill(
+            {
+              skill: role.skill,
+              model: role.model,
+              rawArgs: role.rawArgs,
+              sessionId: undefined,
+              additionalDirs: Array.from(
+                new Set([
+                  ...wave.additionalDirs,
+                  materialized.baseRepo,
+                ]),
+              ),
+              attachmentPaths: [],
+              extraPrompt: undefined,
+            },
+            {
+              ...dependencies,
+              cwd: role.cwd,
+              providerRoot: dependencies.providerRoot,
+              env: {
+                ...sourceEnv,
+                SPECRAILS_REPO_DIR: role.repoDir,
+                SPECRAILS_MERGE_TARGET: materialized.baseRepo,
+                SPECRAILS_KIMI_WORKTREE_MANIFEST:
+                  materialized.manifestPath,
+                ...(role.profile === 'inherit'
+                  ? inheritedProfile === undefined
+                    ? {}
+                    : {
+                        SPECRAILS_PROFILE_PATH: path.isAbsolute(
+                          inheritedProfile,
+                        )
+                          ? inheritedProfile
+                          : path.resolve(
+                              materialized.baseRepo,
+                              inheritedProfile,
+                            ),
+                      }
+                  : {
+                      SPECRAILS_PROFILE_PATH: path.join(
+                        materialized.baseRepo,
+                        '.specrails',
+                        'profiles',
+                        `${role.profile}.json`,
+                      ),
+                    }),
+                GIT_CONFIG_COUNT: '1',
+                GIT_CONFIG_KEY_0: 'core.excludesFile',
+                GIT_CONFIG_VALUE_0: role.gitExcludeFile,
+              },
+              captureRoleKey: role.key,
+              writeOutput,
+              childRegistry: children,
+              forwardSignals: false,
+            },
+          )
+          emitRoleFrame(writeOutput, {
+            type: 'specrails.role.completed',
+            run: materialized.run,
+            roleKey: role.key,
+            status: code === 0 ? 'succeeded' : 'failed',
+            exitCode: code,
+          })
+          return code
+        } catch (error) {
+          emitRoleFrame(writeOutput, {
+            type: 'specrails.role.completed',
+            run: materialized.run,
+            roleKey: role.key,
+            status: 'failed',
+            exitCode: 1,
+            error: errorMessage(error),
+          })
+          return 1
+        }
+      }),
+    )
+    return results.find((code) => code !== 0) ?? 0
+  } finally {
+    removeSignalForwarding()
+  }
+}
+
+async function runPreparedSkill(parsed, dependencies) {
+  const prepared = prepareSkillLaunch(
+    { ...parsed, providerRoot: dependencies.providerRoot },
+    dependencies,
+  )
+  return runPreparedPrompt(
+    prepared.kimiArgs,
+    prepared.prompt,
+    {
+      ...dependencies,
+      model: parsed.model,
+    },
+  )
+}
+
+async function runPreparedPrompt(kimiArgs, prompt, dependencies) {
+  assertManagedPrompt(prompt)
+  let child
+  let removeSignalForwarding = () => {}
+  try {
+    // Kimi 0.27 exposes only `-p <prompt>` for an exact non-interactive user
+    // turn. The managed runner receives plain prompts over stdin so the host
+    // process does not expose them, but a native Kimi binary must still receive
+    // the exact prompt in its own argv. npm Windows shims use the exact stdin
+    // bootstrap in resolveKimiLaunch instead. Do not replace this with a
+    // prompt-file instruction: that changes the first user turn and telemetry.
+    const launch = resolveKimiLaunch(kimiArgs, dependencies)
+    const spawnChild = dependencies.spawnChild ?? spawn
+    const env = stableKimiEnvironment(
+      dependencies.env ?? process.env,
+      dependencies.model,
+    )
+    child = spawnChild(launch.command, launch.args, {
+      cwd: dependencies.cwd,
+      env,
+      shell: false,
+      stdio:
+        dependencies.captureRoleKey === undefined
+          ? launch.stdinText === undefined
+            ? 'inherit'
+            : ['pipe', 'inherit', 'inherit']
+          : launch.stdinText === undefined
+            ? ['ignore', 'pipe', 'pipe']
+            : ['pipe', 'pipe', 'pipe'],
+    })
+    dependencies.childRegistry?.add(child)
+    const completion = waitForChild(child)
+    const outputCompletion =
+      dependencies.captureRoleKey === undefined
+        ? Promise.resolve()
+        : captureRoleOutput(
+            child,
+            dependencies.captureRoleKey,
+            dependencies.writeOutput,
+          )
+    removeSignalForwarding =
+      dependencies.forwardSignals === false
+        ? () => {}
+        : forwardTerminationSignals(
+            child,
+            dependencies.signalSource ?? process,
+        )
+    if (launch.stdinText === undefined) {
+      const [code] = await Promise.all([completion, outputCompletion])
+      return code
+    }
+    try {
+      const [code] = await Promise.all([
+        completion,
+        writePromptToChild(child, launch.stdinText),
+        outputCompletion,
+      ])
+      return code
+    } catch (error) {
+      child.kill?.('SIGTERM')
+      throw error
+    }
+  } finally {
+    if (child !== undefined) dependencies.childRegistry?.delete(child)
+    removeSignalForwarding()
+  }
+}
+
+function assertManagedPrompt(prompt) {
+  if (typeof prompt !== 'string' || prompt.trim() === '') {
+    throw new RunnerUsageError('Kimi prompt must not be empty')
+  }
+  const byteLength = Buffer.byteLength(prompt, 'utf8')
+  if (byteLength > MAX_MANAGED_PROMPT_BYTES) {
+    throw new RunnerUsageError(
+      `Kimi prompt exceeds ${MAX_MANAGED_PROMPT_BYTES} UTF-8 bytes`,
+    )
+  }
+}
+
+function captureRoleOutput(child, roleKey, writeOutput) {
+  const streams = [
+    ['stdout', child.stdout],
+    ['stderr', child.stderr],
+  ].filter(([, stream]) => stream?.on)
+  if (streams.length === 0) return Promise.resolve()
+  return Promise.all(
+    streams.map(([streamName, stream]) =>
+      new Promise((resolve) => {
+        const decoder = new StringDecoder('utf8')
+        let pending = ''
+        let finished = false
+        const emitLines = (final) => {
+          const parts = pending.split('\n')
+          pending = final ? '' : (parts.pop() ?? '')
+          for (const line of parts) {
+            emitCapturedRoleLine(
+              writeOutput,
+              roleKey,
+              streamName,
+              line.replace(/\r$/, ''),
+            )
+          }
+          if (final && pending !== '') {
+            emitCapturedRoleLine(
+              writeOutput,
+              roleKey,
+              streamName,
+              pending.replace(/\r$/, ''),
+            )
+            pending = ''
+          }
+        }
+        const finish = () => {
+          if (finished) return
+          finished = true
+          pending += decoder.end()
+          emitLines(true)
+          resolve()
+        }
+        stream.on('data', (chunk) => {
+          pending += decoder.write(
+            Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)),
+          )
+          emitLines(false)
+        })
+        stream.once('end', finish)
+        stream.once('close', finish)
+        stream.once('error', (error) => {
+          emitRoleFrame(writeOutput, {
+            type: 'specrails.role.output-error',
+            roleKey,
+            stream: streamName,
+            error: errorMessage(error),
+          })
+          finish()
+        })
+      }),
+    ),
+  ).then(() => undefined)
+}
+
+function emitCapturedRoleLine(writeOutput, roleKey, stream, line) {
+  if (line === '') return
+  if (stream === 'stdout') {
+    try {
+      emitRoleFrame(writeOutput, {
+        type: 'specrails.role.event',
+        roleKey,
+        event: JSON.parse(line),
+      })
+      return
+    } catch {
+      // Preserve non-JSON output as an attributed frame.
+    }
+  }
+  emitRoleFrame(writeOutput, {
+    type: 'specrails.role.output',
+    roleKey,
+    stream,
+    data: line,
+  })
+}
+
+function emitRoleFrame(writeOutput, value) {
+  writeOutput(`${JSON.stringify({ role: 'meta', ...value })}\n`)
+}
+
+export function forwardTerminationSignals(child, signalSource = process) {
+  const signals = ['SIGINT', 'SIGTERM', 'SIGHUP']
+  const handlers = new Map()
+  for (const signal of signals) {
+    const handler = () => {
+      try {
+        child.kill?.(signal)
+      } catch {
+        // The child may already have exited; waitForChild owns final status.
+      }
+    }
+    handlers.set(signal, handler)
+    signalSource.on(signal, handler)
+  }
+  return () => {
+    for (const [signal, handler] of handlers) {
+      signalSource.off(signal, handler)
+    }
+  }
+}
+
+export function resolveProviderRoot(scriptPath) {
+  const absolute = path.resolve(requireNonEmpty(scriptPath, 'runner path'))
+  const runnerDir = path.dirname(absolute)
+  const providerRoot = path.dirname(runnerDir)
+  if (
+    path.basename(runnerDir) !== 'specrails' ||
+    path.basename(providerRoot) !== '.kimi-code'
+  ) {
+    throw new RunnerUsageError(
+      'run-skill.mjs must be invoked from .kimi-code/specrails/run-skill.mjs',
+    )
+  }
+  return providerRoot
+}
+
+function skillArgumentNames(value) {
+  const isValidName = (name) => name.trim() !== '' && !/^\d+$/.test(name)
+  if (typeof value === 'string') return value.split(/\s+/).filter(isValidName)
+  if (!Array.isArray(value)) return []
+  return value.filter((item) => typeof item === 'string' && isValidName(item))
+}
+
+function isRecord(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function nonEmptyString(value) {
+  return typeof value === 'string' && value.trim() !== ''
+    ? value.trim()
+    : undefined
+}
+
+function escapeXml(input) {
+  return input
+    .split('&')
+    .join('&amp;')
+    .split('<')
+    .join('&lt;')
+    .split('>')
+    .join('&gt;')
+    .split('"')
+    .join('&quot;')
+}
+
+function escapeXmlTags(input) {
+  return input.split('<').join('&lt;').split('>').join('&gt;')
+}
+
+function escapeRegExp(input) {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function toPromptPath(nativePath) {
+  const slashPath = nativePath.split('\\').join('/').split(path.sep).join('/')
+  return /^[a-z]:\//.test(slashPath)
+    ? slashPath[0].toUpperCase() + slashPath.slice(1)
+    : slashPath
+}
+
+function requireSafeSkillId(value) {
+  const skill = requireNonEmpty(value, 'skill')
+  if (!SAFE_SKILL_ID.test(skill)) {
+    throw new RunnerUsageError(`Invalid skill id: ${skill}`)
+  }
+  return skill
+}
+
+function requireSafeModelId(value) {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > MAX_MODEL_ID_LENGTH ||
+    !SAFE_MODEL_ID.test(value)
+  ) {
+    throw new RunnerUsageError(
+      'Invalid model id: expected 1-128 characters matching ' +
+        '[A-Za-z0-9][A-Za-z0-9._/:-]*',
+    )
+  }
+  return value
+}
+
+function requireSafeSessionId(value) {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > MAX_SESSION_ID_LENGTH ||
+    !SAFE_SESSION_ID.test(value) ||
+    value === '.' ||
+    value === '..'
+  ) {
+    throw new RunnerUsageError(
+      'Invalid session id: expected 1-128 characters matching ' +
+        '[A-Za-z0-9._-]+, excluding "." and ".."',
+    )
+  }
+  return value
+}
+
+function requireSafeWaveId(value, label) {
+  if (typeof value !== 'string' || !SAFE_WAVE_ID.test(value)) {
+    throw new RunnerUsageError(
+      `Invalid ${label}: expected 1-64 lowercase letters, digits, or hyphens`,
+    )
+  }
+  return value
+}
+
+function requireGitOid(value, label) {
+  if (typeof value !== 'string' || !SAFE_GIT_OID.test(value)) {
+    throw new RunnerUsageError(
+      `Invalid ${label}: expected a 40- or 64-character lowercase hex commit id`,
+    )
+  }
+  return value
+}
+
+function requireSafeRelativePath(value, label) {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    Buffer.byteLength(value, 'utf8') > 4_096 ||
+    value.includes('\0') ||
+    value.includes('\\') ||
+    path.posix.isAbsolute(value) ||
+    path.posix.normalize(value) !== value ||
+    value.split('/').some((part) => part === '' || part === '.' || part === '..') ||
+    isManagedRolePath(value)
+  ) {
+    throw new RunnerUsageError(`Invalid ${label}`)
+  }
+  return value
+}
+
+function requireNonEmpty(value, label) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new RunnerUsageError(`Missing or empty ${label}`)
+  }
+  assertNoNul(value, label)
+  return value.trim()
+}
+
+function assertNoNul(value, label) {
+  if (value.includes('\0')) throw new RunnerUsageError(`${label} contains a NUL byte`)
+}
+
+function getEnvCaseInsensitive(env, key) {
+  const found = Object.entries(env ?? {}).find(
+    ([candidate]) => candidate.toUpperCase() === key,
+  )
+  return found?.[1]
+}
+
+export function windowsCommandLineLength(command, args) {
+  return [command, ...args].map(quoteWindowsArgument).join(' ').length
+}
+
+function assertWindowsCommandLineBudget(command, args) {
+  const length = windowsCommandLineLength(command, args)
+  if (length > WINDOWS_COMMAND_LINE_BUDGET) {
+    throw new RunnerUsageError(
+      `Kimi Windows command line requires ${length} UTF-16 code units, above ` +
+        `${WINDOWS_COMMAND_LINE_BUDGET}. Use the standard npm kimi.cmd shim so ` +
+        'SpecRails can transport the materialized prompt over stdin.',
+    )
+  }
+}
+
+function quoteWindowsArgument(value) {
+  if (value !== '' && !/[\s"]/u.test(value)) return value
+  return (
+    '"' +
+    value
+      .replace(/(\\*)"/g, '$1$1\\"')
+      .replace(/(\\+)$/g, '$1$1') +
+    '"'
+  )
+}
+
+export function stableKimiEnvironment(source, model) {
+  const env = { ...source }
+  let validThinkingEffort
+  for (const key of Object.keys(env)) {
+    const normalizedKey = key.toUpperCase()
+    if (normalizedKey === 'KIMI_CODE_EXPERIMENTAL_FLAG') {
+      delete env[key]
+    } else if (
+      normalizedKey === 'KIMI_DISABLE_CRON' ||
+      normalizedKey === 'KIMI_CODE_NO_AUTO_UPDATE'
+    ) {
+      delete env[key]
+    } else if (normalizedKey === 'KIMI_MODEL_THINKING_EFFORT') {
+      const value = env[key]
+      if (
+        validThinkingEffort === undefined &&
+        (value === 'low' || value === 'high' || value === 'max')
+      ) {
+        validThinkingEffort = value
+      }
+      delete env[key]
+    }
+  }
+  // A managed `-p` run owns one bounded foreground invocation. It must not
+  // create persistent schedules or mutate the external CLI during startup.
+  env.KIMI_DISABLE_CRON = '1'
+  env.KIMI_CODE_NO_AUTO_UPDATE = '1'
+  if (
+    normalizeKimiCliModel(model) === 'kimi-code/k3' &&
+    validThinkingEffort !== undefined
+  ) {
+    env.KIMI_MODEL_THINKING_EFFORT = validThinkingEffort
+  }
+  return env
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function waitForChild(child) {
+  return new Promise((resolve, reject) => {
+    child.once('error', reject)
+    child.once('exit', (code, signal) => {
+      if (code !== null) {
+        resolve(code)
+        return
+      }
+      resolve(signal === 'SIGINT' ? 130 : signal === 'SIGHUP' ? 129 : 143)
+    })
+  })
+}
+
+function writePromptToChild(child, prompt) {
+  if (!child.stdin || typeof child.stdin.end !== 'function') {
+    return Promise.reject(new RunnerUsageError(
+      'Cannot transport the Kimi prompt: child stdin is unavailable',
+    ))
+  }
+
+  return new Promise((resolve, reject) => {
+    let settled = false
+    const finish = (error, keepErrorListener = false) => {
+      if (settled) return
+      settled = true
+      // Node's Writable.end callback receives a write error before the stream
+      // emits its corresponding `error` event. Keep the once-listener in that
+      // case so the later event is consumed instead of becoming unhandled.
+      if (!keepErrorListener) child.stdin.off?.('error', onError)
+      if (error) {
+        reject(
+          new RunnerUsageError(
+            `Cannot transport the Kimi prompt: ${errorMessage(error)}`,
+          ),
+        )
+      } else {
+        resolve()
+      }
+    }
+    const onError = (error) => finish(error)
+    child.stdin.once('error', onError)
+    child.stdin.end(prompt, 'utf8', (error) =>
+      finish(error, Boolean(error)),
+    )
+  })
+}
+
+function isDirectExecution() {
+  if (!process.argv[1]) return false
+  try {
+    return realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url))
+  } catch {
+    return false
+  }
+}
+
+if (isDirectExecution()) {
+  try {
+    process.exitCode = await runSkillCli(process.argv.slice(2))
+  } catch (error) {
+    const prefix = error instanceof RunnerUsageError ? 'usage error' : 'error'
+    process.stderr.write(`specrails Kimi skill runner ${prefix}: ${errorMessage(error)}\n`)
+    process.exitCode = error instanceof RunnerUsageError ? 2 : 1
+  }
+}

--- a/templates/kimi/specrails/vendor/js-yaml/LICENSE
+++ b/templates/kimi/specrails/vendor/js-yaml/LICENSE
@@ -1,0 +1,21 @@
+(The MIT License)
+
+Copyright (C) 2011-2015 by Vitaly Puzrin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/templates/kimi/specrails/vendor/js-yaml/NOTICE.md
+++ b/templates/kimi/specrails/vendor/js-yaml/NOTICE.md
@@ -1,0 +1,16 @@
+# Vendored js-yaml
+
+This directory contains the unmodified ESM distribution and MIT license from
+[`js-yaml` 4.1.1](https://www.npmjs.com/package/js-yaml/v/4.1.1).
+
+- Source package: `js-yaml@4.1.1`
+- Source file: `dist/js-yaml.mjs`
+- `js-yaml.mjs` SHA-256:
+  `efbc45850bf15f0c8ee3434983f512be656002d7507dc292c7ade4449b5d57fa`
+- `LICENSE` SHA-256:
+  `a07bc24468b9654ce76a547d47a2db282d07733b715db4c73a98bd63961f9550`
+
+SpecRails vendors this parser so `.kimi-code/specrails/run-skill.mjs` can apply
+Kimi-compatible YAML frontmatter semantics without depending on the target
+project's `node_modules`. The files are copied, updated, checksummed, and
+diagnosed as one managed runtime bundle.

--- a/templates/kimi/specrails/vendor/js-yaml/js-yaml.mjs
+++ b/templates/kimi/specrails/vendor/js-yaml/js-yaml.mjs
@@ -1,0 +1,3856 @@
+
+/*! js-yaml 4.1.1 https://github.com/nodeca/js-yaml @license MIT */
+function isNothing(subject) {
+  return (typeof subject === 'undefined') || (subject === null);
+}
+
+
+function isObject(subject) {
+  return (typeof subject === 'object') && (subject !== null);
+}
+
+
+function toArray(sequence) {
+  if (Array.isArray(sequence)) return sequence;
+  else if (isNothing(sequence)) return [];
+
+  return [ sequence ];
+}
+
+
+function extend(target, source) {
+  var index, length, key, sourceKeys;
+
+  if (source) {
+    sourceKeys = Object.keys(source);
+
+    for (index = 0, length = sourceKeys.length; index < length; index += 1) {
+      key = sourceKeys[index];
+      target[key] = source[key];
+    }
+  }
+
+  return target;
+}
+
+
+function repeat(string, count) {
+  var result = '', cycle;
+
+  for (cycle = 0; cycle < count; cycle += 1) {
+    result += string;
+  }
+
+  return result;
+}
+
+
+function isNegativeZero(number) {
+  return (number === 0) && (Number.NEGATIVE_INFINITY === 1 / number);
+}
+
+
+var isNothing_1      = isNothing;
+var isObject_1       = isObject;
+var toArray_1        = toArray;
+var repeat_1         = repeat;
+var isNegativeZero_1 = isNegativeZero;
+var extend_1         = extend;
+
+var common = {
+	isNothing: isNothing_1,
+	isObject: isObject_1,
+	toArray: toArray_1,
+	repeat: repeat_1,
+	isNegativeZero: isNegativeZero_1,
+	extend: extend_1
+};
+
+// YAML error class. http://stackoverflow.com/questions/8458984
+
+
+function formatError(exception, compact) {
+  var where = '', message = exception.reason || '(unknown reason)';
+
+  if (!exception.mark) return message;
+
+  if (exception.mark.name) {
+    where += 'in "' + exception.mark.name + '" ';
+  }
+
+  where += '(' + (exception.mark.line + 1) + ':' + (exception.mark.column + 1) + ')';
+
+  if (!compact && exception.mark.snippet) {
+    where += '\n\n' + exception.mark.snippet;
+  }
+
+  return message + ' ' + where;
+}
+
+
+function YAMLException$1(reason, mark) {
+  // Super constructor
+  Error.call(this);
+
+  this.name = 'YAMLException';
+  this.reason = reason;
+  this.mark = mark;
+  this.message = formatError(this, false);
+
+  // Include stack trace in error object
+  if (Error.captureStackTrace) {
+    // Chrome and NodeJS
+    Error.captureStackTrace(this, this.constructor);
+  } else {
+    // FF, IE 10+ and Safari 6+. Fallback for others
+    this.stack = (new Error()).stack || '';
+  }
+}
+
+
+// Inherit from Error
+YAMLException$1.prototype = Object.create(Error.prototype);
+YAMLException$1.prototype.constructor = YAMLException$1;
+
+
+YAMLException$1.prototype.toString = function toString(compact) {
+  return this.name + ': ' + formatError(this, compact);
+};
+
+
+var exception = YAMLException$1;
+
+// get snippet for a single line, respecting maxLength
+function getLine(buffer, lineStart, lineEnd, position, maxLineLength) {
+  var head = '';
+  var tail = '';
+  var maxHalfLength = Math.floor(maxLineLength / 2) - 1;
+
+  if (position - lineStart > maxHalfLength) {
+    head = ' ... ';
+    lineStart = position - maxHalfLength + head.length;
+  }
+
+  if (lineEnd - position > maxHalfLength) {
+    tail = ' ...';
+    lineEnd = position + maxHalfLength - tail.length;
+  }
+
+  return {
+    str: head + buffer.slice(lineStart, lineEnd).replace(/\t/g, '→') + tail,
+    pos: position - lineStart + head.length // relative position
+  };
+}
+
+
+function padStart(string, max) {
+  return common.repeat(' ', max - string.length) + string;
+}
+
+
+function makeSnippet(mark, options) {
+  options = Object.create(options || null);
+
+  if (!mark.buffer) return null;
+
+  if (!options.maxLength) options.maxLength = 79;
+  if (typeof options.indent      !== 'number') options.indent      = 1;
+  if (typeof options.linesBefore !== 'number') options.linesBefore = 3;
+  if (typeof options.linesAfter  !== 'number') options.linesAfter  = 2;
+
+  var re = /\r?\n|\r|\0/g;
+  var lineStarts = [ 0 ];
+  var lineEnds = [];
+  var match;
+  var foundLineNo = -1;
+
+  while ((match = re.exec(mark.buffer))) {
+    lineEnds.push(match.index);
+    lineStarts.push(match.index + match[0].length);
+
+    if (mark.position <= match.index && foundLineNo < 0) {
+      foundLineNo = lineStarts.length - 2;
+    }
+  }
+
+  if (foundLineNo < 0) foundLineNo = lineStarts.length - 1;
+
+  var result = '', i, line;
+  var lineNoLength = Math.min(mark.line + options.linesAfter, lineEnds.length).toString().length;
+  var maxLineLength = options.maxLength - (options.indent + lineNoLength + 3);
+
+  for (i = 1; i <= options.linesBefore; i++) {
+    if (foundLineNo - i < 0) break;
+    line = getLine(
+      mark.buffer,
+      lineStarts[foundLineNo - i],
+      lineEnds[foundLineNo - i],
+      mark.position - (lineStarts[foundLineNo] - lineStarts[foundLineNo - i]),
+      maxLineLength
+    );
+    result = common.repeat(' ', options.indent) + padStart((mark.line - i + 1).toString(), lineNoLength) +
+      ' | ' + line.str + '\n' + result;
+  }
+
+  line = getLine(mark.buffer, lineStarts[foundLineNo], lineEnds[foundLineNo], mark.position, maxLineLength);
+  result += common.repeat(' ', options.indent) + padStart((mark.line + 1).toString(), lineNoLength) +
+    ' | ' + line.str + '\n';
+  result += common.repeat('-', options.indent + lineNoLength + 3 + line.pos) + '^' + '\n';
+
+  for (i = 1; i <= options.linesAfter; i++) {
+    if (foundLineNo + i >= lineEnds.length) break;
+    line = getLine(
+      mark.buffer,
+      lineStarts[foundLineNo + i],
+      lineEnds[foundLineNo + i],
+      mark.position - (lineStarts[foundLineNo] - lineStarts[foundLineNo + i]),
+      maxLineLength
+    );
+    result += common.repeat(' ', options.indent) + padStart((mark.line + i + 1).toString(), lineNoLength) +
+      ' | ' + line.str + '\n';
+  }
+
+  return result.replace(/\n$/, '');
+}
+
+
+var snippet = makeSnippet;
+
+var TYPE_CONSTRUCTOR_OPTIONS = [
+  'kind',
+  'multi',
+  'resolve',
+  'construct',
+  'instanceOf',
+  'predicate',
+  'represent',
+  'representName',
+  'defaultStyle',
+  'styleAliases'
+];
+
+var YAML_NODE_KINDS = [
+  'scalar',
+  'sequence',
+  'mapping'
+];
+
+function compileStyleAliases(map) {
+  var result = {};
+
+  if (map !== null) {
+    Object.keys(map).forEach(function (style) {
+      map[style].forEach(function (alias) {
+        result[String(alias)] = style;
+      });
+    });
+  }
+
+  return result;
+}
+
+function Type$1(tag, options) {
+  options = options || {};
+
+  Object.keys(options).forEach(function (name) {
+    if (TYPE_CONSTRUCTOR_OPTIONS.indexOf(name) === -1) {
+      throw new exception('Unknown option "' + name + '" is met in definition of "' + tag + '" YAML type.');
+    }
+  });
+
+  // TODO: Add tag format check.
+  this.options       = options; // keep original options in case user wants to extend this type later
+  this.tag           = tag;
+  this.kind          = options['kind']          || null;
+  this.resolve       = options['resolve']       || function () { return true; };
+  this.construct     = options['construct']     || function (data) { return data; };
+  this.instanceOf    = options['instanceOf']    || null;
+  this.predicate     = options['predicate']     || null;
+  this.represent     = options['represent']     || null;
+  this.representName = options['representName'] || null;
+  this.defaultStyle  = options['defaultStyle']  || null;
+  this.multi         = options['multi']         || false;
+  this.styleAliases  = compileStyleAliases(options['styleAliases'] || null);
+
+  if (YAML_NODE_KINDS.indexOf(this.kind) === -1) {
+    throw new exception('Unknown kind "' + this.kind + '" is specified for "' + tag + '" YAML type.');
+  }
+}
+
+var type = Type$1;
+
+/*eslint-disable max-len*/
+
+
+
+
+
+function compileList(schema, name) {
+  var result = [];
+
+  schema[name].forEach(function (currentType) {
+    var newIndex = result.length;
+
+    result.forEach(function (previousType, previousIndex) {
+      if (previousType.tag === currentType.tag &&
+          previousType.kind === currentType.kind &&
+          previousType.multi === currentType.multi) {
+
+        newIndex = previousIndex;
+      }
+    });
+
+    result[newIndex] = currentType;
+  });
+
+  return result;
+}
+
+
+function compileMap(/* lists... */) {
+  var result = {
+        scalar: {},
+        sequence: {},
+        mapping: {},
+        fallback: {},
+        multi: {
+          scalar: [],
+          sequence: [],
+          mapping: [],
+          fallback: []
+        }
+      }, index, length;
+
+  function collectType(type) {
+    if (type.multi) {
+      result.multi[type.kind].push(type);
+      result.multi['fallback'].push(type);
+    } else {
+      result[type.kind][type.tag] = result['fallback'][type.tag] = type;
+    }
+  }
+
+  for (index = 0, length = arguments.length; index < length; index += 1) {
+    arguments[index].forEach(collectType);
+  }
+  return result;
+}
+
+
+function Schema$1(definition) {
+  return this.extend(definition);
+}
+
+
+Schema$1.prototype.extend = function extend(definition) {
+  var implicit = [];
+  var explicit = [];
+
+  if (definition instanceof type) {
+    // Schema.extend(type)
+    explicit.push(definition);
+
+  } else if (Array.isArray(definition)) {
+    // Schema.extend([ type1, type2, ... ])
+    explicit = explicit.concat(definition);
+
+  } else if (definition && (Array.isArray(definition.implicit) || Array.isArray(definition.explicit))) {
+    // Schema.extend({ explicit: [ type1, type2, ... ], implicit: [ type1, type2, ... ] })
+    if (definition.implicit) implicit = implicit.concat(definition.implicit);
+    if (definition.explicit) explicit = explicit.concat(definition.explicit);
+
+  } else {
+    throw new exception('Schema.extend argument should be a Type, [ Type ], ' +
+      'or a schema definition ({ implicit: [...], explicit: [...] })');
+  }
+
+  implicit.forEach(function (type$1) {
+    if (!(type$1 instanceof type)) {
+      throw new exception('Specified list of YAML types (or a single Type object) contains a non-Type object.');
+    }
+
+    if (type$1.loadKind && type$1.loadKind !== 'scalar') {
+      throw new exception('There is a non-scalar type in the implicit list of a schema. Implicit resolving of such types is not supported.');
+    }
+
+    if (type$1.multi) {
+      throw new exception('There is a multi type in the implicit list of a schema. Multi tags can only be listed as explicit.');
+    }
+  });
+
+  explicit.forEach(function (type$1) {
+    if (!(type$1 instanceof type)) {
+      throw new exception('Specified list of YAML types (or a single Type object) contains a non-Type object.');
+    }
+  });
+
+  var result = Object.create(Schema$1.prototype);
+
+  result.implicit = (this.implicit || []).concat(implicit);
+  result.explicit = (this.explicit || []).concat(explicit);
+
+  result.compiledImplicit = compileList(result, 'implicit');
+  result.compiledExplicit = compileList(result, 'explicit');
+  result.compiledTypeMap  = compileMap(result.compiledImplicit, result.compiledExplicit);
+
+  return result;
+};
+
+
+var schema = Schema$1;
+
+var str = new type('tag:yaml.org,2002:str', {
+  kind: 'scalar',
+  construct: function (data) { return data !== null ? data : ''; }
+});
+
+var seq = new type('tag:yaml.org,2002:seq', {
+  kind: 'sequence',
+  construct: function (data) { return data !== null ? data : []; }
+});
+
+var map = new type('tag:yaml.org,2002:map', {
+  kind: 'mapping',
+  construct: function (data) { return data !== null ? data : {}; }
+});
+
+var failsafe = new schema({
+  explicit: [
+    str,
+    seq,
+    map
+  ]
+});
+
+function resolveYamlNull(data) {
+  if (data === null) return true;
+
+  var max = data.length;
+
+  return (max === 1 && data === '~') ||
+         (max === 4 && (data === 'null' || data === 'Null' || data === 'NULL'));
+}
+
+function constructYamlNull() {
+  return null;
+}
+
+function isNull(object) {
+  return object === null;
+}
+
+var _null = new type('tag:yaml.org,2002:null', {
+  kind: 'scalar',
+  resolve: resolveYamlNull,
+  construct: constructYamlNull,
+  predicate: isNull,
+  represent: {
+    canonical: function () { return '~';    },
+    lowercase: function () { return 'null'; },
+    uppercase: function () { return 'NULL'; },
+    camelcase: function () { return 'Null'; },
+    empty:     function () { return '';     }
+  },
+  defaultStyle: 'lowercase'
+});
+
+function resolveYamlBoolean(data) {
+  if (data === null) return false;
+
+  var max = data.length;
+
+  return (max === 4 && (data === 'true' || data === 'True' || data === 'TRUE')) ||
+         (max === 5 && (data === 'false' || data === 'False' || data === 'FALSE'));
+}
+
+function constructYamlBoolean(data) {
+  return data === 'true' ||
+         data === 'True' ||
+         data === 'TRUE';
+}
+
+function isBoolean(object) {
+  return Object.prototype.toString.call(object) === '[object Boolean]';
+}
+
+var bool = new type('tag:yaml.org,2002:bool', {
+  kind: 'scalar',
+  resolve: resolveYamlBoolean,
+  construct: constructYamlBoolean,
+  predicate: isBoolean,
+  represent: {
+    lowercase: function (object) { return object ? 'true' : 'false'; },
+    uppercase: function (object) { return object ? 'TRUE' : 'FALSE'; },
+    camelcase: function (object) { return object ? 'True' : 'False'; }
+  },
+  defaultStyle: 'lowercase'
+});
+
+function isHexCode(c) {
+  return ((0x30/* 0 */ <= c) && (c <= 0x39/* 9 */)) ||
+         ((0x41/* A */ <= c) && (c <= 0x46/* F */)) ||
+         ((0x61/* a */ <= c) && (c <= 0x66/* f */));
+}
+
+function isOctCode(c) {
+  return ((0x30/* 0 */ <= c) && (c <= 0x37/* 7 */));
+}
+
+function isDecCode(c) {
+  return ((0x30/* 0 */ <= c) && (c <= 0x39/* 9 */));
+}
+
+function resolveYamlInteger(data) {
+  if (data === null) return false;
+
+  var max = data.length,
+      index = 0,
+      hasDigits = false,
+      ch;
+
+  if (!max) return false;
+
+  ch = data[index];
+
+  // sign
+  if (ch === '-' || ch === '+') {
+    ch = data[++index];
+  }
+
+  if (ch === '0') {
+    // 0
+    if (index + 1 === max) return true;
+    ch = data[++index];
+
+    // base 2, base 8, base 16
+
+    if (ch === 'b') {
+      // base 2
+      index++;
+
+      for (; index < max; index++) {
+        ch = data[index];
+        if (ch === '_') continue;
+        if (ch !== '0' && ch !== '1') return false;
+        hasDigits = true;
+      }
+      return hasDigits && ch !== '_';
+    }
+
+
+    if (ch === 'x') {
+      // base 16
+      index++;
+
+      for (; index < max; index++) {
+        ch = data[index];
+        if (ch === '_') continue;
+        if (!isHexCode(data.charCodeAt(index))) return false;
+        hasDigits = true;
+      }
+      return hasDigits && ch !== '_';
+    }
+
+
+    if (ch === 'o') {
+      // base 8
+      index++;
+
+      for (; index < max; index++) {
+        ch = data[index];
+        if (ch === '_') continue;
+        if (!isOctCode(data.charCodeAt(index))) return false;
+        hasDigits = true;
+      }
+      return hasDigits && ch !== '_';
+    }
+  }
+
+  // base 10 (except 0)
+
+  // value should not start with `_`;
+  if (ch === '_') return false;
+
+  for (; index < max; index++) {
+    ch = data[index];
+    if (ch === '_') continue;
+    if (!isDecCode(data.charCodeAt(index))) {
+      return false;
+    }
+    hasDigits = true;
+  }
+
+  // Should have digits and should not end with `_`
+  if (!hasDigits || ch === '_') return false;
+
+  return true;
+}
+
+function constructYamlInteger(data) {
+  var value = data, sign = 1, ch;
+
+  if (value.indexOf('_') !== -1) {
+    value = value.replace(/_/g, '');
+  }
+
+  ch = value[0];
+
+  if (ch === '-' || ch === '+') {
+    if (ch === '-') sign = -1;
+    value = value.slice(1);
+    ch = value[0];
+  }
+
+  if (value === '0') return 0;
+
+  if (ch === '0') {
+    if (value[1] === 'b') return sign * parseInt(value.slice(2), 2);
+    if (value[1] === 'x') return sign * parseInt(value.slice(2), 16);
+    if (value[1] === 'o') return sign * parseInt(value.slice(2), 8);
+  }
+
+  return sign * parseInt(value, 10);
+}
+
+function isInteger(object) {
+  return (Object.prototype.toString.call(object)) === '[object Number]' &&
+         (object % 1 === 0 && !common.isNegativeZero(object));
+}
+
+var int = new type('tag:yaml.org,2002:int', {
+  kind: 'scalar',
+  resolve: resolveYamlInteger,
+  construct: constructYamlInteger,
+  predicate: isInteger,
+  represent: {
+    binary:      function (obj) { return obj >= 0 ? '0b' + obj.toString(2) : '-0b' + obj.toString(2).slice(1); },
+    octal:       function (obj) { return obj >= 0 ? '0o'  + obj.toString(8) : '-0o'  + obj.toString(8).slice(1); },
+    decimal:     function (obj) { return obj.toString(10); },
+    /* eslint-disable max-len */
+    hexadecimal: function (obj) { return obj >= 0 ? '0x' + obj.toString(16).toUpperCase() :  '-0x' + obj.toString(16).toUpperCase().slice(1); }
+  },
+  defaultStyle: 'decimal',
+  styleAliases: {
+    binary:      [ 2,  'bin' ],
+    octal:       [ 8,  'oct' ],
+    decimal:     [ 10, 'dec' ],
+    hexadecimal: [ 16, 'hex' ]
+  }
+});
+
+var YAML_FLOAT_PATTERN = new RegExp(
+  // 2.5e4, 2.5 and integers
+  '^(?:[-+]?(?:[0-9][0-9_]*)(?:\\.[0-9_]*)?(?:[eE][-+]?[0-9]+)?' +
+  // .2e4, .2
+  // special case, seems not from spec
+  '|\\.[0-9_]+(?:[eE][-+]?[0-9]+)?' +
+  // .inf
+  '|[-+]?\\.(?:inf|Inf|INF)' +
+  // .nan
+  '|\\.(?:nan|NaN|NAN))$');
+
+function resolveYamlFloat(data) {
+  if (data === null) return false;
+
+  if (!YAML_FLOAT_PATTERN.test(data) ||
+      // Quick hack to not allow integers end with `_`
+      // Probably should update regexp & check speed
+      data[data.length - 1] === '_') {
+    return false;
+  }
+
+  return true;
+}
+
+function constructYamlFloat(data) {
+  var value, sign;
+
+  value  = data.replace(/_/g, '').toLowerCase();
+  sign   = value[0] === '-' ? -1 : 1;
+
+  if ('+-'.indexOf(value[0]) >= 0) {
+    value = value.slice(1);
+  }
+
+  if (value === '.inf') {
+    return (sign === 1) ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
+
+  } else if (value === '.nan') {
+    return NaN;
+  }
+  return sign * parseFloat(value, 10);
+}
+
+
+var SCIENTIFIC_WITHOUT_DOT = /^[-+]?[0-9]+e/;
+
+function representYamlFloat(object, style) {
+  var res;
+
+  if (isNaN(object)) {
+    switch (style) {
+      case 'lowercase': return '.nan';
+      case 'uppercase': return '.NAN';
+      case 'camelcase': return '.NaN';
+    }
+  } else if (Number.POSITIVE_INFINITY === object) {
+    switch (style) {
+      case 'lowercase': return '.inf';
+      case 'uppercase': return '.INF';
+      case 'camelcase': return '.Inf';
+    }
+  } else if (Number.NEGATIVE_INFINITY === object) {
+    switch (style) {
+      case 'lowercase': return '-.inf';
+      case 'uppercase': return '-.INF';
+      case 'camelcase': return '-.Inf';
+    }
+  } else if (common.isNegativeZero(object)) {
+    return '-0.0';
+  }
+
+  res = object.toString(10);
+
+  // JS stringifier can build scientific format without dots: 5e-100,
+  // while YAML requres dot: 5.e-100. Fix it with simple hack
+
+  return SCIENTIFIC_WITHOUT_DOT.test(res) ? res.replace('e', '.e') : res;
+}
+
+function isFloat(object) {
+  return (Object.prototype.toString.call(object) === '[object Number]') &&
+         (object % 1 !== 0 || common.isNegativeZero(object));
+}
+
+var float = new type('tag:yaml.org,2002:float', {
+  kind: 'scalar',
+  resolve: resolveYamlFloat,
+  construct: constructYamlFloat,
+  predicate: isFloat,
+  represent: representYamlFloat,
+  defaultStyle: 'lowercase'
+});
+
+var json = failsafe.extend({
+  implicit: [
+    _null,
+    bool,
+    int,
+    float
+  ]
+});
+
+var core = json;
+
+var YAML_DATE_REGEXP = new RegExp(
+  '^([0-9][0-9][0-9][0-9])'          + // [1] year
+  '-([0-9][0-9])'                    + // [2] month
+  '-([0-9][0-9])$');                   // [3] day
+
+var YAML_TIMESTAMP_REGEXP = new RegExp(
+  '^([0-9][0-9][0-9][0-9])'          + // [1] year
+  '-([0-9][0-9]?)'                   + // [2] month
+  '-([0-9][0-9]?)'                   + // [3] day
+  '(?:[Tt]|[ \\t]+)'                 + // ...
+  '([0-9][0-9]?)'                    + // [4] hour
+  ':([0-9][0-9])'                    + // [5] minute
+  ':([0-9][0-9])'                    + // [6] second
+  '(?:\\.([0-9]*))?'                 + // [7] fraction
+  '(?:[ \\t]*(Z|([-+])([0-9][0-9]?)' + // [8] tz [9] tz_sign [10] tz_hour
+  '(?::([0-9][0-9]))?))?$');           // [11] tz_minute
+
+function resolveYamlTimestamp(data) {
+  if (data === null) return false;
+  if (YAML_DATE_REGEXP.exec(data) !== null) return true;
+  if (YAML_TIMESTAMP_REGEXP.exec(data) !== null) return true;
+  return false;
+}
+
+function constructYamlTimestamp(data) {
+  var match, year, month, day, hour, minute, second, fraction = 0,
+      delta = null, tz_hour, tz_minute, date;
+
+  match = YAML_DATE_REGEXP.exec(data);
+  if (match === null) match = YAML_TIMESTAMP_REGEXP.exec(data);
+
+  if (match === null) throw new Error('Date resolve error');
+
+  // match: [1] year [2] month [3] day
+
+  year = +(match[1]);
+  month = +(match[2]) - 1; // JS month starts with 0
+  day = +(match[3]);
+
+  if (!match[4]) { // no hour
+    return new Date(Date.UTC(year, month, day));
+  }
+
+  // match: [4] hour [5] minute [6] second [7] fraction
+
+  hour = +(match[4]);
+  minute = +(match[5]);
+  second = +(match[6]);
+
+  if (match[7]) {
+    fraction = match[7].slice(0, 3);
+    while (fraction.length < 3) { // milli-seconds
+      fraction += '0';
+    }
+    fraction = +fraction;
+  }
+
+  // match: [8] tz [9] tz_sign [10] tz_hour [11] tz_minute
+
+  if (match[9]) {
+    tz_hour = +(match[10]);
+    tz_minute = +(match[11] || 0);
+    delta = (tz_hour * 60 + tz_minute) * 60000; // delta in mili-seconds
+    if (match[9] === '-') delta = -delta;
+  }
+
+  date = new Date(Date.UTC(year, month, day, hour, minute, second, fraction));
+
+  if (delta) date.setTime(date.getTime() - delta);
+
+  return date;
+}
+
+function representYamlTimestamp(object /*, style*/) {
+  return object.toISOString();
+}
+
+var timestamp = new type('tag:yaml.org,2002:timestamp', {
+  kind: 'scalar',
+  resolve: resolveYamlTimestamp,
+  construct: constructYamlTimestamp,
+  instanceOf: Date,
+  represent: representYamlTimestamp
+});
+
+function resolveYamlMerge(data) {
+  return data === '<<' || data === null;
+}
+
+var merge = new type('tag:yaml.org,2002:merge', {
+  kind: 'scalar',
+  resolve: resolveYamlMerge
+});
+
+/*eslint-disable no-bitwise*/
+
+
+
+
+
+// [ 64, 65, 66 ] -> [ padding, CR, LF ]
+var BASE64_MAP = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=\n\r';
+
+
+function resolveYamlBinary(data) {
+  if (data === null) return false;
+
+  var code, idx, bitlen = 0, max = data.length, map = BASE64_MAP;
+
+  // Convert one by one.
+  for (idx = 0; idx < max; idx++) {
+    code = map.indexOf(data.charAt(idx));
+
+    // Skip CR/LF
+    if (code > 64) continue;
+
+    // Fail on illegal characters
+    if (code < 0) return false;
+
+    bitlen += 6;
+  }
+
+  // If there are any bits left, source was corrupted
+  return (bitlen % 8) === 0;
+}
+
+function constructYamlBinary(data) {
+  var idx, tailbits,
+      input = data.replace(/[\r\n=]/g, ''), // remove CR/LF & padding to simplify scan
+      max = input.length,
+      map = BASE64_MAP,
+      bits = 0,
+      result = [];
+
+  // Collect by 6*4 bits (3 bytes)
+
+  for (idx = 0; idx < max; idx++) {
+    if ((idx % 4 === 0) && idx) {
+      result.push((bits >> 16) & 0xFF);
+      result.push((bits >> 8) & 0xFF);
+      result.push(bits & 0xFF);
+    }
+
+    bits = (bits << 6) | map.indexOf(input.charAt(idx));
+  }
+
+  // Dump tail
+
+  tailbits = (max % 4) * 6;
+
+  if (tailbits === 0) {
+    result.push((bits >> 16) & 0xFF);
+    result.push((bits >> 8) & 0xFF);
+    result.push(bits & 0xFF);
+  } else if (tailbits === 18) {
+    result.push((bits >> 10) & 0xFF);
+    result.push((bits >> 2) & 0xFF);
+  } else if (tailbits === 12) {
+    result.push((bits >> 4) & 0xFF);
+  }
+
+  return new Uint8Array(result);
+}
+
+function representYamlBinary(object /*, style*/) {
+  var result = '', bits = 0, idx, tail,
+      max = object.length,
+      map = BASE64_MAP;
+
+  // Convert every three bytes to 4 ASCII characters.
+
+  for (idx = 0; idx < max; idx++) {
+    if ((idx % 3 === 0) && idx) {
+      result += map[(bits >> 18) & 0x3F];
+      result += map[(bits >> 12) & 0x3F];
+      result += map[(bits >> 6) & 0x3F];
+      result += map[bits & 0x3F];
+    }
+
+    bits = (bits << 8) + object[idx];
+  }
+
+  // Dump tail
+
+  tail = max % 3;
+
+  if (tail === 0) {
+    result += map[(bits >> 18) & 0x3F];
+    result += map[(bits >> 12) & 0x3F];
+    result += map[(bits >> 6) & 0x3F];
+    result += map[bits & 0x3F];
+  } else if (tail === 2) {
+    result += map[(bits >> 10) & 0x3F];
+    result += map[(bits >> 4) & 0x3F];
+    result += map[(bits << 2) & 0x3F];
+    result += map[64];
+  } else if (tail === 1) {
+    result += map[(bits >> 2) & 0x3F];
+    result += map[(bits << 4) & 0x3F];
+    result += map[64];
+    result += map[64];
+  }
+
+  return result;
+}
+
+function isBinary(obj) {
+  return Object.prototype.toString.call(obj) ===  '[object Uint8Array]';
+}
+
+var binary = new type('tag:yaml.org,2002:binary', {
+  kind: 'scalar',
+  resolve: resolveYamlBinary,
+  construct: constructYamlBinary,
+  predicate: isBinary,
+  represent: representYamlBinary
+});
+
+var _hasOwnProperty$3 = Object.prototype.hasOwnProperty;
+var _toString$2       = Object.prototype.toString;
+
+function resolveYamlOmap(data) {
+  if (data === null) return true;
+
+  var objectKeys = [], index, length, pair, pairKey, pairHasKey,
+      object = data;
+
+  for (index = 0, length = object.length; index < length; index += 1) {
+    pair = object[index];
+    pairHasKey = false;
+
+    if (_toString$2.call(pair) !== '[object Object]') return false;
+
+    for (pairKey in pair) {
+      if (_hasOwnProperty$3.call(pair, pairKey)) {
+        if (!pairHasKey) pairHasKey = true;
+        else return false;
+      }
+    }
+
+    if (!pairHasKey) return false;
+
+    if (objectKeys.indexOf(pairKey) === -1) objectKeys.push(pairKey);
+    else return false;
+  }
+
+  return true;
+}
+
+function constructYamlOmap(data) {
+  return data !== null ? data : [];
+}
+
+var omap = new type('tag:yaml.org,2002:omap', {
+  kind: 'sequence',
+  resolve: resolveYamlOmap,
+  construct: constructYamlOmap
+});
+
+var _toString$1 = Object.prototype.toString;
+
+function resolveYamlPairs(data) {
+  if (data === null) return true;
+
+  var index, length, pair, keys, result,
+      object = data;
+
+  result = new Array(object.length);
+
+  for (index = 0, length = object.length; index < length; index += 1) {
+    pair = object[index];
+
+    if (_toString$1.call(pair) !== '[object Object]') return false;
+
+    keys = Object.keys(pair);
+
+    if (keys.length !== 1) return false;
+
+    result[index] = [ keys[0], pair[keys[0]] ];
+  }
+
+  return true;
+}
+
+function constructYamlPairs(data) {
+  if (data === null) return [];
+
+  var index, length, pair, keys, result,
+      object = data;
+
+  result = new Array(object.length);
+
+  for (index = 0, length = object.length; index < length; index += 1) {
+    pair = object[index];
+
+    keys = Object.keys(pair);
+
+    result[index] = [ keys[0], pair[keys[0]] ];
+  }
+
+  return result;
+}
+
+var pairs = new type('tag:yaml.org,2002:pairs', {
+  kind: 'sequence',
+  resolve: resolveYamlPairs,
+  construct: constructYamlPairs
+});
+
+var _hasOwnProperty$2 = Object.prototype.hasOwnProperty;
+
+function resolveYamlSet(data) {
+  if (data === null) return true;
+
+  var key, object = data;
+
+  for (key in object) {
+    if (_hasOwnProperty$2.call(object, key)) {
+      if (object[key] !== null) return false;
+    }
+  }
+
+  return true;
+}
+
+function constructYamlSet(data) {
+  return data !== null ? data : {};
+}
+
+var set = new type('tag:yaml.org,2002:set', {
+  kind: 'mapping',
+  resolve: resolveYamlSet,
+  construct: constructYamlSet
+});
+
+var _default = core.extend({
+  implicit: [
+    timestamp,
+    merge
+  ],
+  explicit: [
+    binary,
+    omap,
+    pairs,
+    set
+  ]
+});
+
+/*eslint-disable max-len,no-use-before-define*/
+
+
+
+
+
+
+
+var _hasOwnProperty$1 = Object.prototype.hasOwnProperty;
+
+
+var CONTEXT_FLOW_IN   = 1;
+var CONTEXT_FLOW_OUT  = 2;
+var CONTEXT_BLOCK_IN  = 3;
+var CONTEXT_BLOCK_OUT = 4;
+
+
+var CHOMPING_CLIP  = 1;
+var CHOMPING_STRIP = 2;
+var CHOMPING_KEEP  = 3;
+
+
+var PATTERN_NON_PRINTABLE         = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x84\x86-\x9F\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/;
+var PATTERN_NON_ASCII_LINE_BREAKS = /[\x85\u2028\u2029]/;
+var PATTERN_FLOW_INDICATORS       = /[,\[\]\{\}]/;
+var PATTERN_TAG_HANDLE            = /^(?:!|!!|![a-z\-]+!)$/i;
+var PATTERN_TAG_URI               = /^(?:!|[^,\[\]\{\}])(?:%[0-9a-f]{2}|[0-9a-z\-#;\/\?:@&=\+\$,_\.!~\*'\(\)\[\]])*$/i;
+
+
+function _class(obj) { return Object.prototype.toString.call(obj); }
+
+function is_EOL(c) {
+  return (c === 0x0A/* LF */) || (c === 0x0D/* CR */);
+}
+
+function is_WHITE_SPACE(c) {
+  return (c === 0x09/* Tab */) || (c === 0x20/* Space */);
+}
+
+function is_WS_OR_EOL(c) {
+  return (c === 0x09/* Tab */) ||
+         (c === 0x20/* Space */) ||
+         (c === 0x0A/* LF */) ||
+         (c === 0x0D/* CR */);
+}
+
+function is_FLOW_INDICATOR(c) {
+  return c === 0x2C/* , */ ||
+         c === 0x5B/* [ */ ||
+         c === 0x5D/* ] */ ||
+         c === 0x7B/* { */ ||
+         c === 0x7D/* } */;
+}
+
+function fromHexCode(c) {
+  var lc;
+
+  if ((0x30/* 0 */ <= c) && (c <= 0x39/* 9 */)) {
+    return c - 0x30;
+  }
+
+  /*eslint-disable no-bitwise*/
+  lc = c | 0x20;
+
+  if ((0x61/* a */ <= lc) && (lc <= 0x66/* f */)) {
+    return lc - 0x61 + 10;
+  }
+
+  return -1;
+}
+
+function escapedHexLen(c) {
+  if (c === 0x78/* x */) { return 2; }
+  if (c === 0x75/* u */) { return 4; }
+  if (c === 0x55/* U */) { return 8; }
+  return 0;
+}
+
+function fromDecimalCode(c) {
+  if ((0x30/* 0 */ <= c) && (c <= 0x39/* 9 */)) {
+    return c - 0x30;
+  }
+
+  return -1;
+}
+
+function simpleEscapeSequence(c) {
+  /* eslint-disable indent */
+  return (c === 0x30/* 0 */) ? '\x00' :
+        (c === 0x61/* a */) ? '\x07' :
+        (c === 0x62/* b */) ? '\x08' :
+        (c === 0x74/* t */) ? '\x09' :
+        (c === 0x09/* Tab */) ? '\x09' :
+        (c === 0x6E/* n */) ? '\x0A' :
+        (c === 0x76/* v */) ? '\x0B' :
+        (c === 0x66/* f */) ? '\x0C' :
+        (c === 0x72/* r */) ? '\x0D' :
+        (c === 0x65/* e */) ? '\x1B' :
+        (c === 0x20/* Space */) ? ' ' :
+        (c === 0x22/* " */) ? '\x22' :
+        (c === 0x2F/* / */) ? '/' :
+        (c === 0x5C/* \ */) ? '\x5C' :
+        (c === 0x4E/* N */) ? '\x85' :
+        (c === 0x5F/* _ */) ? '\xA0' :
+        (c === 0x4C/* L */) ? '\u2028' :
+        (c === 0x50/* P */) ? '\u2029' : '';
+}
+
+function charFromCodepoint(c) {
+  if (c <= 0xFFFF) {
+    return String.fromCharCode(c);
+  }
+  // Encode UTF-16 surrogate pair
+  // https://en.wikipedia.org/wiki/UTF-16#Code_points_U.2B010000_to_U.2B10FFFF
+  return String.fromCharCode(
+    ((c - 0x010000) >> 10) + 0xD800,
+    ((c - 0x010000) & 0x03FF) + 0xDC00
+  );
+}
+
+// set a property of a literal object, while protecting against prototype pollution,
+// see https://github.com/nodeca/js-yaml/issues/164 for more details
+function setProperty(object, key, value) {
+  // used for this specific key only because Object.defineProperty is slow
+  if (key === '__proto__') {
+    Object.defineProperty(object, key, {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: value
+    });
+  } else {
+    object[key] = value;
+  }
+}
+
+var simpleEscapeCheck = new Array(256); // integer, for fast access
+var simpleEscapeMap = new Array(256);
+for (var i = 0; i < 256; i++) {
+  simpleEscapeCheck[i] = simpleEscapeSequence(i) ? 1 : 0;
+  simpleEscapeMap[i] = simpleEscapeSequence(i);
+}
+
+
+function State$1(input, options) {
+  this.input = input;
+
+  this.filename  = options['filename']  || null;
+  this.schema    = options['schema']    || _default;
+  this.onWarning = options['onWarning'] || null;
+  // (Hidden) Remove? makes the loader to expect YAML 1.1 documents
+  // if such documents have no explicit %YAML directive
+  this.legacy    = options['legacy']    || false;
+
+  this.json      = options['json']      || false;
+  this.listener  = options['listener']  || null;
+
+  this.implicitTypes = this.schema.compiledImplicit;
+  this.typeMap       = this.schema.compiledTypeMap;
+
+  this.length     = input.length;
+  this.position   = 0;
+  this.line       = 0;
+  this.lineStart  = 0;
+  this.lineIndent = 0;
+
+  // position of first leading tab in the current line,
+  // used to make sure there are no tabs in the indentation
+  this.firstTabInLine = -1;
+
+  this.documents = [];
+
+  /*
+  this.version;
+  this.checkLineBreaks;
+  this.tagMap;
+  this.anchorMap;
+  this.tag;
+  this.anchor;
+  this.kind;
+  this.result;*/
+
+}
+
+
+function generateError(state, message) {
+  var mark = {
+    name:     state.filename,
+    buffer:   state.input.slice(0, -1), // omit trailing \0
+    position: state.position,
+    line:     state.line,
+    column:   state.position - state.lineStart
+  };
+
+  mark.snippet = snippet(mark);
+
+  return new exception(message, mark);
+}
+
+function throwError(state, message) {
+  throw generateError(state, message);
+}
+
+function throwWarning(state, message) {
+  if (state.onWarning) {
+    state.onWarning.call(null, generateError(state, message));
+  }
+}
+
+
+var directiveHandlers = {
+
+  YAML: function handleYamlDirective(state, name, args) {
+
+    var match, major, minor;
+
+    if (state.version !== null) {
+      throwError(state, 'duplication of %YAML directive');
+    }
+
+    if (args.length !== 1) {
+      throwError(state, 'YAML directive accepts exactly one argument');
+    }
+
+    match = /^([0-9]+)\.([0-9]+)$/.exec(args[0]);
+
+    if (match === null) {
+      throwError(state, 'ill-formed argument of the YAML directive');
+    }
+
+    major = parseInt(match[1], 10);
+    minor = parseInt(match[2], 10);
+
+    if (major !== 1) {
+      throwError(state, 'unacceptable YAML version of the document');
+    }
+
+    state.version = args[0];
+    state.checkLineBreaks = (minor < 2);
+
+    if (minor !== 1 && minor !== 2) {
+      throwWarning(state, 'unsupported YAML version of the document');
+    }
+  },
+
+  TAG: function handleTagDirective(state, name, args) {
+
+    var handle, prefix;
+
+    if (args.length !== 2) {
+      throwError(state, 'TAG directive accepts exactly two arguments');
+    }
+
+    handle = args[0];
+    prefix = args[1];
+
+    if (!PATTERN_TAG_HANDLE.test(handle)) {
+      throwError(state, 'ill-formed tag handle (first argument) of the TAG directive');
+    }
+
+    if (_hasOwnProperty$1.call(state.tagMap, handle)) {
+      throwError(state, 'there is a previously declared suffix for "' + handle + '" tag handle');
+    }
+
+    if (!PATTERN_TAG_URI.test(prefix)) {
+      throwError(state, 'ill-formed tag prefix (second argument) of the TAG directive');
+    }
+
+    try {
+      prefix = decodeURIComponent(prefix);
+    } catch (err) {
+      throwError(state, 'tag prefix is malformed: ' + prefix);
+    }
+
+    state.tagMap[handle] = prefix;
+  }
+};
+
+
+function captureSegment(state, start, end, checkJson) {
+  var _position, _length, _character, _result;
+
+  if (start < end) {
+    _result = state.input.slice(start, end);
+
+    if (checkJson) {
+      for (_position = 0, _length = _result.length; _position < _length; _position += 1) {
+        _character = _result.charCodeAt(_position);
+        if (!(_character === 0x09 ||
+              (0x20 <= _character && _character <= 0x10FFFF))) {
+          throwError(state, 'expected valid JSON character');
+        }
+      }
+    } else if (PATTERN_NON_PRINTABLE.test(_result)) {
+      throwError(state, 'the stream contains non-printable characters');
+    }
+
+    state.result += _result;
+  }
+}
+
+function mergeMappings(state, destination, source, overridableKeys) {
+  var sourceKeys, key, index, quantity;
+
+  if (!common.isObject(source)) {
+    throwError(state, 'cannot merge mappings; the provided source object is unacceptable');
+  }
+
+  sourceKeys = Object.keys(source);
+
+  for (index = 0, quantity = sourceKeys.length; index < quantity; index += 1) {
+    key = sourceKeys[index];
+
+    if (!_hasOwnProperty$1.call(destination, key)) {
+      setProperty(destination, key, source[key]);
+      overridableKeys[key] = true;
+    }
+  }
+}
+
+function storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, valueNode,
+  startLine, startLineStart, startPos) {
+
+  var index, quantity;
+
+  // The output is a plain object here, so keys can only be strings.
+  // We need to convert keyNode to a string, but doing so can hang the process
+  // (deeply nested arrays that explode exponentially using aliases).
+  if (Array.isArray(keyNode)) {
+    keyNode = Array.prototype.slice.call(keyNode);
+
+    for (index = 0, quantity = keyNode.length; index < quantity; index += 1) {
+      if (Array.isArray(keyNode[index])) {
+        throwError(state, 'nested arrays are not supported inside keys');
+      }
+
+      if (typeof keyNode === 'object' && _class(keyNode[index]) === '[object Object]') {
+        keyNode[index] = '[object Object]';
+      }
+    }
+  }
+
+  // Avoid code execution in load() via toString property
+  // (still use its own toString for arrays, timestamps,
+  // and whatever user schema extensions happen to have @@toStringTag)
+  if (typeof keyNode === 'object' && _class(keyNode) === '[object Object]') {
+    keyNode = '[object Object]';
+  }
+
+
+  keyNode = String(keyNode);
+
+  if (_result === null) {
+    _result = {};
+  }
+
+  if (keyTag === 'tag:yaml.org,2002:merge') {
+    if (Array.isArray(valueNode)) {
+      for (index = 0, quantity = valueNode.length; index < quantity; index += 1) {
+        mergeMappings(state, _result, valueNode[index], overridableKeys);
+      }
+    } else {
+      mergeMappings(state, _result, valueNode, overridableKeys);
+    }
+  } else {
+    if (!state.json &&
+        !_hasOwnProperty$1.call(overridableKeys, keyNode) &&
+        _hasOwnProperty$1.call(_result, keyNode)) {
+      state.line = startLine || state.line;
+      state.lineStart = startLineStart || state.lineStart;
+      state.position = startPos || state.position;
+      throwError(state, 'duplicated mapping key');
+    }
+
+    setProperty(_result, keyNode, valueNode);
+    delete overridableKeys[keyNode];
+  }
+
+  return _result;
+}
+
+function readLineBreak(state) {
+  var ch;
+
+  ch = state.input.charCodeAt(state.position);
+
+  if (ch === 0x0A/* LF */) {
+    state.position++;
+  } else if (ch === 0x0D/* CR */) {
+    state.position++;
+    if (state.input.charCodeAt(state.position) === 0x0A/* LF */) {
+      state.position++;
+    }
+  } else {
+    throwError(state, 'a line break is expected');
+  }
+
+  state.line += 1;
+  state.lineStart = state.position;
+  state.firstTabInLine = -1;
+}
+
+function skipSeparationSpace(state, allowComments, checkIndent) {
+  var lineBreaks = 0,
+      ch = state.input.charCodeAt(state.position);
+
+  while (ch !== 0) {
+    while (is_WHITE_SPACE(ch)) {
+      if (ch === 0x09/* Tab */ && state.firstTabInLine === -1) {
+        state.firstTabInLine = state.position;
+      }
+      ch = state.input.charCodeAt(++state.position);
+    }
+
+    if (allowComments && ch === 0x23/* # */) {
+      do {
+        ch = state.input.charCodeAt(++state.position);
+      } while (ch !== 0x0A/* LF */ && ch !== 0x0D/* CR */ && ch !== 0);
+    }
+
+    if (is_EOL(ch)) {
+      readLineBreak(state);
+
+      ch = state.input.charCodeAt(state.position);
+      lineBreaks++;
+      state.lineIndent = 0;
+
+      while (ch === 0x20/* Space */) {
+        state.lineIndent++;
+        ch = state.input.charCodeAt(++state.position);
+      }
+    } else {
+      break;
+    }
+  }
+
+  if (checkIndent !== -1 && lineBreaks !== 0 && state.lineIndent < checkIndent) {
+    throwWarning(state, 'deficient indentation');
+  }
+
+  return lineBreaks;
+}
+
+function testDocumentSeparator(state) {
+  var _position = state.position,
+      ch;
+
+  ch = state.input.charCodeAt(_position);
+
+  // Condition state.position === state.lineStart is tested
+  // in parent on each call, for efficiency. No needs to test here again.
+  if ((ch === 0x2D/* - */ || ch === 0x2E/* . */) &&
+      ch === state.input.charCodeAt(_position + 1) &&
+      ch === state.input.charCodeAt(_position + 2)) {
+
+    _position += 3;
+
+    ch = state.input.charCodeAt(_position);
+
+    if (ch === 0 || is_WS_OR_EOL(ch)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function writeFoldedLines(state, count) {
+  if (count === 1) {
+    state.result += ' ';
+  } else if (count > 1) {
+    state.result += common.repeat('\n', count - 1);
+  }
+}
+
+
+function readPlainScalar(state, nodeIndent, withinFlowCollection) {
+  var preceding,
+      following,
+      captureStart,
+      captureEnd,
+      hasPendingContent,
+      _line,
+      _lineStart,
+      _lineIndent,
+      _kind = state.kind,
+      _result = state.result,
+      ch;
+
+  ch = state.input.charCodeAt(state.position);
+
+  if (is_WS_OR_EOL(ch)      ||
+      is_FLOW_INDICATOR(ch) ||
+      ch === 0x23/* # */    ||
+      ch === 0x26/* & */    ||
+      ch === 0x2A/* * */    ||
+      ch === 0x21/* ! */    ||
+      ch === 0x7C/* | */    ||
+      ch === 0x3E/* > */    ||
+      ch === 0x27/* ' */    ||
+      ch === 0x22/* " */    ||
+      ch === 0x25/* % */    ||
+      ch === 0x40/* @ */    ||
+      ch === 0x60/* ` */) {
+    return false;
+  }
+
+  if (ch === 0x3F/* ? */ || ch === 0x2D/* - */) {
+    following = state.input.charCodeAt(state.position + 1);
+
+    if (is_WS_OR_EOL(following) ||
+        withinFlowCollection && is_FLOW_INDICATOR(following)) {
+      return false;
+    }
+  }
+
+  state.kind = 'scalar';
+  state.result = '';
+  captureStart = captureEnd = state.position;
+  hasPendingContent = false;
+
+  while (ch !== 0) {
+    if (ch === 0x3A/* : */) {
+      following = state.input.charCodeAt(state.position + 1);
+
+      if (is_WS_OR_EOL(following) ||
+          withinFlowCollection && is_FLOW_INDICATOR(following)) {
+        break;
+      }
+
+    } else if (ch === 0x23/* # */) {
+      preceding = state.input.charCodeAt(state.position - 1);
+
+      if (is_WS_OR_EOL(preceding)) {
+        break;
+      }
+
+    } else if ((state.position === state.lineStart && testDocumentSeparator(state)) ||
+               withinFlowCollection && is_FLOW_INDICATOR(ch)) {
+      break;
+
+    } else if (is_EOL(ch)) {
+      _line = state.line;
+      _lineStart = state.lineStart;
+      _lineIndent = state.lineIndent;
+      skipSeparationSpace(state, false, -1);
+
+      if (state.lineIndent >= nodeIndent) {
+        hasPendingContent = true;
+        ch = state.input.charCodeAt(state.position);
+        continue;
+      } else {
+        state.position = captureEnd;
+        state.line = _line;
+        state.lineStart = _lineStart;
+        state.lineIndent = _lineIndent;
+        break;
+      }
+    }
+
+    if (hasPendingContent) {
+      captureSegment(state, captureStart, captureEnd, false);
+      writeFoldedLines(state, state.line - _line);
+      captureStart = captureEnd = state.position;
+      hasPendingContent = false;
+    }
+
+    if (!is_WHITE_SPACE(ch)) {
+      captureEnd = state.position + 1;
+    }
+
+    ch = state.input.charCodeAt(++state.position);
+  }
+
+  captureSegment(state, captureStart, captureEnd, false);
+
+  if (state.result) {
+    return true;
+  }
+
+  state.kind = _kind;
+  state.result = _result;
+  return false;
+}
+
+function readSingleQuotedScalar(state, nodeIndent) {
+  var ch,
+      captureStart, captureEnd;
+
+  ch = state.input.charCodeAt(state.position);
+
+  if (ch !== 0x27/* ' */) {
+    return false;
+  }
+
+  state.kind = 'scalar';
+  state.result = '';
+  state.position++;
+  captureStart = captureEnd = state.position;
+
+  while ((ch = state.input.charCodeAt(state.position)) !== 0) {
+    if (ch === 0x27/* ' */) {
+      captureSegment(state, captureStart, state.position, true);
+      ch = state.input.charCodeAt(++state.position);
+
+      if (ch === 0x27/* ' */) {
+        captureStart = state.position;
+        state.position++;
+        captureEnd = state.position;
+      } else {
+        return true;
+      }
+
+    } else if (is_EOL(ch)) {
+      captureSegment(state, captureStart, captureEnd, true);
+      writeFoldedLines(state, skipSeparationSpace(state, false, nodeIndent));
+      captureStart = captureEnd = state.position;
+
+    } else if (state.position === state.lineStart && testDocumentSeparator(state)) {
+      throwError(state, 'unexpected end of the document within a single quoted scalar');
+
+    } else {
+      state.position++;
+      captureEnd = state.position;
+    }
+  }
+
+  throwError(state, 'unexpected end of the stream within a single quoted scalar');
+}
+
+function readDoubleQuotedScalar(state, nodeIndent) {
+  var captureStart,
+      captureEnd,
+      hexLength,
+      hexResult,
+      tmp,
+      ch;
+
+  ch = state.input.charCodeAt(state.position);
+
+  if (ch !== 0x22/* " */) {
+    return false;
+  }
+
+  state.kind = 'scalar';
+  state.result = '';
+  state.position++;
+  captureStart = captureEnd = state.position;
+
+  while ((ch = state.input.charCodeAt(state.position)) !== 0) {
+    if (ch === 0x22/* " */) {
+      captureSegment(state, captureStart, state.position, true);
+      state.position++;
+      return true;
+
+    } else if (ch === 0x5C/* \ */) {
+      captureSegment(state, captureStart, state.position, true);
+      ch = state.input.charCodeAt(++state.position);
+
+      if (is_EOL(ch)) {
+        skipSeparationSpace(state, false, nodeIndent);
+
+        // TODO: rework to inline fn with no type cast?
+      } else if (ch < 256 && simpleEscapeCheck[ch]) {
+        state.result += simpleEscapeMap[ch];
+        state.position++;
+
+      } else if ((tmp = escapedHexLen(ch)) > 0) {
+        hexLength = tmp;
+        hexResult = 0;
+
+        for (; hexLength > 0; hexLength--) {
+          ch = state.input.charCodeAt(++state.position);
+
+          if ((tmp = fromHexCode(ch)) >= 0) {
+            hexResult = (hexResult << 4) + tmp;
+
+          } else {
+            throwError(state, 'expected hexadecimal character');
+          }
+        }
+
+        state.result += charFromCodepoint(hexResult);
+
+        state.position++;
+
+      } else {
+        throwError(state, 'unknown escape sequence');
+      }
+
+      captureStart = captureEnd = state.position;
+
+    } else if (is_EOL(ch)) {
+      captureSegment(state, captureStart, captureEnd, true);
+      writeFoldedLines(state, skipSeparationSpace(state, false, nodeIndent));
+      captureStart = captureEnd = state.position;
+
+    } else if (state.position === state.lineStart && testDocumentSeparator(state)) {
+      throwError(state, 'unexpected end of the document within a double quoted scalar');
+
+    } else {
+      state.position++;
+      captureEnd = state.position;
+    }
+  }
+
+  throwError(state, 'unexpected end of the stream within a double quoted scalar');
+}
+
+function readFlowCollection(state, nodeIndent) {
+  var readNext = true,
+      _line,
+      _lineStart,
+      _pos,
+      _tag     = state.tag,
+      _result,
+      _anchor  = state.anchor,
+      following,
+      terminator,
+      isPair,
+      isExplicitPair,
+      isMapping,
+      overridableKeys = Object.create(null),
+      keyNode,
+      keyTag,
+      valueNode,
+      ch;
+
+  ch = state.input.charCodeAt(state.position);
+
+  if (ch === 0x5B/* [ */) {
+    terminator = 0x5D;/* ] */
+    isMapping = false;
+    _result = [];
+  } else if (ch === 0x7B/* { */) {
+    terminator = 0x7D;/* } */
+    isMapping = true;
+    _result = {};
+  } else {
+    return false;
+  }
+
+  if (state.anchor !== null) {
+    state.anchorMap[state.anchor] = _result;
+  }
+
+  ch = state.input.charCodeAt(++state.position);
+
+  while (ch !== 0) {
+    skipSeparationSpace(state, true, nodeIndent);
+
+    ch = state.input.charCodeAt(state.position);
+
+    if (ch === terminator) {
+      state.position++;
+      state.tag = _tag;
+      state.anchor = _anchor;
+      state.kind = isMapping ? 'mapping' : 'sequence';
+      state.result = _result;
+      return true;
+    } else if (!readNext) {
+      throwError(state, 'missed comma between flow collection entries');
+    } else if (ch === 0x2C/* , */) {
+      // "flow collection entries can never be completely empty", as per YAML 1.2, section 7.4
+      throwError(state, "expected the node content, but found ','");
+    }
+
+    keyTag = keyNode = valueNode = null;
+    isPair = isExplicitPair = false;
+
+    if (ch === 0x3F/* ? */) {
+      following = state.input.charCodeAt(state.position + 1);
+
+      if (is_WS_OR_EOL(following)) {
+        isPair = isExplicitPair = true;
+        state.position++;
+        skipSeparationSpace(state, true, nodeIndent);
+      }
+    }
+
+    _line = state.line; // Save the current line.
+    _lineStart = state.lineStart;
+    _pos = state.position;
+    composeNode(state, nodeIndent, CONTEXT_FLOW_IN, false, true);
+    keyTag = state.tag;
+    keyNode = state.result;
+    skipSeparationSpace(state, true, nodeIndent);
+
+    ch = state.input.charCodeAt(state.position);
+
+    if ((isExplicitPair || state.line === _line) && ch === 0x3A/* : */) {
+      isPair = true;
+      ch = state.input.charCodeAt(++state.position);
+      skipSeparationSpace(state, true, nodeIndent);
+      composeNode(state, nodeIndent, CONTEXT_FLOW_IN, false, true);
+      valueNode = state.result;
+    }
+
+    if (isMapping) {
+      storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, valueNode, _line, _lineStart, _pos);
+    } else if (isPair) {
+      _result.push(storeMappingPair(state, null, overridableKeys, keyTag, keyNode, valueNode, _line, _lineStart, _pos));
+    } else {
+      _result.push(keyNode);
+    }
+
+    skipSeparationSpace(state, true, nodeIndent);
+
+    ch = state.input.charCodeAt(state.position);
+
+    if (ch === 0x2C/* , */) {
+      readNext = true;
+      ch = state.input.charCodeAt(++state.position);
+    } else {
+      readNext = false;
+    }
+  }
+
+  throwError(state, 'unexpected end of the stream within a flow collection');
+}
+
+function readBlockScalar(state, nodeIndent) {
+  var captureStart,
+      folding,
+      chomping       = CHOMPING_CLIP,
+      didReadContent = false,
+      detectedIndent = false,
+      textIndent     = nodeIndent,
+      emptyLines     = 0,
+      atMoreIndented = false,
+      tmp,
+      ch;
+
+  ch = state.input.charCodeAt(state.position);
+
+  if (ch === 0x7C/* | */) {
+    folding = false;
+  } else if (ch === 0x3E/* > */) {
+    folding = true;
+  } else {
+    return false;
+  }
+
+  state.kind = 'scalar';
+  state.result = '';
+
+  while (ch !== 0) {
+    ch = state.input.charCodeAt(++state.position);
+
+    if (ch === 0x2B/* + */ || ch === 0x2D/* - */) {
+      if (CHOMPING_CLIP === chomping) {
+        chomping = (ch === 0x2B/* + */) ? CHOMPING_KEEP : CHOMPING_STRIP;
+      } else {
+        throwError(state, 'repeat of a chomping mode identifier');
+      }
+
+    } else if ((tmp = fromDecimalCode(ch)) >= 0) {
+      if (tmp === 0) {
+        throwError(state, 'bad explicit indentation width of a block scalar; it cannot be less than one');
+      } else if (!detectedIndent) {
+        textIndent = nodeIndent + tmp - 1;
+        detectedIndent = true;
+      } else {
+        throwError(state, 'repeat of an indentation width identifier');
+      }
+
+    } else {
+      break;
+    }
+  }
+
+  if (is_WHITE_SPACE(ch)) {
+    do { ch = state.input.charCodeAt(++state.position); }
+    while (is_WHITE_SPACE(ch));
+
+    if (ch === 0x23/* # */) {
+      do { ch = state.input.charCodeAt(++state.position); }
+      while (!is_EOL(ch) && (ch !== 0));
+    }
+  }
+
+  while (ch !== 0) {
+    readLineBreak(state);
+    state.lineIndent = 0;
+
+    ch = state.input.charCodeAt(state.position);
+
+    while ((!detectedIndent || state.lineIndent < textIndent) &&
+           (ch === 0x20/* Space */)) {
+      state.lineIndent++;
+      ch = state.input.charCodeAt(++state.position);
+    }
+
+    if (!detectedIndent && state.lineIndent > textIndent) {
+      textIndent = state.lineIndent;
+    }
+
+    if (is_EOL(ch)) {
+      emptyLines++;
+      continue;
+    }
+
+    // End of the scalar.
+    if (state.lineIndent < textIndent) {
+
+      // Perform the chomping.
+      if (chomping === CHOMPING_KEEP) {
+        state.result += common.repeat('\n', didReadContent ? 1 + emptyLines : emptyLines);
+      } else if (chomping === CHOMPING_CLIP) {
+        if (didReadContent) { // i.e. only if the scalar is not empty.
+          state.result += '\n';
+        }
+      }
+
+      // Break this `while` cycle and go to the funciton's epilogue.
+      break;
+    }
+
+    // Folded style: use fancy rules to handle line breaks.
+    if (folding) {
+
+      // Lines starting with white space characters (more-indented lines) are not folded.
+      if (is_WHITE_SPACE(ch)) {
+        atMoreIndented = true;
+        // except for the first content line (cf. Example 8.1)
+        state.result += common.repeat('\n', didReadContent ? 1 + emptyLines : emptyLines);
+
+      // End of more-indented block.
+      } else if (atMoreIndented) {
+        atMoreIndented = false;
+        state.result += common.repeat('\n', emptyLines + 1);
+
+      // Just one line break - perceive as the same line.
+      } else if (emptyLines === 0) {
+        if (didReadContent) { // i.e. only if we have already read some scalar content.
+          state.result += ' ';
+        }
+
+      // Several line breaks - perceive as different lines.
+      } else {
+        state.result += common.repeat('\n', emptyLines);
+      }
+
+    // Literal style: just add exact number of line breaks between content lines.
+    } else {
+      // Keep all line breaks except the header line break.
+      state.result += common.repeat('\n', didReadContent ? 1 + emptyLines : emptyLines);
+    }
+
+    didReadContent = true;
+    detectedIndent = true;
+    emptyLines = 0;
+    captureStart = state.position;
+
+    while (!is_EOL(ch) && (ch !== 0)) {
+      ch = state.input.charCodeAt(++state.position);
+    }
+
+    captureSegment(state, captureStart, state.position, false);
+  }
+
+  return true;
+}
+
+function readBlockSequence(state, nodeIndent) {
+  var _line,
+      _tag      = state.tag,
+      _anchor   = state.anchor,
+      _result   = [],
+      following,
+      detected  = false,
+      ch;
+
+  // there is a leading tab before this token, so it can't be a block sequence/mapping;
+  // it can still be flow sequence/mapping or a scalar
+  if (state.firstTabInLine !== -1) return false;
+
+  if (state.anchor !== null) {
+    state.anchorMap[state.anchor] = _result;
+  }
+
+  ch = state.input.charCodeAt(state.position);
+
+  while (ch !== 0) {
+    if (state.firstTabInLine !== -1) {
+      state.position = state.firstTabInLine;
+      throwError(state, 'tab characters must not be used in indentation');
+    }
+
+    if (ch !== 0x2D/* - */) {
+      break;
+    }
+
+    following = state.input.charCodeAt(state.position + 1);
+
+    if (!is_WS_OR_EOL(following)) {
+      break;
+    }
+
+    detected = true;
+    state.position++;
+
+    if (skipSeparationSpace(state, true, -1)) {
+      if (state.lineIndent <= nodeIndent) {
+        _result.push(null);
+        ch = state.input.charCodeAt(state.position);
+        continue;
+      }
+    }
+
+    _line = state.line;
+    composeNode(state, nodeIndent, CONTEXT_BLOCK_IN, false, true);
+    _result.push(state.result);
+    skipSeparationSpace(state, true, -1);
+
+    ch = state.input.charCodeAt(state.position);
+
+    if ((state.line === _line || state.lineIndent > nodeIndent) && (ch !== 0)) {
+      throwError(state, 'bad indentation of a sequence entry');
+    } else if (state.lineIndent < nodeIndent) {
+      break;
+    }
+  }
+
+  if (detected) {
+    state.tag = _tag;
+    state.anchor = _anchor;
+    state.kind = 'sequence';
+    state.result = _result;
+    return true;
+  }
+  return false;
+}
+
+function readBlockMapping(state, nodeIndent, flowIndent) {
+  var following,
+      allowCompact,
+      _line,
+      _keyLine,
+      _keyLineStart,
+      _keyPos,
+      _tag          = state.tag,
+      _anchor       = state.anchor,
+      _result       = {},
+      overridableKeys = Object.create(null),
+      keyTag        = null,
+      keyNode       = null,
+      valueNode     = null,
+      atExplicitKey = false,
+      detected      = false,
+      ch;
+
+  // there is a leading tab before this token, so it can't be a block sequence/mapping;
+  // it can still be flow sequence/mapping or a scalar
+  if (state.firstTabInLine !== -1) return false;
+
+  if (state.anchor !== null) {
+    state.anchorMap[state.anchor] = _result;
+  }
+
+  ch = state.input.charCodeAt(state.position);
+
+  while (ch !== 0) {
+    if (!atExplicitKey && state.firstTabInLine !== -1) {
+      state.position = state.firstTabInLine;
+      throwError(state, 'tab characters must not be used in indentation');
+    }
+
+    following = state.input.charCodeAt(state.position + 1);
+    _line = state.line; // Save the current line.
+
+    //
+    // Explicit notation case. There are two separate blocks:
+    // first for the key (denoted by "?") and second for the value (denoted by ":")
+    //
+    if ((ch === 0x3F/* ? */ || ch === 0x3A/* : */) && is_WS_OR_EOL(following)) {
+
+      if (ch === 0x3F/* ? */) {
+        if (atExplicitKey) {
+          storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, null, _keyLine, _keyLineStart, _keyPos);
+          keyTag = keyNode = valueNode = null;
+        }
+
+        detected = true;
+        atExplicitKey = true;
+        allowCompact = true;
+
+      } else if (atExplicitKey) {
+        // i.e. 0x3A/* : */ === character after the explicit key.
+        atExplicitKey = false;
+        allowCompact = true;
+
+      } else {
+        throwError(state, 'incomplete explicit mapping pair; a key node is missed; or followed by a non-tabulated empty line');
+      }
+
+      state.position += 1;
+      ch = following;
+
+    //
+    // Implicit notation case. Flow-style node as the key first, then ":", and the value.
+    //
+    } else {
+      _keyLine = state.line;
+      _keyLineStart = state.lineStart;
+      _keyPos = state.position;
+
+      if (!composeNode(state, flowIndent, CONTEXT_FLOW_OUT, false, true)) {
+        // Neither implicit nor explicit notation.
+        // Reading is done. Go to the epilogue.
+        break;
+      }
+
+      if (state.line === _line) {
+        ch = state.input.charCodeAt(state.position);
+
+        while (is_WHITE_SPACE(ch)) {
+          ch = state.input.charCodeAt(++state.position);
+        }
+
+        if (ch === 0x3A/* : */) {
+          ch = state.input.charCodeAt(++state.position);
+
+          if (!is_WS_OR_EOL(ch)) {
+            throwError(state, 'a whitespace character is expected after the key-value separator within a block mapping');
+          }
+
+          if (atExplicitKey) {
+            storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, null, _keyLine, _keyLineStart, _keyPos);
+            keyTag = keyNode = valueNode = null;
+          }
+
+          detected = true;
+          atExplicitKey = false;
+          allowCompact = false;
+          keyTag = state.tag;
+          keyNode = state.result;
+
+        } else if (detected) {
+          throwError(state, 'can not read an implicit mapping pair; a colon is missed');
+
+        } else {
+          state.tag = _tag;
+          state.anchor = _anchor;
+          return true; // Keep the result of `composeNode`.
+        }
+
+      } else if (detected) {
+        throwError(state, 'can not read a block mapping entry; a multiline key may not be an implicit key');
+
+      } else {
+        state.tag = _tag;
+        state.anchor = _anchor;
+        return true; // Keep the result of `composeNode`.
+      }
+    }
+
+    //
+    // Common reading code for both explicit and implicit notations.
+    //
+    if (state.line === _line || state.lineIndent > nodeIndent) {
+      if (atExplicitKey) {
+        _keyLine = state.line;
+        _keyLineStart = state.lineStart;
+        _keyPos = state.position;
+      }
+
+      if (composeNode(state, nodeIndent, CONTEXT_BLOCK_OUT, true, allowCompact)) {
+        if (atExplicitKey) {
+          keyNode = state.result;
+        } else {
+          valueNode = state.result;
+        }
+      }
+
+      if (!atExplicitKey) {
+        storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, valueNode, _keyLine, _keyLineStart, _keyPos);
+        keyTag = keyNode = valueNode = null;
+      }
+
+      skipSeparationSpace(state, true, -1);
+      ch = state.input.charCodeAt(state.position);
+    }
+
+    if ((state.line === _line || state.lineIndent > nodeIndent) && (ch !== 0)) {
+      throwError(state, 'bad indentation of a mapping entry');
+    } else if (state.lineIndent < nodeIndent) {
+      break;
+    }
+  }
+
+  //
+  // Epilogue.
+  //
+
+  // Special case: last mapping's node contains only the key in explicit notation.
+  if (atExplicitKey) {
+    storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, null, _keyLine, _keyLineStart, _keyPos);
+  }
+
+  // Expose the resulting mapping.
+  if (detected) {
+    state.tag = _tag;
+    state.anchor = _anchor;
+    state.kind = 'mapping';
+    state.result = _result;
+  }
+
+  return detected;
+}
+
+function readTagProperty(state) {
+  var _position,
+      isVerbatim = false,
+      isNamed    = false,
+      tagHandle,
+      tagName,
+      ch;
+
+  ch = state.input.charCodeAt(state.position);
+
+  if (ch !== 0x21/* ! */) return false;
+
+  if (state.tag !== null) {
+    throwError(state, 'duplication of a tag property');
+  }
+
+  ch = state.input.charCodeAt(++state.position);
+
+  if (ch === 0x3C/* < */) {
+    isVerbatim = true;
+    ch = state.input.charCodeAt(++state.position);
+
+  } else if (ch === 0x21/* ! */) {
+    isNamed = true;
+    tagHandle = '!!';
+    ch = state.input.charCodeAt(++state.position);
+
+  } else {
+    tagHandle = '!';
+  }
+
+  _position = state.position;
+
+  if (isVerbatim) {
+    do { ch = state.input.charCodeAt(++state.position); }
+    while (ch !== 0 && ch !== 0x3E/* > */);
+
+    if (state.position < state.length) {
+      tagName = state.input.slice(_position, state.position);
+      ch = state.input.charCodeAt(++state.position);
+    } else {
+      throwError(state, 'unexpected end of the stream within a verbatim tag');
+    }
+  } else {
+    while (ch !== 0 && !is_WS_OR_EOL(ch)) {
+
+      if (ch === 0x21/* ! */) {
+        if (!isNamed) {
+          tagHandle = state.input.slice(_position - 1, state.position + 1);
+
+          if (!PATTERN_TAG_HANDLE.test(tagHandle)) {
+            throwError(state, 'named tag handle cannot contain such characters');
+          }
+
+          isNamed = true;
+          _position = state.position + 1;
+        } else {
+          throwError(state, 'tag suffix cannot contain exclamation marks');
+        }
+      }
+
+      ch = state.input.charCodeAt(++state.position);
+    }
+
+    tagName = state.input.slice(_position, state.position);
+
+    if (PATTERN_FLOW_INDICATORS.test(tagName)) {
+      throwError(state, 'tag suffix cannot contain flow indicator characters');
+    }
+  }
+
+  if (tagName && !PATTERN_TAG_URI.test(tagName)) {
+    throwError(state, 'tag name cannot contain such characters: ' + tagName);
+  }
+
+  try {
+    tagName = decodeURIComponent(tagName);
+  } catch (err) {
+    throwError(state, 'tag name is malformed: ' + tagName);
+  }
+
+  if (isVerbatim) {
+    state.tag = tagName;
+
+  } else if (_hasOwnProperty$1.call(state.tagMap, tagHandle)) {
+    state.tag = state.tagMap[tagHandle] + tagName;
+
+  } else if (tagHandle === '!') {
+    state.tag = '!' + tagName;
+
+  } else if (tagHandle === '!!') {
+    state.tag = 'tag:yaml.org,2002:' + tagName;
+
+  } else {
+    throwError(state, 'undeclared tag handle "' + tagHandle + '"');
+  }
+
+  return true;
+}
+
+function readAnchorProperty(state) {
+  var _position,
+      ch;
+
+  ch = state.input.charCodeAt(state.position);
+
+  if (ch !== 0x26/* & */) return false;
+
+  if (state.anchor !== null) {
+    throwError(state, 'duplication of an anchor property');
+  }
+
+  ch = state.input.charCodeAt(++state.position);
+  _position = state.position;
+
+  while (ch !== 0 && !is_WS_OR_EOL(ch) && !is_FLOW_INDICATOR(ch)) {
+    ch = state.input.charCodeAt(++state.position);
+  }
+
+  if (state.position === _position) {
+    throwError(state, 'name of an anchor node must contain at least one character');
+  }
+
+  state.anchor = state.input.slice(_position, state.position);
+  return true;
+}
+
+function readAlias(state) {
+  var _position, alias,
+      ch;
+
+  ch = state.input.charCodeAt(state.position);
+
+  if (ch !== 0x2A/* * */) return false;
+
+  ch = state.input.charCodeAt(++state.position);
+  _position = state.position;
+
+  while (ch !== 0 && !is_WS_OR_EOL(ch) && !is_FLOW_INDICATOR(ch)) {
+    ch = state.input.charCodeAt(++state.position);
+  }
+
+  if (state.position === _position) {
+    throwError(state, 'name of an alias node must contain at least one character');
+  }
+
+  alias = state.input.slice(_position, state.position);
+
+  if (!_hasOwnProperty$1.call(state.anchorMap, alias)) {
+    throwError(state, 'unidentified alias "' + alias + '"');
+  }
+
+  state.result = state.anchorMap[alias];
+  skipSeparationSpace(state, true, -1);
+  return true;
+}
+
+function composeNode(state, parentIndent, nodeContext, allowToSeek, allowCompact) {
+  var allowBlockStyles,
+      allowBlockScalars,
+      allowBlockCollections,
+      indentStatus = 1, // 1: this>parent, 0: this=parent, -1: this<parent
+      atNewLine  = false,
+      hasContent = false,
+      typeIndex,
+      typeQuantity,
+      typeList,
+      type,
+      flowIndent,
+      blockIndent;
+
+  if (state.listener !== null) {
+    state.listener('open', state);
+  }
+
+  state.tag    = null;
+  state.anchor = null;
+  state.kind   = null;
+  state.result = null;
+
+  allowBlockStyles = allowBlockScalars = allowBlockCollections =
+    CONTEXT_BLOCK_OUT === nodeContext ||
+    CONTEXT_BLOCK_IN  === nodeContext;
+
+  if (allowToSeek) {
+    if (skipSeparationSpace(state, true, -1)) {
+      atNewLine = true;
+
+      if (state.lineIndent > parentIndent) {
+        indentStatus = 1;
+      } else if (state.lineIndent === parentIndent) {
+        indentStatus = 0;
+      } else if (state.lineIndent < parentIndent) {
+        indentStatus = -1;
+      }
+    }
+  }
+
+  if (indentStatus === 1) {
+    while (readTagProperty(state) || readAnchorProperty(state)) {
+      if (skipSeparationSpace(state, true, -1)) {
+        atNewLine = true;
+        allowBlockCollections = allowBlockStyles;
+
+        if (state.lineIndent > parentIndent) {
+          indentStatus = 1;
+        } else if (state.lineIndent === parentIndent) {
+          indentStatus = 0;
+        } else if (state.lineIndent < parentIndent) {
+          indentStatus = -1;
+        }
+      } else {
+        allowBlockCollections = false;
+      }
+    }
+  }
+
+  if (allowBlockCollections) {
+    allowBlockCollections = atNewLine || allowCompact;
+  }
+
+  if (indentStatus === 1 || CONTEXT_BLOCK_OUT === nodeContext) {
+    if (CONTEXT_FLOW_IN === nodeContext || CONTEXT_FLOW_OUT === nodeContext) {
+      flowIndent = parentIndent;
+    } else {
+      flowIndent = parentIndent + 1;
+    }
+
+    blockIndent = state.position - state.lineStart;
+
+    if (indentStatus === 1) {
+      if (allowBlockCollections &&
+          (readBlockSequence(state, blockIndent) ||
+           readBlockMapping(state, blockIndent, flowIndent)) ||
+          readFlowCollection(state, flowIndent)) {
+        hasContent = true;
+      } else {
+        if ((allowBlockScalars && readBlockScalar(state, flowIndent)) ||
+            readSingleQuotedScalar(state, flowIndent) ||
+            readDoubleQuotedScalar(state, flowIndent)) {
+          hasContent = true;
+
+        } else if (readAlias(state)) {
+          hasContent = true;
+
+          if (state.tag !== null || state.anchor !== null) {
+            throwError(state, 'alias node should not have any properties');
+          }
+
+        } else if (readPlainScalar(state, flowIndent, CONTEXT_FLOW_IN === nodeContext)) {
+          hasContent = true;
+
+          if (state.tag === null) {
+            state.tag = '?';
+          }
+        }
+
+        if (state.anchor !== null) {
+          state.anchorMap[state.anchor] = state.result;
+        }
+      }
+    } else if (indentStatus === 0) {
+      // Special case: block sequences are allowed to have same indentation level as the parent.
+      // http://www.yaml.org/spec/1.2/spec.html#id2799784
+      hasContent = allowBlockCollections && readBlockSequence(state, blockIndent);
+    }
+  }
+
+  if (state.tag === null) {
+    if (state.anchor !== null) {
+      state.anchorMap[state.anchor] = state.result;
+    }
+
+  } else if (state.tag === '?') {
+    // Implicit resolving is not allowed for non-scalar types, and '?'
+    // non-specific tag is only automatically assigned to plain scalars.
+    //
+    // We only need to check kind conformity in case user explicitly assigns '?'
+    // tag, for example like this: "!<?> [0]"
+    //
+    if (state.result !== null && state.kind !== 'scalar') {
+      throwError(state, 'unacceptable node kind for !<?> tag; it should be "scalar", not "' + state.kind + '"');
+    }
+
+    for (typeIndex = 0, typeQuantity = state.implicitTypes.length; typeIndex < typeQuantity; typeIndex += 1) {
+      type = state.implicitTypes[typeIndex];
+
+      if (type.resolve(state.result)) { // `state.result` updated in resolver if matched
+        state.result = type.construct(state.result);
+        state.tag = type.tag;
+        if (state.anchor !== null) {
+          state.anchorMap[state.anchor] = state.result;
+        }
+        break;
+      }
+    }
+  } else if (state.tag !== '!') {
+    if (_hasOwnProperty$1.call(state.typeMap[state.kind || 'fallback'], state.tag)) {
+      type = state.typeMap[state.kind || 'fallback'][state.tag];
+    } else {
+      // looking for multi type
+      type = null;
+      typeList = state.typeMap.multi[state.kind || 'fallback'];
+
+      for (typeIndex = 0, typeQuantity = typeList.length; typeIndex < typeQuantity; typeIndex += 1) {
+        if (state.tag.slice(0, typeList[typeIndex].tag.length) === typeList[typeIndex].tag) {
+          type = typeList[typeIndex];
+          break;
+        }
+      }
+    }
+
+    if (!type) {
+      throwError(state, 'unknown tag !<' + state.tag + '>');
+    }
+
+    if (state.result !== null && type.kind !== state.kind) {
+      throwError(state, 'unacceptable node kind for !<' + state.tag + '> tag; it should be "' + type.kind + '", not "' + state.kind + '"');
+    }
+
+    if (!type.resolve(state.result, state.tag)) { // `state.result` updated in resolver if matched
+      throwError(state, 'cannot resolve a node with !<' + state.tag + '> explicit tag');
+    } else {
+      state.result = type.construct(state.result, state.tag);
+      if (state.anchor !== null) {
+        state.anchorMap[state.anchor] = state.result;
+      }
+    }
+  }
+
+  if (state.listener !== null) {
+    state.listener('close', state);
+  }
+  return state.tag !== null ||  state.anchor !== null || hasContent;
+}
+
+function readDocument(state) {
+  var documentStart = state.position,
+      _position,
+      directiveName,
+      directiveArgs,
+      hasDirectives = false,
+      ch;
+
+  state.version = null;
+  state.checkLineBreaks = state.legacy;
+  state.tagMap = Object.create(null);
+  state.anchorMap = Object.create(null);
+
+  while ((ch = state.input.charCodeAt(state.position)) !== 0) {
+    skipSeparationSpace(state, true, -1);
+
+    ch = state.input.charCodeAt(state.position);
+
+    if (state.lineIndent > 0 || ch !== 0x25/* % */) {
+      break;
+    }
+
+    hasDirectives = true;
+    ch = state.input.charCodeAt(++state.position);
+    _position = state.position;
+
+    while (ch !== 0 && !is_WS_OR_EOL(ch)) {
+      ch = state.input.charCodeAt(++state.position);
+    }
+
+    directiveName = state.input.slice(_position, state.position);
+    directiveArgs = [];
+
+    if (directiveName.length < 1) {
+      throwError(state, 'directive name must not be less than one character in length');
+    }
+
+    while (ch !== 0) {
+      while (is_WHITE_SPACE(ch)) {
+        ch = state.input.charCodeAt(++state.position);
+      }
+
+      if (ch === 0x23/* # */) {
+        do { ch = state.input.charCodeAt(++state.position); }
+        while (ch !== 0 && !is_EOL(ch));
+        break;
+      }
+
+      if (is_EOL(ch)) break;
+
+      _position = state.position;
+
+      while (ch !== 0 && !is_WS_OR_EOL(ch)) {
+        ch = state.input.charCodeAt(++state.position);
+      }
+
+      directiveArgs.push(state.input.slice(_position, state.position));
+    }
+
+    if (ch !== 0) readLineBreak(state);
+
+    if (_hasOwnProperty$1.call(directiveHandlers, directiveName)) {
+      directiveHandlers[directiveName](state, directiveName, directiveArgs);
+    } else {
+      throwWarning(state, 'unknown document directive "' + directiveName + '"');
+    }
+  }
+
+  skipSeparationSpace(state, true, -1);
+
+  if (state.lineIndent === 0 &&
+      state.input.charCodeAt(state.position)     === 0x2D/* - */ &&
+      state.input.charCodeAt(state.position + 1) === 0x2D/* - */ &&
+      state.input.charCodeAt(state.position + 2) === 0x2D/* - */) {
+    state.position += 3;
+    skipSeparationSpace(state, true, -1);
+
+  } else if (hasDirectives) {
+    throwError(state, 'directives end mark is expected');
+  }
+
+  composeNode(state, state.lineIndent - 1, CONTEXT_BLOCK_OUT, false, true);
+  skipSeparationSpace(state, true, -1);
+
+  if (state.checkLineBreaks &&
+      PATTERN_NON_ASCII_LINE_BREAKS.test(state.input.slice(documentStart, state.position))) {
+    throwWarning(state, 'non-ASCII line breaks are interpreted as content');
+  }
+
+  state.documents.push(state.result);
+
+  if (state.position === state.lineStart && testDocumentSeparator(state)) {
+
+    if (state.input.charCodeAt(state.position) === 0x2E/* . */) {
+      state.position += 3;
+      skipSeparationSpace(state, true, -1);
+    }
+    return;
+  }
+
+  if (state.position < (state.length - 1)) {
+    throwError(state, 'end of the stream or a document separator is expected');
+  } else {
+    return;
+  }
+}
+
+
+function loadDocuments(input, options) {
+  input = String(input);
+  options = options || {};
+
+  if (input.length !== 0) {
+
+    // Add tailing `\n` if not exists
+    if (input.charCodeAt(input.length - 1) !== 0x0A/* LF */ &&
+        input.charCodeAt(input.length - 1) !== 0x0D/* CR */) {
+      input += '\n';
+    }
+
+    // Strip BOM
+    if (input.charCodeAt(0) === 0xFEFF) {
+      input = input.slice(1);
+    }
+  }
+
+  var state = new State$1(input, options);
+
+  var nullpos = input.indexOf('\0');
+
+  if (nullpos !== -1) {
+    state.position = nullpos;
+    throwError(state, 'null byte is not allowed in input');
+  }
+
+  // Use 0 as string terminator. That significantly simplifies bounds check.
+  state.input += '\0';
+
+  while (state.input.charCodeAt(state.position) === 0x20/* Space */) {
+    state.lineIndent += 1;
+    state.position += 1;
+  }
+
+  while (state.position < (state.length - 1)) {
+    readDocument(state);
+  }
+
+  return state.documents;
+}
+
+
+function loadAll$1(input, iterator, options) {
+  if (iterator !== null && typeof iterator === 'object' && typeof options === 'undefined') {
+    options = iterator;
+    iterator = null;
+  }
+
+  var documents = loadDocuments(input, options);
+
+  if (typeof iterator !== 'function') {
+    return documents;
+  }
+
+  for (var index = 0, length = documents.length; index < length; index += 1) {
+    iterator(documents[index]);
+  }
+}
+
+
+function load$1(input, options) {
+  var documents = loadDocuments(input, options);
+
+  if (documents.length === 0) {
+    /*eslint-disable no-undefined*/
+    return undefined;
+  } else if (documents.length === 1) {
+    return documents[0];
+  }
+  throw new exception('expected a single document in the stream, but found more');
+}
+
+
+var loadAll_1 = loadAll$1;
+var load_1    = load$1;
+
+var loader = {
+	loadAll: loadAll_1,
+	load: load_1
+};
+
+/*eslint-disable no-use-before-define*/
+
+
+
+
+
+var _toString       = Object.prototype.toString;
+var _hasOwnProperty = Object.prototype.hasOwnProperty;
+
+var CHAR_BOM                  = 0xFEFF;
+var CHAR_TAB                  = 0x09; /* Tab */
+var CHAR_LINE_FEED            = 0x0A; /* LF */
+var CHAR_CARRIAGE_RETURN      = 0x0D; /* CR */
+var CHAR_SPACE                = 0x20; /* Space */
+var CHAR_EXCLAMATION          = 0x21; /* ! */
+var CHAR_DOUBLE_QUOTE         = 0x22; /* " */
+var CHAR_SHARP                = 0x23; /* # */
+var CHAR_PERCENT              = 0x25; /* % */
+var CHAR_AMPERSAND            = 0x26; /* & */
+var CHAR_SINGLE_QUOTE         = 0x27; /* ' */
+var CHAR_ASTERISK             = 0x2A; /* * */
+var CHAR_COMMA                = 0x2C; /* , */
+var CHAR_MINUS                = 0x2D; /* - */
+var CHAR_COLON                = 0x3A; /* : */
+var CHAR_EQUALS               = 0x3D; /* = */
+var CHAR_GREATER_THAN         = 0x3E; /* > */
+var CHAR_QUESTION             = 0x3F; /* ? */
+var CHAR_COMMERCIAL_AT        = 0x40; /* @ */
+var CHAR_LEFT_SQUARE_BRACKET  = 0x5B; /* [ */
+var CHAR_RIGHT_SQUARE_BRACKET = 0x5D; /* ] */
+var CHAR_GRAVE_ACCENT         = 0x60; /* ` */
+var CHAR_LEFT_CURLY_BRACKET   = 0x7B; /* { */
+var CHAR_VERTICAL_LINE        = 0x7C; /* | */
+var CHAR_RIGHT_CURLY_BRACKET  = 0x7D; /* } */
+
+var ESCAPE_SEQUENCES = {};
+
+ESCAPE_SEQUENCES[0x00]   = '\\0';
+ESCAPE_SEQUENCES[0x07]   = '\\a';
+ESCAPE_SEQUENCES[0x08]   = '\\b';
+ESCAPE_SEQUENCES[0x09]   = '\\t';
+ESCAPE_SEQUENCES[0x0A]   = '\\n';
+ESCAPE_SEQUENCES[0x0B]   = '\\v';
+ESCAPE_SEQUENCES[0x0C]   = '\\f';
+ESCAPE_SEQUENCES[0x0D]   = '\\r';
+ESCAPE_SEQUENCES[0x1B]   = '\\e';
+ESCAPE_SEQUENCES[0x22]   = '\\"';
+ESCAPE_SEQUENCES[0x5C]   = '\\\\';
+ESCAPE_SEQUENCES[0x85]   = '\\N';
+ESCAPE_SEQUENCES[0xA0]   = '\\_';
+ESCAPE_SEQUENCES[0x2028] = '\\L';
+ESCAPE_SEQUENCES[0x2029] = '\\P';
+
+var DEPRECATED_BOOLEANS_SYNTAX = [
+  'y', 'Y', 'yes', 'Yes', 'YES', 'on', 'On', 'ON',
+  'n', 'N', 'no', 'No', 'NO', 'off', 'Off', 'OFF'
+];
+
+var DEPRECATED_BASE60_SYNTAX = /^[-+]?[0-9_]+(?::[0-9_]+)+(?:\.[0-9_]*)?$/;
+
+function compileStyleMap(schema, map) {
+  var result, keys, index, length, tag, style, type;
+
+  if (map === null) return {};
+
+  result = {};
+  keys = Object.keys(map);
+
+  for (index = 0, length = keys.length; index < length; index += 1) {
+    tag = keys[index];
+    style = String(map[tag]);
+
+    if (tag.slice(0, 2) === '!!') {
+      tag = 'tag:yaml.org,2002:' + tag.slice(2);
+    }
+    type = schema.compiledTypeMap['fallback'][tag];
+
+    if (type && _hasOwnProperty.call(type.styleAliases, style)) {
+      style = type.styleAliases[style];
+    }
+
+    result[tag] = style;
+  }
+
+  return result;
+}
+
+function encodeHex(character) {
+  var string, handle, length;
+
+  string = character.toString(16).toUpperCase();
+
+  if (character <= 0xFF) {
+    handle = 'x';
+    length = 2;
+  } else if (character <= 0xFFFF) {
+    handle = 'u';
+    length = 4;
+  } else if (character <= 0xFFFFFFFF) {
+    handle = 'U';
+    length = 8;
+  } else {
+    throw new exception('code point within a string may not be greater than 0xFFFFFFFF');
+  }
+
+  return '\\' + handle + common.repeat('0', length - string.length) + string;
+}
+
+
+var QUOTING_TYPE_SINGLE = 1,
+    QUOTING_TYPE_DOUBLE = 2;
+
+function State(options) {
+  this.schema        = options['schema'] || _default;
+  this.indent        = Math.max(1, (options['indent'] || 2));
+  this.noArrayIndent = options['noArrayIndent'] || false;
+  this.skipInvalid   = options['skipInvalid'] || false;
+  this.flowLevel     = (common.isNothing(options['flowLevel']) ? -1 : options['flowLevel']);
+  this.styleMap      = compileStyleMap(this.schema, options['styles'] || null);
+  this.sortKeys      = options['sortKeys'] || false;
+  this.lineWidth     = options['lineWidth'] || 80;
+  this.noRefs        = options['noRefs'] || false;
+  this.noCompatMode  = options['noCompatMode'] || false;
+  this.condenseFlow  = options['condenseFlow'] || false;
+  this.quotingType   = options['quotingType'] === '"' ? QUOTING_TYPE_DOUBLE : QUOTING_TYPE_SINGLE;
+  this.forceQuotes   = options['forceQuotes'] || false;
+  this.replacer      = typeof options['replacer'] === 'function' ? options['replacer'] : null;
+
+  this.implicitTypes = this.schema.compiledImplicit;
+  this.explicitTypes = this.schema.compiledExplicit;
+
+  this.tag = null;
+  this.result = '';
+
+  this.duplicates = [];
+  this.usedDuplicates = null;
+}
+
+// Indents every line in a string. Empty lines (\n only) are not indented.
+function indentString(string, spaces) {
+  var ind = common.repeat(' ', spaces),
+      position = 0,
+      next = -1,
+      result = '',
+      line,
+      length = string.length;
+
+  while (position < length) {
+    next = string.indexOf('\n', position);
+    if (next === -1) {
+      line = string.slice(position);
+      position = length;
+    } else {
+      line = string.slice(position, next + 1);
+      position = next + 1;
+    }
+
+    if (line.length && line !== '\n') result += ind;
+
+    result += line;
+  }
+
+  return result;
+}
+
+function generateNextLine(state, level) {
+  return '\n' + common.repeat(' ', state.indent * level);
+}
+
+function testImplicitResolving(state, str) {
+  var index, length, type;
+
+  for (index = 0, length = state.implicitTypes.length; index < length; index += 1) {
+    type = state.implicitTypes[index];
+
+    if (type.resolve(str)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// [33] s-white ::= s-space | s-tab
+function isWhitespace(c) {
+  return c === CHAR_SPACE || c === CHAR_TAB;
+}
+
+// Returns true if the character can be printed without escaping.
+// From YAML 1.2: "any allowed characters known to be non-printable
+// should also be escaped. [However,] This isn’t mandatory"
+// Derived from nb-char - \t - #x85 - #xA0 - #x2028 - #x2029.
+function isPrintable(c) {
+  return  (0x00020 <= c && c <= 0x00007E)
+      || ((0x000A1 <= c && c <= 0x00D7FF) && c !== 0x2028 && c !== 0x2029)
+      || ((0x0E000 <= c && c <= 0x00FFFD) && c !== CHAR_BOM)
+      ||  (0x10000 <= c && c <= 0x10FFFF);
+}
+
+// [34] ns-char ::= nb-char - s-white
+// [27] nb-char ::= c-printable - b-char - c-byte-order-mark
+// [26] b-char  ::= b-line-feed | b-carriage-return
+// Including s-white (for some reason, examples doesn't match specs in this aspect)
+// ns-char ::= c-printable - b-line-feed - b-carriage-return - c-byte-order-mark
+function isNsCharOrWhitespace(c) {
+  return isPrintable(c)
+    && c !== CHAR_BOM
+    // - b-char
+    && c !== CHAR_CARRIAGE_RETURN
+    && c !== CHAR_LINE_FEED;
+}
+
+// [127]  ns-plain-safe(c) ::= c = flow-out  ⇒ ns-plain-safe-out
+//                             c = flow-in   ⇒ ns-plain-safe-in
+//                             c = block-key ⇒ ns-plain-safe-out
+//                             c = flow-key  ⇒ ns-plain-safe-in
+// [128] ns-plain-safe-out ::= ns-char
+// [129]  ns-plain-safe-in ::= ns-char - c-flow-indicator
+// [130]  ns-plain-char(c) ::=  ( ns-plain-safe(c) - “:” - “#” )
+//                            | ( /* An ns-char preceding */ “#” )
+//                            | ( “:” /* Followed by an ns-plain-safe(c) */ )
+function isPlainSafe(c, prev, inblock) {
+  var cIsNsCharOrWhitespace = isNsCharOrWhitespace(c);
+  var cIsNsChar = cIsNsCharOrWhitespace && !isWhitespace(c);
+  return (
+    // ns-plain-safe
+    inblock ? // c = flow-in
+      cIsNsCharOrWhitespace
+      : cIsNsCharOrWhitespace
+        // - c-flow-indicator
+        && c !== CHAR_COMMA
+        && c !== CHAR_LEFT_SQUARE_BRACKET
+        && c !== CHAR_RIGHT_SQUARE_BRACKET
+        && c !== CHAR_LEFT_CURLY_BRACKET
+        && c !== CHAR_RIGHT_CURLY_BRACKET
+  )
+    // ns-plain-char
+    && c !== CHAR_SHARP // false on '#'
+    && !(prev === CHAR_COLON && !cIsNsChar) // false on ': '
+    || (isNsCharOrWhitespace(prev) && !isWhitespace(prev) && c === CHAR_SHARP) // change to true on '[^ ]#'
+    || (prev === CHAR_COLON && cIsNsChar); // change to true on ':[^ ]'
+}
+
+// Simplified test for values allowed as the first character in plain style.
+function isPlainSafeFirst(c) {
+  // Uses a subset of ns-char - c-indicator
+  // where ns-char = nb-char - s-white.
+  // No support of ( ( “?” | “:” | “-” ) /* Followed by an ns-plain-safe(c)) */ ) part
+  return isPrintable(c) && c !== CHAR_BOM
+    && !isWhitespace(c) // - s-white
+    // - (c-indicator ::=
+    // “-” | “?” | “:” | “,” | “[” | “]” | “{” | “}”
+    && c !== CHAR_MINUS
+    && c !== CHAR_QUESTION
+    && c !== CHAR_COLON
+    && c !== CHAR_COMMA
+    && c !== CHAR_LEFT_SQUARE_BRACKET
+    && c !== CHAR_RIGHT_SQUARE_BRACKET
+    && c !== CHAR_LEFT_CURLY_BRACKET
+    && c !== CHAR_RIGHT_CURLY_BRACKET
+    // | “#” | “&” | “*” | “!” | “|” | “=” | “>” | “'” | “"”
+    && c !== CHAR_SHARP
+    && c !== CHAR_AMPERSAND
+    && c !== CHAR_ASTERISK
+    && c !== CHAR_EXCLAMATION
+    && c !== CHAR_VERTICAL_LINE
+    && c !== CHAR_EQUALS
+    && c !== CHAR_GREATER_THAN
+    && c !== CHAR_SINGLE_QUOTE
+    && c !== CHAR_DOUBLE_QUOTE
+    // | “%” | “@” | “`”)
+    && c !== CHAR_PERCENT
+    && c !== CHAR_COMMERCIAL_AT
+    && c !== CHAR_GRAVE_ACCENT;
+}
+
+// Simplified test for values allowed as the last character in plain style.
+function isPlainSafeLast(c) {
+  // just not whitespace or colon, it will be checked to be plain character later
+  return !isWhitespace(c) && c !== CHAR_COLON;
+}
+
+// Same as 'string'.codePointAt(pos), but works in older browsers.
+function codePointAt(string, pos) {
+  var first = string.charCodeAt(pos), second;
+  if (first >= 0xD800 && first <= 0xDBFF && pos + 1 < string.length) {
+    second = string.charCodeAt(pos + 1);
+    if (second >= 0xDC00 && second <= 0xDFFF) {
+      // https://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
+      return (first - 0xD800) * 0x400 + second - 0xDC00 + 0x10000;
+    }
+  }
+  return first;
+}
+
+// Determines whether block indentation indicator is required.
+function needIndentIndicator(string) {
+  var leadingSpaceRe = /^\n* /;
+  return leadingSpaceRe.test(string);
+}
+
+var STYLE_PLAIN   = 1,
+    STYLE_SINGLE  = 2,
+    STYLE_LITERAL = 3,
+    STYLE_FOLDED  = 4,
+    STYLE_DOUBLE  = 5;
+
+// Determines which scalar styles are possible and returns the preferred style.
+// lineWidth = -1 => no limit.
+// Pre-conditions: str.length > 0.
+// Post-conditions:
+//    STYLE_PLAIN or STYLE_SINGLE => no \n are in the string.
+//    STYLE_LITERAL => no lines are suitable for folding (or lineWidth is -1).
+//    STYLE_FOLDED => a line > lineWidth and can be folded (and lineWidth != -1).
+function chooseScalarStyle(string, singleLineOnly, indentPerLevel, lineWidth,
+  testAmbiguousType, quotingType, forceQuotes, inblock) {
+
+  var i;
+  var char = 0;
+  var prevChar = null;
+  var hasLineBreak = false;
+  var hasFoldableLine = false; // only checked if shouldTrackWidth
+  var shouldTrackWidth = lineWidth !== -1;
+  var previousLineBreak = -1; // count the first line correctly
+  var plain = isPlainSafeFirst(codePointAt(string, 0))
+          && isPlainSafeLast(codePointAt(string, string.length - 1));
+
+  if (singleLineOnly || forceQuotes) {
+    // Case: no block styles.
+    // Check for disallowed characters to rule out plain and single.
+    for (i = 0; i < string.length; char >= 0x10000 ? i += 2 : i++) {
+      char = codePointAt(string, i);
+      if (!isPrintable(char)) {
+        return STYLE_DOUBLE;
+      }
+      plain = plain && isPlainSafe(char, prevChar, inblock);
+      prevChar = char;
+    }
+  } else {
+    // Case: block styles permitted.
+    for (i = 0; i < string.length; char >= 0x10000 ? i += 2 : i++) {
+      char = codePointAt(string, i);
+      if (char === CHAR_LINE_FEED) {
+        hasLineBreak = true;
+        // Check if any line can be folded.
+        if (shouldTrackWidth) {
+          hasFoldableLine = hasFoldableLine ||
+            // Foldable line = too long, and not more-indented.
+            (i - previousLineBreak - 1 > lineWidth &&
+             string[previousLineBreak + 1] !== ' ');
+          previousLineBreak = i;
+        }
+      } else if (!isPrintable(char)) {
+        return STYLE_DOUBLE;
+      }
+      plain = plain && isPlainSafe(char, prevChar, inblock);
+      prevChar = char;
+    }
+    // in case the end is missing a \n
+    hasFoldableLine = hasFoldableLine || (shouldTrackWidth &&
+      (i - previousLineBreak - 1 > lineWidth &&
+       string[previousLineBreak + 1] !== ' '));
+  }
+  // Although every style can represent \n without escaping, prefer block styles
+  // for multiline, since they're more readable and they don't add empty lines.
+  // Also prefer folding a super-long line.
+  if (!hasLineBreak && !hasFoldableLine) {
+    // Strings interpretable as another type have to be quoted;
+    // e.g. the string 'true' vs. the boolean true.
+    if (plain && !forceQuotes && !testAmbiguousType(string)) {
+      return STYLE_PLAIN;
+    }
+    return quotingType === QUOTING_TYPE_DOUBLE ? STYLE_DOUBLE : STYLE_SINGLE;
+  }
+  // Edge case: block indentation indicator can only have one digit.
+  if (indentPerLevel > 9 && needIndentIndicator(string)) {
+    return STYLE_DOUBLE;
+  }
+  // At this point we know block styles are valid.
+  // Prefer literal style unless we want to fold.
+  if (!forceQuotes) {
+    return hasFoldableLine ? STYLE_FOLDED : STYLE_LITERAL;
+  }
+  return quotingType === QUOTING_TYPE_DOUBLE ? STYLE_DOUBLE : STYLE_SINGLE;
+}
+
+// Note: line breaking/folding is implemented for only the folded style.
+// NB. We drop the last trailing newline (if any) of a returned block scalar
+//  since the dumper adds its own newline. This always works:
+//    • No ending newline => unaffected; already using strip "-" chomping.
+//    • Ending newline    => removed then restored.
+//  Importantly, this keeps the "+" chomp indicator from gaining an extra line.
+function writeScalar(state, string, level, iskey, inblock) {
+  state.dump = (function () {
+    if (string.length === 0) {
+      return state.quotingType === QUOTING_TYPE_DOUBLE ? '""' : "''";
+    }
+    if (!state.noCompatMode) {
+      if (DEPRECATED_BOOLEANS_SYNTAX.indexOf(string) !== -1 || DEPRECATED_BASE60_SYNTAX.test(string)) {
+        return state.quotingType === QUOTING_TYPE_DOUBLE ? ('"' + string + '"') : ("'" + string + "'");
+      }
+    }
+
+    var indent = state.indent * Math.max(1, level); // no 0-indent scalars
+    // As indentation gets deeper, let the width decrease monotonically
+    // to the lower bound min(state.lineWidth, 40).
+    // Note that this implies
+    //  state.lineWidth ≤ 40 + state.indent: width is fixed at the lower bound.
+    //  state.lineWidth > 40 + state.indent: width decreases until the lower bound.
+    // This behaves better than a constant minimum width which disallows narrower options,
+    // or an indent threshold which causes the width to suddenly increase.
+    var lineWidth = state.lineWidth === -1
+      ? -1 : Math.max(Math.min(state.lineWidth, 40), state.lineWidth - indent);
+
+    // Without knowing if keys are implicit/explicit, assume implicit for safety.
+    var singleLineOnly = iskey
+      // No block styles in flow mode.
+      || (state.flowLevel > -1 && level >= state.flowLevel);
+    function testAmbiguity(string) {
+      return testImplicitResolving(state, string);
+    }
+
+    switch (chooseScalarStyle(string, singleLineOnly, state.indent, lineWidth,
+      testAmbiguity, state.quotingType, state.forceQuotes && !iskey, inblock)) {
+
+      case STYLE_PLAIN:
+        return string;
+      case STYLE_SINGLE:
+        return "'" + string.replace(/'/g, "''") + "'";
+      case STYLE_LITERAL:
+        return '|' + blockHeader(string, state.indent)
+          + dropEndingNewline(indentString(string, indent));
+      case STYLE_FOLDED:
+        return '>' + blockHeader(string, state.indent)
+          + dropEndingNewline(indentString(foldString(string, lineWidth), indent));
+      case STYLE_DOUBLE:
+        return '"' + escapeString(string) + '"';
+      default:
+        throw new exception('impossible error: invalid scalar style');
+    }
+  }());
+}
+
+// Pre-conditions: string is valid for a block scalar, 1 <= indentPerLevel <= 9.
+function blockHeader(string, indentPerLevel) {
+  var indentIndicator = needIndentIndicator(string) ? String(indentPerLevel) : '';
+
+  // note the special case: the string '\n' counts as a "trailing" empty line.
+  var clip =          string[string.length - 1] === '\n';
+  var keep = clip && (string[string.length - 2] === '\n' || string === '\n');
+  var chomp = keep ? '+' : (clip ? '' : '-');
+
+  return indentIndicator + chomp + '\n';
+}
+
+// (See the note for writeScalar.)
+function dropEndingNewline(string) {
+  return string[string.length - 1] === '\n' ? string.slice(0, -1) : string;
+}
+
+// Note: a long line without a suitable break point will exceed the width limit.
+// Pre-conditions: every char in str isPrintable, str.length > 0, width > 0.
+function foldString(string, width) {
+  // In folded style, $k$ consecutive newlines output as $k+1$ newlines—
+  // unless they're before or after a more-indented line, or at the very
+  // beginning or end, in which case $k$ maps to $k$.
+  // Therefore, parse each chunk as newline(s) followed by a content line.
+  var lineRe = /(\n+)([^\n]*)/g;
+
+  // first line (possibly an empty line)
+  var result = (function () {
+    var nextLF = string.indexOf('\n');
+    nextLF = nextLF !== -1 ? nextLF : string.length;
+    lineRe.lastIndex = nextLF;
+    return foldLine(string.slice(0, nextLF), width);
+  }());
+  // If we haven't reached the first content line yet, don't add an extra \n.
+  var prevMoreIndented = string[0] === '\n' || string[0] === ' ';
+  var moreIndented;
+
+  // rest of the lines
+  var match;
+  while ((match = lineRe.exec(string))) {
+    var prefix = match[1], line = match[2];
+    moreIndented = (line[0] === ' ');
+    result += prefix
+      + (!prevMoreIndented && !moreIndented && line !== ''
+        ? '\n' : '')
+      + foldLine(line, width);
+    prevMoreIndented = moreIndented;
+  }
+
+  return result;
+}
+
+// Greedy line breaking.
+// Picks the longest line under the limit each time,
+// otherwise settles for the shortest line over the limit.
+// NB. More-indented lines *cannot* be folded, as that would add an extra \n.
+function foldLine(line, width) {
+  if (line === '' || line[0] === ' ') return line;
+
+  // Since a more-indented line adds a \n, breaks can't be followed by a space.
+  var breakRe = / [^ ]/g; // note: the match index will always be <= length-2.
+  var match;
+  // start is an inclusive index. end, curr, and next are exclusive.
+  var start = 0, end, curr = 0, next = 0;
+  var result = '';
+
+  // Invariants: 0 <= start <= length-1.
+  //   0 <= curr <= next <= max(0, length-2). curr - start <= width.
+  // Inside the loop:
+  //   A match implies length >= 2, so curr and next are <= length-2.
+  while ((match = breakRe.exec(line))) {
+    next = match.index;
+    // maintain invariant: curr - start <= width
+    if (next - start > width) {
+      end = (curr > start) ? curr : next; // derive end <= length-2
+      result += '\n' + line.slice(start, end);
+      // skip the space that was output as \n
+      start = end + 1;                    // derive start <= length-1
+    }
+    curr = next;
+  }
+
+  // By the invariants, start <= length-1, so there is something left over.
+  // It is either the whole string or a part starting from non-whitespace.
+  result += '\n';
+  // Insert a break if the remainder is too long and there is a break available.
+  if (line.length - start > width && curr > start) {
+    result += line.slice(start, curr) + '\n' + line.slice(curr + 1);
+  } else {
+    result += line.slice(start);
+  }
+
+  return result.slice(1); // drop extra \n joiner
+}
+
+// Escapes a double-quoted string.
+function escapeString(string) {
+  var result = '';
+  var char = 0;
+  var escapeSeq;
+
+  for (var i = 0; i < string.length; char >= 0x10000 ? i += 2 : i++) {
+    char = codePointAt(string, i);
+    escapeSeq = ESCAPE_SEQUENCES[char];
+
+    if (!escapeSeq && isPrintable(char)) {
+      result += string[i];
+      if (char >= 0x10000) result += string[i + 1];
+    } else {
+      result += escapeSeq || encodeHex(char);
+    }
+  }
+
+  return result;
+}
+
+function writeFlowSequence(state, level, object) {
+  var _result = '',
+      _tag    = state.tag,
+      index,
+      length,
+      value;
+
+  for (index = 0, length = object.length; index < length; index += 1) {
+    value = object[index];
+
+    if (state.replacer) {
+      value = state.replacer.call(object, String(index), value);
+    }
+
+    // Write only valid elements, put null instead of invalid elements.
+    if (writeNode(state, level, value, false, false) ||
+        (typeof value === 'undefined' &&
+         writeNode(state, level, null, false, false))) {
+
+      if (_result !== '') _result += ',' + (!state.condenseFlow ? ' ' : '');
+      _result += state.dump;
+    }
+  }
+
+  state.tag = _tag;
+  state.dump = '[' + _result + ']';
+}
+
+function writeBlockSequence(state, level, object, compact) {
+  var _result = '',
+      _tag    = state.tag,
+      index,
+      length,
+      value;
+
+  for (index = 0, length = object.length; index < length; index += 1) {
+    value = object[index];
+
+    if (state.replacer) {
+      value = state.replacer.call(object, String(index), value);
+    }
+
+    // Write only valid elements, put null instead of invalid elements.
+    if (writeNode(state, level + 1, value, true, true, false, true) ||
+        (typeof value === 'undefined' &&
+         writeNode(state, level + 1, null, true, true, false, true))) {
+
+      if (!compact || _result !== '') {
+        _result += generateNextLine(state, level);
+      }
+
+      if (state.dump && CHAR_LINE_FEED === state.dump.charCodeAt(0)) {
+        _result += '-';
+      } else {
+        _result += '- ';
+      }
+
+      _result += state.dump;
+    }
+  }
+
+  state.tag = _tag;
+  state.dump = _result || '[]'; // Empty sequence if no valid values.
+}
+
+function writeFlowMapping(state, level, object) {
+  var _result       = '',
+      _tag          = state.tag,
+      objectKeyList = Object.keys(object),
+      index,
+      length,
+      objectKey,
+      objectValue,
+      pairBuffer;
+
+  for (index = 0, length = objectKeyList.length; index < length; index += 1) {
+
+    pairBuffer = '';
+    if (_result !== '') pairBuffer += ', ';
+
+    if (state.condenseFlow) pairBuffer += '"';
+
+    objectKey = objectKeyList[index];
+    objectValue = object[objectKey];
+
+    if (state.replacer) {
+      objectValue = state.replacer.call(object, objectKey, objectValue);
+    }
+
+    if (!writeNode(state, level, objectKey, false, false)) {
+      continue; // Skip this pair because of invalid key;
+    }
+
+    if (state.dump.length > 1024) pairBuffer += '? ';
+
+    pairBuffer += state.dump + (state.condenseFlow ? '"' : '') + ':' + (state.condenseFlow ? '' : ' ');
+
+    if (!writeNode(state, level, objectValue, false, false)) {
+      continue; // Skip this pair because of invalid value.
+    }
+
+    pairBuffer += state.dump;
+
+    // Both key and value are valid.
+    _result += pairBuffer;
+  }
+
+  state.tag = _tag;
+  state.dump = '{' + _result + '}';
+}
+
+function writeBlockMapping(state, level, object, compact) {
+  var _result       = '',
+      _tag          = state.tag,
+      objectKeyList = Object.keys(object),
+      index,
+      length,
+      objectKey,
+      objectValue,
+      explicitPair,
+      pairBuffer;
+
+  // Allow sorting keys so that the output file is deterministic
+  if (state.sortKeys === true) {
+    // Default sorting
+    objectKeyList.sort();
+  } else if (typeof state.sortKeys === 'function') {
+    // Custom sort function
+    objectKeyList.sort(state.sortKeys);
+  } else if (state.sortKeys) {
+    // Something is wrong
+    throw new exception('sortKeys must be a boolean or a function');
+  }
+
+  for (index = 0, length = objectKeyList.length; index < length; index += 1) {
+    pairBuffer = '';
+
+    if (!compact || _result !== '') {
+      pairBuffer += generateNextLine(state, level);
+    }
+
+    objectKey = objectKeyList[index];
+    objectValue = object[objectKey];
+
+    if (state.replacer) {
+      objectValue = state.replacer.call(object, objectKey, objectValue);
+    }
+
+    if (!writeNode(state, level + 1, objectKey, true, true, true)) {
+      continue; // Skip this pair because of invalid key.
+    }
+
+    explicitPair = (state.tag !== null && state.tag !== '?') ||
+                   (state.dump && state.dump.length > 1024);
+
+    if (explicitPair) {
+      if (state.dump && CHAR_LINE_FEED === state.dump.charCodeAt(0)) {
+        pairBuffer += '?';
+      } else {
+        pairBuffer += '? ';
+      }
+    }
+
+    pairBuffer += state.dump;
+
+    if (explicitPair) {
+      pairBuffer += generateNextLine(state, level);
+    }
+
+    if (!writeNode(state, level + 1, objectValue, true, explicitPair)) {
+      continue; // Skip this pair because of invalid value.
+    }
+
+    if (state.dump && CHAR_LINE_FEED === state.dump.charCodeAt(0)) {
+      pairBuffer += ':';
+    } else {
+      pairBuffer += ': ';
+    }
+
+    pairBuffer += state.dump;
+
+    // Both key and value are valid.
+    _result += pairBuffer;
+  }
+
+  state.tag = _tag;
+  state.dump = _result || '{}'; // Empty mapping if no valid pairs.
+}
+
+function detectType(state, object, explicit) {
+  var _result, typeList, index, length, type, style;
+
+  typeList = explicit ? state.explicitTypes : state.implicitTypes;
+
+  for (index = 0, length = typeList.length; index < length; index += 1) {
+    type = typeList[index];
+
+    if ((type.instanceOf  || type.predicate) &&
+        (!type.instanceOf || ((typeof object === 'object') && (object instanceof type.instanceOf))) &&
+        (!type.predicate  || type.predicate(object))) {
+
+      if (explicit) {
+        if (type.multi && type.representName) {
+          state.tag = type.representName(object);
+        } else {
+          state.tag = type.tag;
+        }
+      } else {
+        state.tag = '?';
+      }
+
+      if (type.represent) {
+        style = state.styleMap[type.tag] || type.defaultStyle;
+
+        if (_toString.call(type.represent) === '[object Function]') {
+          _result = type.represent(object, style);
+        } else if (_hasOwnProperty.call(type.represent, style)) {
+          _result = type.represent[style](object, style);
+        } else {
+          throw new exception('!<' + type.tag + '> tag resolver accepts not "' + style + '" style');
+        }
+
+        state.dump = _result;
+      }
+
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// Serializes `object` and writes it to global `result`.
+// Returns true on success, or false on invalid object.
+//
+function writeNode(state, level, object, block, compact, iskey, isblockseq) {
+  state.tag = null;
+  state.dump = object;
+
+  if (!detectType(state, object, false)) {
+    detectType(state, object, true);
+  }
+
+  var type = _toString.call(state.dump);
+  var inblock = block;
+  var tagStr;
+
+  if (block) {
+    block = (state.flowLevel < 0 || state.flowLevel > level);
+  }
+
+  var objectOrArray = type === '[object Object]' || type === '[object Array]',
+      duplicateIndex,
+      duplicate;
+
+  if (objectOrArray) {
+    duplicateIndex = state.duplicates.indexOf(object);
+    duplicate = duplicateIndex !== -1;
+  }
+
+  if ((state.tag !== null && state.tag !== '?') || duplicate || (state.indent !== 2 && level > 0)) {
+    compact = false;
+  }
+
+  if (duplicate && state.usedDuplicates[duplicateIndex]) {
+    state.dump = '*ref_' + duplicateIndex;
+  } else {
+    if (objectOrArray && duplicate && !state.usedDuplicates[duplicateIndex]) {
+      state.usedDuplicates[duplicateIndex] = true;
+    }
+    if (type === '[object Object]') {
+      if (block && (Object.keys(state.dump).length !== 0)) {
+        writeBlockMapping(state, level, state.dump, compact);
+        if (duplicate) {
+          state.dump = '&ref_' + duplicateIndex + state.dump;
+        }
+      } else {
+        writeFlowMapping(state, level, state.dump);
+        if (duplicate) {
+          state.dump = '&ref_' + duplicateIndex + ' ' + state.dump;
+        }
+      }
+    } else if (type === '[object Array]') {
+      if (block && (state.dump.length !== 0)) {
+        if (state.noArrayIndent && !isblockseq && level > 0) {
+          writeBlockSequence(state, level - 1, state.dump, compact);
+        } else {
+          writeBlockSequence(state, level, state.dump, compact);
+        }
+        if (duplicate) {
+          state.dump = '&ref_' + duplicateIndex + state.dump;
+        }
+      } else {
+        writeFlowSequence(state, level, state.dump);
+        if (duplicate) {
+          state.dump = '&ref_' + duplicateIndex + ' ' + state.dump;
+        }
+      }
+    } else if (type === '[object String]') {
+      if (state.tag !== '?') {
+        writeScalar(state, state.dump, level, iskey, inblock);
+      }
+    } else if (type === '[object Undefined]') {
+      return false;
+    } else {
+      if (state.skipInvalid) return false;
+      throw new exception('unacceptable kind of an object to dump ' + type);
+    }
+
+    if (state.tag !== null && state.tag !== '?') {
+      // Need to encode all characters except those allowed by the spec:
+      //
+      // [35] ns-dec-digit    ::=  [#x30-#x39] /* 0-9 */
+      // [36] ns-hex-digit    ::=  ns-dec-digit
+      //                         | [#x41-#x46] /* A-F */ | [#x61-#x66] /* a-f */
+      // [37] ns-ascii-letter ::=  [#x41-#x5A] /* A-Z */ | [#x61-#x7A] /* a-z */
+      // [38] ns-word-char    ::=  ns-dec-digit | ns-ascii-letter | “-”
+      // [39] ns-uri-char     ::=  “%” ns-hex-digit ns-hex-digit | ns-word-char | “#”
+      //                         | “;” | “/” | “?” | “:” | “@” | “&” | “=” | “+” | “$” | “,”
+      //                         | “_” | “.” | “!” | “~” | “*” | “'” | “(” | “)” | “[” | “]”
+      //
+      // Also need to encode '!' because it has special meaning (end of tag prefix).
+      //
+      tagStr = encodeURI(
+        state.tag[0] === '!' ? state.tag.slice(1) : state.tag
+      ).replace(/!/g, '%21');
+
+      if (state.tag[0] === '!') {
+        tagStr = '!' + tagStr;
+      } else if (tagStr.slice(0, 18) === 'tag:yaml.org,2002:') {
+        tagStr = '!!' + tagStr.slice(18);
+      } else {
+        tagStr = '!<' + tagStr + '>';
+      }
+
+      state.dump = tagStr + ' ' + state.dump;
+    }
+  }
+
+  return true;
+}
+
+function getDuplicateReferences(object, state) {
+  var objects = [],
+      duplicatesIndexes = [],
+      index,
+      length;
+
+  inspectNode(object, objects, duplicatesIndexes);
+
+  for (index = 0, length = duplicatesIndexes.length; index < length; index += 1) {
+    state.duplicates.push(objects[duplicatesIndexes[index]]);
+  }
+  state.usedDuplicates = new Array(length);
+}
+
+function inspectNode(object, objects, duplicatesIndexes) {
+  var objectKeyList,
+      index,
+      length;
+
+  if (object !== null && typeof object === 'object') {
+    index = objects.indexOf(object);
+    if (index !== -1) {
+      if (duplicatesIndexes.indexOf(index) === -1) {
+        duplicatesIndexes.push(index);
+      }
+    } else {
+      objects.push(object);
+
+      if (Array.isArray(object)) {
+        for (index = 0, length = object.length; index < length; index += 1) {
+          inspectNode(object[index], objects, duplicatesIndexes);
+        }
+      } else {
+        objectKeyList = Object.keys(object);
+
+        for (index = 0, length = objectKeyList.length; index < length; index += 1) {
+          inspectNode(object[objectKeyList[index]], objects, duplicatesIndexes);
+        }
+      }
+    }
+  }
+}
+
+function dump$1(input, options) {
+  options = options || {};
+
+  var state = new State(options);
+
+  if (!state.noRefs) getDuplicateReferences(input, state);
+
+  var value = input;
+
+  if (state.replacer) {
+    value = state.replacer.call({ '': value }, '', value);
+  }
+
+  if (writeNode(state, 0, value, true, true)) return state.dump + '\n';
+
+  return '';
+}
+
+var dump_1 = dump$1;
+
+var dumper = {
+	dump: dump_1
+};
+
+function renamed(from, to) {
+  return function () {
+    throw new Error('Function yaml.' + from + ' is removed in js-yaml 4. ' +
+      'Use yaml.' + to + ' instead, which is now safe by default.');
+  };
+}
+
+
+var Type                = type;
+var Schema              = schema;
+var FAILSAFE_SCHEMA     = failsafe;
+var JSON_SCHEMA         = json;
+var CORE_SCHEMA         = core;
+var DEFAULT_SCHEMA      = _default;
+var load                = loader.load;
+var loadAll             = loader.loadAll;
+var dump                = dumper.dump;
+var YAMLException       = exception;
+
+// Re-export all types in case user wants to create custom schema
+var types = {
+  binary:    binary,
+  float:     float,
+  map:       map,
+  null:      _null,
+  pairs:     pairs,
+  set:       set,
+  timestamp: timestamp,
+  bool:      bool,
+  int:       int,
+  merge:     merge,
+  omap:      omap,
+  seq:       seq,
+  str:       str
+};
+
+// Removed functions from JS-YAML 3.0.x
+var safeLoad            = renamed('safeLoad', 'load');
+var safeLoadAll         = renamed('safeLoadAll', 'loadAll');
+var safeDump            = renamed('safeDump', 'dump');
+
+var jsYaml = {
+	Type: Type,
+	Schema: Schema,
+	FAILSAFE_SCHEMA: FAILSAFE_SCHEMA,
+	JSON_SCHEMA: JSON_SCHEMA,
+	CORE_SCHEMA: CORE_SCHEMA,
+	DEFAULT_SCHEMA: DEFAULT_SCHEMA,
+	load: load,
+	loadAll: loadAll,
+	dump: dump,
+	YAMLException: YAMLException,
+	types: types,
+	safeLoad: safeLoad,
+	safeLoadAll: safeLoadAll,
+	safeDump: safeDump
+};
+
+export { CORE_SCHEMA, DEFAULT_SCHEMA, FAILSAFE_SCHEMA, JSON_SCHEMA, Schema, Type, YAMLException, jsYaml as default, dump, load, loadAll, safeDump, safeLoad, safeLoadAll, types };

--- a/templates/profiles/kimi-default.json
+++ b/templates/profiles/kimi-default.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": 1,
+  "name": "kimi-default",
+  "description": "Baseline Kimi profile with explicit provider-native model identifiers.",
+  "provider": "kimi",
+  "orchestrator": { "model": "k3" },
+  "agents": [
+    { "id": "sr-architect",            "model": "k3", "required": true },
+    { "id": "sr-developer",            "model": "k3", "required": true },
+    { "id": "sr-reviewer",             "model": "k3", "required": true }
+  ],
+  "routing": [
+    { "default": true, "agent": "sr-developer" }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds Kimi Code as a fourth first-class SpecRails Core provider, with the same provider-neutral installation and workflow lifecycle used by Claude Code, Codex, and Gemini wherever Kimi exposes an equivalent contract.

The integration targets the external Kimi Code CLI `>= 0.27.0`. Core does **not** bundle Kimi, start `kimi server`, open a local port, register a service, or persist credentials.

## Why the runtime uses `kimi -p`

Kimi's documented unattended interface is prompt mode. In Kimi Code 0.27, `-p` is forwarded to `session.prompt()`; arbitrary `/skill:*` text is not activated by the print-mode path.

Core therefore:

- installs a self-contained `.kimi-code/specrails/run-skill.mjs`
- loads and validates the selected direct-child `SKILL.md`
- reproduces Kimi 0.27's YAML, argument/placeholder, XML escaping, and visible `kimi-skill-loaded` prompt envelope
- launches external `kimi -m <model> -p <materialized prompt> --output-format stream-json`
- uses argv arrays with `shell: false`
- uses Kimi's native `Skill` tool for nested SpecRails/OpenSpec activation

This remains CLI-only. A Kimi server/ACP process would add installation, supervision, port, authentication, recovery, and shutdown ownership that does not belong in Core.

## Provider and framework coverage

- canonical provider types, `--provider kimi`, TUI selection, config validation, help, and errors
- cross-platform executable detection while preserving the existing automatic provider priority
- minimum-version and bounded authentication probes with official install/`kimi login` remediation
- Kimi-native `.kimi-code/AGENTS.md`, additive `mcp.json`, rules, personas, memory/state, and gitignore behavior
- full and quick tier workflow catalogs
- direct-child `specrails-*`, `openspec-*`, `sr-*`, and `custom-*` skills
- provider-aware profiles and exact safe Kimi model aliases; no Claude alias translation
- standalone init/update and Desktop-relocated, versioned framework assembly
- multi-provider registry/manifest coexistence
- same-version repair, rollback, stale-provider pruning, and non-destructive migration from the pre-release nested `skills/rails` layout
- atomic normalization of OpenSpec's legacy `.kimi/skills/openspec-*` output into `.kimi-code/skills`
- Kimi-specific doctor checks, integration contract, CLI/user docs, Windows guidance, and release/package coverage

## Headless and agentic execution

- exact plain prompts are transported from host to helper over stdin, bounded to 1 MiB
- skill runs support validated models, K3 effort, attachments, known-session resume, and stream JSON parsing
- a resume id is exposed only from a terminal non-empty `session.resume_hint` after a zero exit
- attachments must be absolute, readable, regular non-symlink files; only canonical parent directories become `--add-dir` grants
- single and parallel roles use one bounded structured role-wave request
- current-repository roles receive isolated execution directories
- isolated roles receive reusable detached worktrees based on a private synthetic snapshot of dirty tracked and non-ignored untracked input
- status, retry, explicit A/M/D merge actions, cleanup, attributed streams, aggregate failure, and all-child signal forwarding are implemented

## Security and lifecycle hardening

- validates every skill, model, session, profile, role, run, worktree, attachment, and relative merge identifier before spawn
- never evaluates prompt/request content as shell source
- treats persisted role manifests as untrusted and recomputes all managed paths, worktree registration, git-exclude content, and private-ref identity
- verifies complete copied-overlay hashes before Windows reuse and never trusts an ownership marker alone
- rejects symlinks and special files in managed OpenSpec staging and copied overlays
- removes inherited `KIMI_CODE_EXPERIMENTAL_FLAG`
- forces `KIMI_DISABLE_CRON=1` and `KIMI_CODE_NO_AUTO_UPDATE=1`
- scopes `KIMI_MODEL_THINKING_EFFORT` to K3 (`low|high|max`); omission preserves Kimi's documented `high` default
- unwraps only the standard npm Windows shim and still launches Node with `shell: false`
- transports large Windows npm-shim prompts through stdin; rejects oversized native argv instead of truncating workflows

## Compatibility boundaries

- Native Kimi has no documented stdin/file equivalent for its own `-p` boundary, so the exact prompt is visible in the native child process argv. Core protects the host-to-helper boundary and does not substitute a behavior-changing file/read-tool envelope.
- Initial helper materialization reproduces the visible skill prompt but cannot fabricate Kimi's private `skill.activated` telemetry. Nested activations use Kimi's native `Skill` tool.
- Unknown JSONL events are tolerated, but Core does not fabricate Claude-style token/cost/result fields.
- The npm-distributed Kimi CLI has its own Node `>= 22.19` requirement; Core itself and native Kimi integration remain supported on Node `>= 20.19`.
- A live authenticated account canary was not possible in this environment. The contract was checked against the official Kimi Code 0.27 CLI/source and exercised end-to-end with a protocol-faithful external fake executable.

## Validation

- GitHub CI (`push` and `pull_request`): all jobs passed, including coverage and the full Ubuntu/macOS/Windows × Node 20.19/22 matrix
- `npm test`: **34 files, 499 tests passed**
- `npm run build`: passed
- focused post-hardening suites:
  - runtime/runner: 86/86
  - scaffold: 42/42
  - OpenSpec/invocation: 13/13
  - framework/registry: 62/62
  - profile/init: 25/25
  - doctor: 18/18
- `npx openspec validate add-kimi-provider --strict --no-interactive`: passed
- OpenSpec verification: **33/33 tasks, 8/8 requirements**, no critical issues or warnings
- `git diff --check`, all repository JSON parsing, CLI/runner syntax checks, and credential-shape scan: passed
- npm dry-run package: **151 files**, all runner/vendor/profile/schema/contract/doc artifacts present
- end-to-end manual smoke on Node **25.9.0** and **20.19.5**:
  - TUI config + Kimi init
  - 19 workflow skills
  - profile validation
  - 14-check doctor
  - headless execution and byte-exact Unicode/multiline prompt transport
  - update preservation of user skill/MCP data
  - relocated Claude+Kimi registry/manifest coexistence

## Downstream

- Desktop consumer PR: https://github.com/fjpulidop/specrails-desktop/pull/563
- After this feature merges, Release Please must publish `specrails-core@4.12.0`; Desktop can then regenerate and pin its exact bundled Core artifact.

## Official Kimi references

- https://www.kimi.com/code/docs/en/kimi-code-cli/reference/kimi-command
- https://www.kimi.com/code/docs/en/kimi-code-cli/customization/skills.html
- https://www.kimi.com/code/docs/en/kimi-code-cli/customization/mcp.html
- https://www.kimi.com/code/docs/en/kimi-code/models.html
- https://www.kimi.com/code/docs/en/kimi-code-cli/configuration/env-vars.html
