### PR TITLE
perf(pipeline): scoped-first verification (one full pass, not three)

### DIFF
--- a/templates/agents/sr-developer.md
+++ b/templates/agents/sr-developer.md
@@ -142,7 +142,7 @@ This gate is non-negotiable. Phase 4 is unreachable until every checkbox in task
 
 1. **RED** — Write a failing test that describes the expected behavior. Run the test. Confirm it fails for the right reason.
 2. **GREEN** — Write the minimum production code to make the test pass. Run the test. Confirm it passes.
-3. **REFACTOR** — Clean up the code while keeping all tests green. Run all tests after refactoring.
+3. **REFACTOR** — Clean up the code while keeping the tests green. Re-run the **scoped** tests for the area you touched (the task's test file(s) / the affected package — e.g. `npx vitest run <file>`, `pytest <file>`, `cargo test <module>`), NOT the whole suite. The full suite runs exactly once, in Phase 4 — running it after every task multiplies wall-clock time without catching anything Phase 4 won't.
 
 **TDD rules:**
 - Never write production code without a corresponding test
@@ -172,9 +172,11 @@ Follow the project architecture strictly:
 
 **All tests MUST pass before you hand off to the reviewer. This is a hard gate — do not proceed if any test fails.**
 
+This phase is the pipeline's **single full verification pass** — the inner TDD loop stayed scoped precisely so this one can be exhaustive.
+
 - Run the **full CI-equivalent verification suite** (see below)
-- If any test fails, fix the issue and re-run ALL tests
-- Repeat until all tests pass — there is no maximum number of attempts
+- If a check fails, fix the issue, re-run the **scoped** tests covering the fix first, then finish with one clean run of the failed check and any check downstream of it
+- Repeat until the full suite is green — there is no maximum number of attempts
 - Review each file for adherence to conventions
 - Ensure all imports are correct and no circular dependencies exist
 - Verify type annotations are complete

--- a/templates/agents/sr-reviewer.md
+++ b/templates/agents/sr-reviewer.md
@@ -52,16 +52,25 @@ Your working directory may NOT be the user's source repository. The user's sourc
 You are the last line of defense between developer output and a PR. You:
 1. **Verify TDD compliance** — every piece of production code must have corresponding tests
 2. **Verify spec completeness** — every requirement from the architect's spec must be implemented
-3. Run every check that CI runs — in the exact same way
+3. Verify the change is green — **scoped-first**: the developer's Phase 4 already ran the full CI-equivalent suite; you re-verify the changed surface, and run the full suite yourself only when your own fixes make it necessary (see Verification policy)
 4. Fix any failures you find (up to 3 attempts per issue)
 5. Verify code quality and consistency across all changes
 6. Report what you found and fixed
 
 ## CI/CD Pipeline Equivalence
 
-The CI pipeline runs these checks. You MUST run ALL of them in this exact order:
+The CI pipeline runs these checks, in this exact order:
 
 {{CI_COMMANDS_FULL}}
+
+## Verification policy (scoped-first)
+
+The developer hands off ONLY after a green full CI-equivalent pass (their Phase 4 hard gate). Re-running the entire suite on an untouched tree re-buys information the pipeline already has — at full wall-clock price. Your verification is therefore **scoped-first**:
+
+1. **Always run the cheap whole-repo static checks** (type-check, lint — the fast entries of the CI list above, in CI order).
+2. **Run the tests SCOPED to the diff**: the test files covering every changed source file, via per-file invocation (`npx vitest run <file>`, `pytest <file>`, `cargo test <module>`, …). Widen the scope when the change touches shared/core modules whose blast radius you cannot bound.
+3. **Full suite — run it yourself only when warranted**: you modified production code during the review, the diff touches build/config/test infrastructure, or the scoped runs surfaced a failure whose blast radius is unclear. In that case finish with ONE clean full pass before handoff — never interleave repeated full passes between fixes.
+4. If you changed nothing and the scoped runs are green, the developer's full pass stands as the pipeline's verification of record — say so in the report instead of re-running it.
 
 ## Known CI vs Local Gaps
 
@@ -116,9 +125,9 @@ After running CI checks, also review for:
 
 ## Workflow
 
-1. **Run all CI checks** (all layers, in the exact order CI runs them)
-2. **If anything fails**: Fix it, then re-run ALL checks from scratch (not just the failing one)
-3. **Repeat** up to 3 fix-and-verify cycles
+1. **Run the scoped-first verification** (see Verification policy: static checks + diff-scoped tests, in CI order)
+2. **If anything fails**: Fix it, re-run the scoped tests covering the fix, and escalate to a full pass per the policy
+3. **Repeat** up to 3 fix-and-verify cycles; when any cycle changed code, finish with ONE clean full CI-equivalent pass
 4. **Report** a summary of what passed, what failed, and what you fixed
 5. **Task Completion Gate** — Before archiving, verify all tasks are complete:
    - Read `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<specName>/tasks.md`
@@ -213,7 +222,8 @@ When done, produce this report:
 ## Rules
 
 - Never ask for clarification. Fix issues autonomously.
-- Always run ALL checks, even if you think nothing changed in a layer.
+- Follow the Verification policy: scoped-first, one full pass only when your own changes (or an unbounded blast radius) warrant it. Never skip the cheap static checks.
+- In the CI Checks report table, mark suites you did not re-run as `covered by developer's full pass` — never as passed-by-you.
 - When fixing lint errors, understand the rule before applying a fix — don't just suppress with disable comments.
 - If a test fails, read the test AND the implementation to understand the root cause before fixing.
 - If a layer reviewer reports High severity findings, include them in your Issues Fixed or Issues Found section. Attempt to fix High-severity layer findings that are straightforward (e.g., adding a missing `alt` attribute, adding a missing `LIMIT` to a query). Flag Critical or architecturally complex findings for human review — do NOT attempt to fix them automatically.

--- a/templates/codex-skills/rails/sr-developer/SKILL.md
+++ b/templates/codex-skills/rails/sr-developer/SKILL.md
@@ -83,14 +83,17 @@ note it in your reply — do not block on the architect.
         modify it.
       - Write the minimum code to make the failing test pass.
         Resist adding code unrelated to the test.
-      - Run the test runner. ALL tests must pass — the new
-        one AND every prior one.
+      - Run the test runner SCOPED to the task's test file(s)
+        (`npx vitest run <file>`, `pytest <file>`, …). They
+        must pass. The full suite runs once, at the validation
+        gate — not after every task.
       - Tick `- [x] N.2`.
 
    c. **REFACTOR — clean up (step N.3, if present).**
       - If the production code can be clearer without changing
         behaviour, refactor it now.
-      - Re-run the test runner. All tests still pass.
+      - Re-run the scoped tests for the files you touched.
+        Still green.
       - Tick `- [x] N.3`.
 
 3. **Honour the design's invariants and edge cases.** When the
@@ -115,7 +118,10 @@ The final task block in `tasks.md` is always the validation gate
 (`## N. Validation gate`). Run it:
 
 - Full project test suite (e.g. `npm test`, `pytest`,
-  `cargo test`). MUST pass.
+  `cargo test`). MUST pass. This is the pipeline's SINGLE
+  full pass — the per-task loop stayed scoped so this one
+  can be exhaustive. On a failure, fix, re-run the scoped
+  tests for the fix, then re-run the suite once clean.
 - Project build if present (e.g. `npm run build`,
   `cargo build`). MUST succeed.
 - A grep for debug breadcrumbs (`console.log`, `print(`, etc.)

--- a/templates/codex-skills/rails/sr-reviewer/SKILL.md
+++ b/templates/codex-skills/rails/sr-reviewer/SKILL.md
@@ -109,16 +109,27 @@ a screenshot/manual-check note in the design's
 "Open questions". A criterion with **no** mapping is a
 blocker finding.
 
-### 5. Re-run the full validation gate
+### 5. Verify the gate — scoped-first
 
-Use the command from the design's `Validation` section in the
-plan artefact (or the final block of `tasks.md`):
+The developer's validation gate already ran the full suite
+green; re-running the whole thing on an untouched tree
+re-buys information the pipeline already has. So:
 
-- Project test suite (`npm test`, `pytest`, `cargo test`, …).
-  Confirm it passes. Capture the count.
-- Project build if present (`npm run build`, …). Confirm it
-  succeeds.
-- If neither runner exists, run whatever fallback the design
+- Run the tests SCOPED to the diff — the test files covering
+  every changed source file, per-file (`npx vitest run
+  <file>`, `pytest <file>`, `cargo test <name>`, …). Confirm
+  green; capture the count.
+- Run the full suite yourself ONLY when: you modified
+  production code in this review, the diff touches
+  build/config/test infrastructure, or a scoped failure has
+  an unclear blast radius. Then finish with ONE clean full
+  pass (plus the build if present) — never repeated full
+  passes between fixes.
+- If you changed nothing and the scoped runs are green,
+  record the developer's gate as the pass of record — in the
+  confidence artefact set `tests.ran` to the scoped command
+  and say so in `tests.details`.
+- If no test runner exists, run whatever fallback the design
   named (`node --check`, etc.).
 
 ### 6. Write the confidence artefact

--- a/templates/commands/specrails/implement.md
+++ b/templates/commands/specrails/implement.md
@@ -1031,7 +1031,7 @@ Construct the generalist reviewer's invocation prompt with layer reports injecte
 - `SECURITY_REVIEW_REPORT`: full output of security-reviewer
 
 Include in the reviewer prompt:
-- Full CI commands
+- Full CI commands (reference material for its scoped-first verification policy — the reviewer runs diff-scoped tests plus fast static checks, escalating to one full pass only when its own fixes warrant it; the developer's Phase 4 full pass is the baseline)
 - Cross-feature merge issue checks
 - Instruction to record learnings to `common-fixes.md`
 - Instruction to archive completed changes via OpenSpec


### PR DESCRIPTION
## Why

Profiling a real 58-minute claude Implement run in specrails-desktop showed the full test/coverage suite executing **~12 times** in a single pipeline pass — per-task REFACTOR "run all tests", the developer's Phase 4 gate, and the reviewer re-running ALL CI checks from scratch on every fix cycle. On repos with minute-long suites that is ~20 minutes of pure re-execution per pass (the dominant slice of implement wall-clock, after the desktop-side fixes in fjpulidop/specrails-desktop#570 and fjpulidop/specrails-desktop#571).

## New contract

- **Developer inner TDD loop is SCOPED**: RED/GREEN stay per-test (unchanged); REFACTOR now re-runs only the tests for the touched area (`npx vitest run <file>` / `pytest <file>` / `cargo test <module>`), not the whole suite.
- **Developer Phase 4 / validation gate is the pipeline's SINGLE exhaustive full pass.** The hard gate is unchanged: never hand off red; fix → scoped re-check → one clean full run.
- **Reviewer goes scoped-first** (new "Verification policy" section): always run the cheap whole-repo static checks + diff-scoped tests; run a full pass itself ONLY when it modified production code, the diff touches build/config/test infrastructure, or a failure's blast radius is unclear — then exactly ONE clean full pass at the end, never interleaved full passes between fixes. Honesty rule: suites it did not re-run are reported as `covered by developer's full pass`, never as passed-by-itself.
- **Orchestrator** (`implement.md` Phase 4b) now frames the CI command list as reference material for that policy.

Net full-suite executions per pass: **3+ → 1** (developer's gate), with the reviewer's conditional pass only when it actually changed something. The remote-CI monitoring phase (4d) is untouched.

## Files

Hand-maintained mirrors, all updated: `templates/agents/sr-developer.md`, `templates/agents/sr-reviewer.md`, `templates/codex-skills/rails/sr-developer/SKILL.md`, `templates/codex-skills/rails/sr-reviewer/SKILL.md`, `templates/commands/specrails/implement.md`. (Gemini implement/batch TOMLs are thin orchestrators with no suite mandates of their own — no change needed.)

## Tests

`npm test` — 310 passing (28 files). Prompt-template change; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)