### PR TITLE
docs(openspec): structured verification results

### DIFF
--- a/openspec/changes/structured-verification-results/.openspec.yaml
+++ b/openspec/changes/structured-verification-results/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/structured-verification-results/design.md
+++ b/openspec/changes/structured-verification-results/design.md
@@ -1,0 +1,220 @@
+---
+change: structured-verification-results
+type: design
+---
+
+# Design: Structured verification results
+
+## Context
+
+Verification already happens. Recording it does not.
+
+```
+ TODAY
+ ─────
+ sr-developer  Phase 4  ──►  "single full verification pass"
+                              runs {{CI_COMMANDS_FULL}}  ← rendered EMPTY at install
+                              reports failures as prose
+
+ sr-reviewer   § Verification policy (scoped-first)
+                 1. cheap whole-repo static checks
+                 2. tests SCOPED to the diff
+                 3. full suite only if it changed production code
+                 4. else "the developer's full pass stands as the
+                    pipeline's verification of record"
+                              │
+                              ├──► markdown report  ── SECURITY_STATUS: <…>   ← the ONE parsed token
+                              │                       CI Checks table         ← rows are {{CI_CHECK_TABLE_ROWS}},
+                              │                                                  stripped to empty
+                              └──► confidence-score.json  ── overall + 5 aspect OPINIONS (0–100)
+                                                            `test_coverage` = "is coverage adequate?",
+                                                            NOT a count
+```
+
+Two consequences follow from that diagram.
+
+**Nobody can read the result.** The only machine-parsed token in the reviewer's
+entire output is `SECURITY_STATUS:`. A consumer wanting "did the tests pass, and
+how many" has to scrape prose or trust an opinion score. specrails-desktop, which
+now presents verification to non-technical reviewers in tiers by source, therefore
+refuses to display any count at all: printing "68 tests passed" from prose would
+turn a self-report into a measurement.
+
+**Step 4 is the trap.** When the reviewer changed nothing and its scoped runs are
+green, it does not re-run the suite — by design, and that design is what made the
+pipeline affordable. So a large share of runs have no reviewer-executed full pass.
+An artifact that emitted a bare `tests_passed: 14` would be read downstream as
+"the suite is green" when it might mean "the fourteen tests covering the diff are
+green, and the full suite was somebody else's pass". That is a worse failure than
+having no artifact, because it looks authoritative.
+
+Everything else needed already exists in the repo:
+
+| Asset | Where | What it gives us |
+|---|---|---|
+| Per-runner JSON invocations | `templates/commands/specrails/health-check.md:137-145` | `jest --json`, `vitest run --reporter=json`, `mocha --reporter json`, `pytest -q`, `go test -v`, `cargo test`, `rspec --format json`, `dotnet test` |
+| Metric vocabulary | `health-check.md:147` | `tests_total`, `tests_passed`, `tests_failed`, `tests_skipped`, `pass_rate`, `duration_seconds` |
+| Artifact precedent | `changes/pipeline-cost-economy/specs/confidence-scoring/spec.md` | the emit + parity + consumer requirement trio, and `design-confidence.json` as an additive file whose absence preserves behaviour |
+| Schema conventions | `schemas/profile.v1.json`, `CLAUDE.md` § schema identity | `<thing>.v<N>.json`, canonical `$id`, `additionalProperties: false`, `$id` ownership across repos |
+
+## Goals / Non-Goals
+
+**Goals**
+
+- One machine-readable file per change recording what verification actually ran.
+- Each entry states its SCOPE and its AUTHOR, so a scoped subset can never be
+  mistaken for a full pass.
+- Field names reused verbatim from `health-check.md` — no second vocabulary for
+  the same measurements.
+- A real JSON Schema with a canonical `$id`, so a downstream consumer validates
+  rather than guesses.
+- Absence is fully backward compatible.
+
+**Non-Goals**
+
+- No gate on the numbers. The confidence gate at Phase 4b-conf is untouched.
+- No reconciliation of the two divergent `confidence-score.json` schemas
+  (claude's `overall`/`aspects` vs the codex rail's `overall_score`/domain
+  objects). That is a separate change; this artifact is additive to both.
+- No coverage, lint, complexity or perf metrics, though `health-check.md` defines
+  them. Tests first; the envelope has room for the rest later.
+- No dependency on `{{CI_COMMANDS_FULL}}` or `{{CI_CHECK_TABLE_ROWS}}`. Both are
+  stripped to empty by `renderPlaceholders` (`scaffold.ts:2972-2978`) since the
+  enrich command was retired, so the agent must detect its own tooling exactly as
+  `health-check.md` already instructs.
+
+## Decisions
+
+### D1 — A new artifact, not a new field on `confidence-score.json`
+
+`confidence-score.json` is the reviewer's self-assessment: five opinions and
+prose. Measured facts do not belong in the same file, because the whole value of
+this work is that a consumer can tell the two apart. Mixing them would force
+every reader to know which fields are measurements and which are judgements.
+
+Precedent: `design-confidence.json` was added as its own file next to
+`confidence-score.json` rather than as a section inside it.
+
+**Alternative rejected** — extend `confidence-score.json` with a `verification`
+object. Fewer files, but it collapses exactly the distinction the artifact exists
+to make, and it would force a `schema_version` bump on a file two providers
+already disagree about.
+
+### D2 — Every entry declares scope and author
+
+```json
+{
+  "check": "tests",
+  "scope": "scoped",
+  "ran_by": "reviewer",
+  "status": "passed",
+  "tool": "vitest",
+  "command": "npx vitest run server/db.test.ts",
+  "metrics": { "tests_total": 14, "tests_passed": 14, "tests_failed": 0,
+               "tests_skipped": 0, "pass_rate": 100.0, "duration_seconds": 4.1 }
+}
+```
+
+`scope` is `scoped | full`, `ran_by` is `reviewer | developer-pass-of-record`, and
+`status` adds `not_rerun` to the usual `passed | failed`. A check the reviewer
+deliberately did not re-run is RECORDED as `not_rerun` with null metrics rather
+than omitted, because omission is indistinguishable from "the artifact is
+incomplete", and a consumer must be able to say "the diff's tests are green; the
+full suite was verified upstream".
+
+**Alternative rejected** — emit only what the reviewer itself ran. Simpler, but
+the common case (step 4) then produces an artifact that silently under-reports,
+and a downstream "N tests passed" would describe a subset while looking total.
+
+### D3 — Absent metrics are `null`, never `0`
+
+A runner whose output could not be parsed yields `metrics: null` (or individual
+nulls) with `status` still recorded. `tests_failed: 0` must mean "zero failures
+were measured", never "we could not tell". This is the same rule the desktop
+review packet enforces on its own display, and it only works if the producer
+honours it too.
+
+### D4 — A real JSON Schema, `schemas/verification-results.v1.json`
+
+`openspec/specs/confidence-scoring.md:15` currently pins its artifact's schema by
+reference to a `design.md` that lives only under `openspec/changes/archive/` — a
+normative reference into an archived file. `schemas/` already ships in the package
+`files` whitelist, and `CLAUDE.md` makes `$id` a cross-repo ownership contract.
+So this artifact gets a schema file from the start rather than inheriting that
+dangling-reference smell.
+
+Note the repo's two versioning conventions: `schemas/profile.v1.json` uses numeric
+`schemaVersion`, while run-time agent artifacts use the string
+`"schema_version": "1"` (snake_case). The artifact follows the RUN-TIME precedent
+(`confidence-score.json`, `design-confidence.json`); the schema FILE follows the
+schema-file precedent.
+
+### D5 — Registered in `integration-contract.json` (3.2 → 3.3)
+
+The contract is the formal desktop↔core surface, and today it describes only
+install/enrich — `grep confidence integration-contract.json` returns nothing. That
+is why desktop's use of `confidence-score.json` is an informal convention
+discovered by reading prompts. Registering this artifact's path and schema version
+makes the count something a consumer can depend on. First run-time artifact to be
+registered, hence the minor bump.
+
+### D6 — The reviewer writes it; the developer's pass is recorded, not re-run
+
+The reviewer is the only agent positioned to write the file: it runs last, it
+knows what it re-ran, and it already writes `confidence-score.json` at the same
+point. When step 4 applies, it records the developer's pass as an entry with
+`ran_by: "developer-pass-of-record"` and whatever the developer reported —
+faithfully, including "the developer reported green without a parseable count",
+which is `status: "passed"` with `metrics: null`.
+
+**Alternative rejected** — have the developer write its own artifact and the
+reviewer merge them. More accurate in principle, but it doubles the surface, needs
+a merge rule, and the developer's pass is exactly what the reviewer already has to
+reason about.
+
+## Risks / Trade-offs
+
+- [The agent writes the file but improvises the runner invocation, since
+  `{{CI_COMMANDS_FULL}}` is empty] → the spec requires the same per-runner
+  detection `health-check.md` already specifies, quoted in the delta rather than
+  referenced, so the instruction survives the stripped placeholder.
+- [Counts parsed from human-readable output are still the agent's reading of
+  stdout] → the artifact records `tool` and `command` alongside the metrics so a
+  consumer can see WHAT produced the number; and the JSON-reporter invocations are
+  preferred precisely because they remove the parsing judgement.
+- [Two divergent confidence schemas mean the codex rail needs its own wiring] →
+  the delta carries a provider-parity requirement, and the codex rail's existing
+  free-text `tests: { ran, passed, details }` is upgraded to the shared metric
+  shape rather than left to drift further.
+- [A consumer trusts `scoped` counts as total anyway] → mitigated by making
+  `scope` and `ran_by` REQUIRED, so a naive consumer cannot read metrics without
+  parsing the qualifier that sits beside them.
+- [Template changes are not retroactive] → projects keep emitting nothing until
+  their framework updates; every consumer requirement therefore treats a missing
+  file as the legacy path.
+
+## Migration Plan
+
+1. Ship `schemas/verification-results.v1.json` and the delta spec. Nothing emits
+   yet, nothing consumes yet.
+2. Add the output section to `templates/agents/sr-reviewer.md` (claude, and gemini
+   and kimi which derive from it at install time), then the codex rail skill and
+   the plugin copy. Each addition is inert until a project reinstalls.
+3. Bump `integration-contract.json` to 3.3 with the artifact registered.
+4. Desktop consumes it and promotes its test claim from ai-reported to
+   app-verified when the file is present and its `scope`/`ran_by` allow the claim.
+
+Rollback is deletion: no consumer requires the file, and the reviewer's existing
+report and score are unchanged by its absence.
+
+## Open Questions
+
+- Should `verification-results.json` also carry the static checks the reviewer
+  always runs (typecheck, lint, build)? The envelope allows it and
+  `health-check.md` already names their metrics; this change scopes itself to
+  tests to keep the first version small.
+- Where does the artifact live for the codex rail, whose confidence file sits
+  under `.specrails/agent-memory/explanations/` rather than
+  `openspec/changes/<name>/`? The delta requires the openspec path where a change
+  exists and permits the rail's own location otherwise; unifying the two is part
+  of the deferred schema reconciliation.

--- a/openspec/changes/structured-verification-results/proposal.md
+++ b/openspec/changes/structured-verification-results/proposal.md
@@ -1,0 +1,46 @@
+# Proposal: Structured verification results
+
+## Why
+
+The pipeline runs tests, but it never records what they said in a form anything can read.
+
+The reviewer's only machine-parsed token is `SECURITY_STATUS:` (`templates/agents/sr-reviewer.md:220`). Test outcomes live in a free-prose markdown table whose rows are the `{{CI_CHECK_TABLE_ROWS}}` placeholder — which `renderPlaceholders` (`src/installer/phases/scaffold.ts:2972-2978`) strips to **empty** at install time, so the shipped agent improvises both the commands and the rows. The one structured reviewer artifact, `confidence-score.json`, carries five self-assigned 0–100 opinions; its `test_coverage` aspect is a judgement about *adequacy*, not a count.
+
+The consequence is concrete and already visible downstream. specrails-desktop's review packet splits verification proof into three tiers by source — measured-by-the-app, reported-by-the-AI, and the AI's own self-assessment — and deliberately **refuses to print any test count at all**, because scraping "68 tests passed" out of prose would launder a self-report into a measurement. A non-technical reviewer therefore gets "the AI reports its verification passed" where they could be getting "312 of 312 tests passed, 4.1s".
+
+Everything needed to fix this already exists in this repo, in the wrong place:
+
+- `templates/commands/specrails/health-check.md:137-147` already specifies the per-runner machine-readable invocations (`jest --json`, `vitest run --reporter=json`, `mocha --reporter json`, `pytest --tb=no -q`, `go test -v`, `cargo test`, `rspec --format json`, `dotnet test`) **and** the exact metric names: `tests_total`, `tests_passed`, `tests_failed`, `tests_skipped`, `pass_rate`, `duration_seconds`.
+- `templates/codex-skills/rails/sr-reviewer/SKILL.md` already asks the codex reviewer to "capture the count" — and then puts it in a free-text `tests.details` field ("14/14 passing").
+
+So the intent and the vocabulary are both written down already. Only the structure is missing.
+
+**Scoped verification is NOT part of this proposal — it already shipped.** `sr-reviewer.md:66-74` § "Verification policy (scoped-first)" and the developer's single full pass landed with `pipeline-cost-economy` in 5.0.0. That policy is precisely *why* this change is delicate: step 4 says that when the reviewer changed nothing and its scoped runs are green, "the developer's full pass stands as the pipeline's verification of record". A large fraction of runs therefore have **no reviewer-executed full suite**, and an artifact that reported a scoped subset as if it were the whole suite would be worse than no artifact at all.
+
+## What Changes
+
+1. **Verification-results artifact** (new `verification-results` capability). After its verification policy completes, the reviewer writes `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<name>/verification-results.json`: a `schema_version: "1"` envelope carrying one entry per check it actually ran, with the health-check metric names reused verbatim. Every entry declares **who ran it** (`reviewer` | `developer-pass-of-record`) and **what scope** (`scoped` | `full`), and a check the reviewer did not re-run is recorded as `not_rerun` rather than omitted or inferred. Absent metrics are `null`, never zero.
+
+2. **Real JSON Schema** (`schemas/verification-results.v1.json`). Today `openspec/specs/confidence-scoring.md:15` pins its artifact's schema by reference to a design doc that now exists only under `openspec/changes/archive/`, and `schemas/` contains only `profile.v1.json`. This artifact gets a normative schema with a canonical `$id`, following the `$id`-ownership rule in `CLAUDE.md`, so a downstream consumer validates instead of guessing.
+
+3. **Registered as a cross-repo contract** (`integration-contract.json`, `schemaVersion` 3.2 → 3.3). The contract today describes only the install/enrich surface and mentions no run-time artifact, which is why desktop's consumption of `confidence-score.json` is an informal convention. Registering the artifact's path and schema version makes the count something a consumer can rely on rather than discover.
+
+**Parity.** The reviewer's output contract lives in four template families and all four move together: `templates/agents/sr-reviewer.md` (claude, and gemini/kimi which derive from it at install time via `placeGeminiAgents` / `writeKimiWorkflowSkill`); `templates/codex-skills/rails/sr-reviewer/SKILL.md` (whose existing `tests: { ran, passed, details }` field is upgraded to the shared metric shape); `templates/commands/specrails/implement.md` (the orchestrator's Phase 4b/4e reporting); and `specrails-plugin/agents/reviewer.md` (the marketplace copy, which also lacks the `${SPECRAILS_REPO_DIR:-.}` wrapper and gains it here).
+
+**Explicitly out of scope.** No gate on the new numbers — the confidence gate at Phase 4b-conf stays exactly as it is; a failing count already surfaces through the existing sentinel and the reviewer's report. No reconciliation of the two divergent confidence-score schemas (claude's `overall`/`aspects` vs the codex rail's `overall_score`/domain sub-objects); that is its own change. No coverage, lint or complexity metrics, even though `health-check.md` defines them — tests first.
+
+## Impact
+
+**Affected specs:** new `verification-results` capability. `confidence-scoring` and `implement` are deliberately untouched: this is an additive artifact alongside `confidence-score.json`, not a change to what scoring means or to when the pipeline gates.
+
+**Affected code:**
+- `templates/agents/sr-reviewer.md` — new "Verification Results" output section; the report table gains a machine-readable sibling rather than replacing it.
+- `templates/codex-skills/rails/sr-reviewer/SKILL.md` — `tests` upgraded to the shared metric shape.
+- `templates/commands/specrails/implement.md` — Phase 4e surfaces the counts when the file exists.
+- `specrails-plugin/agents/reviewer.md` — parity + the missing repo-dir wrapper.
+- `schemas/verification-results.v1.json` — new (already shipped by the `files` whitelist).
+- `integration-contract.json` — `schemaVersion` bump + artifact registration.
+
+**Backward compatibility.** `verification-results.json` is a new additive artifact; absence preserves pre-change behaviour byte-for-byte. Consumers that do not know about it are unaffected, and a consumer that does (desktop's review packet) keeps presenting the sentinel as a self-report until the file appears — at which point the same claim becomes measured, with its scope and its author stated.
+
+**Meta-tool impact.** These are template changes, so they reach target repos only on install/update and are not retroactive: a project scaffolded before this ships keeps emitting no verification artifact until its framework is updated.

--- a/openspec/changes/structured-verification-results/specs/verification-results/spec.md
+++ b/openspec/changes/structured-verification-results/specs/verification-results/spec.md
@@ -1,0 +1,149 @@
+# Delta Spec: verification-results
+
+## ADDED Requirements
+
+### Requirement: Reviewer emits a structured verification-results artifact
+
+The reviewer agent SHALL write `${SPECRAILS_REPO_DIR:-.}/openspec/changes/<name>/verification-results.json`
+after completing its verification policy and before reporting its results,
+containing `schema_version` (`"1"`), `change` (the kebab-case change name),
+`agent` (`"reviewer"`), `recorded_at` (ISO 8601), and `checks`: an array with one
+entry per verification check the pipeline performed. The file SHALL conform to
+`schemas/verification-results.v1.json`. Writing it SHALL NOT be conditional on
+the outcome — a failed verification is exactly the case a consumer most needs
+recorded.
+
+#### Scenario: Reviewer runs the tests scoped to the diff
+
+- **WHEN** the reviewer runs the test files covering the changed sources and they pass
+- **THEN** the artifact SHALL contain a `tests` entry with `scope: "scoped"`, `ran_by: "reviewer"`, `status: "passed"`, the `tool` and `command` used, and the measured metrics
+
+#### Scenario: Verification fails
+
+- **WHEN** any check the reviewer ran reported failures
+- **THEN** that entry SHALL carry `status: "failed"` with the measured failure count, and the artifact SHALL still be written
+
+#### Scenario: Change name cannot be determined
+
+- **WHEN** the reviewer cannot resolve the active change directory
+- **THEN** it SHALL write the artifact with `change: "unknown"` and record why in `notes`, mirroring the existing `confidence-score.json` behaviour
+
+### Requirement: Every check declares its scope and its author
+
+Each entry in `checks` SHALL declare `scope` (`"scoped"` | `"full"`) and `ran_by`
+(`"reviewer"` | `"developer-pass-of-record"`). A check the reviewer deliberately
+did not re-run SHALL be recorded with `status: "not_rerun"` rather than omitted.
+A consumer SHALL therefore never be able to read a metric without the qualifier
+that bounds it.
+
+#### Scenario: Reviewer relies on the developer's full pass
+
+- **WHEN** the reviewer changed no production code, its scoped runs are green, and it does not re-run the suite
+- **THEN** the artifact SHALL record the full-suite entry with `ran_by: "developer-pass-of-record"` and whatever the developer reported
+- **AND** the reviewer's own scoped run SHALL appear as a separate entry with `scope: "scoped"`, `ran_by: "reviewer"`
+
+#### Scenario: A check was skipped entirely
+
+- **WHEN** a check neither the reviewer nor the developer performed is relevant to the change
+- **THEN** it SHALL appear with `status: "not_rerun"` and `metrics: null`, never be silently absent
+
+#### Scenario: Consumer distinguishes a subset from the whole suite
+
+- **WHEN** a consumer reads an entry whose `scope` is `"scoped"`
+- **THEN** the artifact SHALL provide no basis for presenting that count as the full suite's result
+
+### Requirement: Metrics are measured, and absent metrics are null
+
+Test metrics SHALL use the field names already established by the health-check
+command: `tests_total`, `tests_passed`, `tests_failed`, `tests_skipped`,
+`pass_rate` (0.0–100.0) and `duration_seconds`. The reviewer SHALL prefer each
+runner's machine-readable invocation — `jest --json`, `vitest run --reporter=json`,
+`mocha --reporter json`, `pytest --tb=no -q`, `go test ./... -v`, `cargo test`,
+`rspec --format json`, `dotnet test` — detected from the project's own
+configuration. A metric that could not be measured SHALL be `null`; zero SHALL
+mean a measured zero.
+
+#### Scenario: Runner exposes a JSON reporter
+
+- **WHEN** the project's test tool has a machine-readable reporter
+- **THEN** the reviewer SHALL use it and populate every metric it reports
+
+#### Scenario: Counts cannot be parsed
+
+- **WHEN** the reviewer ran a check but could not extract counts from its output
+- **THEN** `metrics` SHALL be `null` while `status`, `tool` and `command` are still recorded
+- **AND** `tests_failed` SHALL NOT be set to `0` to represent an unknown result
+
+#### Scenario: No test tooling exists
+
+- **WHEN** the project has no detectable test runner
+- **THEN** the `tests` entry SHALL record `status: "not_rerun"` with a note stating no runner was detected, rather than being omitted
+
+### Requirement: The artifact does not depend on install-time placeholders
+
+The reviewer's instructions for detecting tooling and invoking runners SHALL be
+self-contained. They SHALL NOT rely on `{{CI_COMMANDS_FULL}}`,
+`{{CI_COMMANDS}}`, or `{{CI_CHECK_TABLE_ROWS}}` being populated, because the
+installer's placeholder renderer strips every unresolved `{{UPPER_CASE}}` token
+to an empty string.
+
+#### Scenario: Installed agent has empty CI placeholders
+
+- **WHEN** the installed agent definition contains no enumerated CI commands
+- **THEN** the reviewer SHALL still detect the project's tooling and produce the artifact
+
+### Requirement: Provider parity for verification results
+
+Every provider surface that runs a reviewer SHALL emit the artifact with the same
+field names and the same scope/author semantics: the claude agent definition
+(from which the gemini and kimi definitions are derived at install time), the
+codex rail reviewer skill, and the marketplace plugin copy. Where a provider's
+reviewer already records test information in another shape, that shape SHALL be
+migrated to these metrics rather than left to diverge.
+
+#### Scenario: Codex rail reviewer
+
+- **WHEN** the codex rail reviewer completes its checks
+- **THEN** its confidence artefact's test information SHALL use the shared metric field names, scope and author
+- **AND** it SHALL write `verification-results.json` under the change directory when one exists, or alongside its own artefact when it does not
+
+#### Scenario: Plugin copy stays in step
+
+- **WHEN** the marketplace plugin's reviewer runs
+- **THEN** it SHALL emit the same artifact, resolving its path through the repo-dir indirection like every other template
+
+### Requirement: A missing artifact preserves existing behaviour
+
+The artifact SHALL be additive. Its absence SHALL NOT change the reviewer's
+report, the confidence score, the confidence gate, or any command's exit status,
+and consumers SHALL treat absence as "verification was not recorded" rather than
+as failure.
+
+#### Scenario: Project installed before this change
+
+- **WHEN** a project's framework predates the artifact and no file is written
+- **THEN** the pipeline SHALL behave byte-for-byte as it did before
+
+#### Scenario: Consumer finds no artifact
+
+- **WHEN** a consumer looks for the artifact and it is absent
+- **THEN** it SHALL fall back to whatever it presented before, without reporting an error
+
+### Requirement: The artifact schema has a canonical, owned identity
+
+`schemas/verification-results.v1.json` SHALL declare a `$id` under the
+specrails-core repository, set `additionalProperties: false`, and require
+`schema_version`, `change`, `agent`, `recorded_at` and `checks`. A downstream tool
+vendoring a diverging copy SHALL give it a distinct `$id`. The artifact's path and
+schema version SHALL be registered in `integration-contract.json` so consumers
+depend on a declared contract rather than on reading agent prompts.
+
+#### Scenario: Consumer validates an artifact
+
+- **WHEN** a consumer validates a produced artifact against the published schema
+- **THEN** validation SHALL pass, and an unknown field SHALL be rejected
+
+#### Scenario: Contract declares where to look
+
+- **WHEN** a consumer reads `integration-contract.json`
+- **THEN** it SHALL find the artifact's path template and schema version without inspecting any template

--- a/openspec/changes/structured-verification-results/tasks.md
+++ b/openspec/changes/structured-verification-results/tasks.md
@@ -1,0 +1,38 @@
+# Implementation Tasks
+
+## 1. Schema and contract
+
+- [ ] 1.1 `schemas/verification-results.v1.json`: new JSON Schema following the `profile.v1.json` conventions (`$schema` draft 2020-12, canonical `$id` under `specrails-core/main/schemas/`, `title`/`description` naming producer and consumers, `additionalProperties: false`). Required: `schema_version` (const `"1"`), `change`, `agent`, `recorded_at`, `checks`. Each check requires `check`, `scope` (`scoped|full`), `ran_by` (`reviewer|developer-pass-of-record`), `status` (`passed|failed|not_rerun`); optional `tool`, `command`, `notes`, and `metrics` which is either `null` or an object of `tests_total`, `tests_passed`, `tests_failed`, `tests_skipped`, `pass_rate`, `duration_seconds` — each individually nullable.
+- [ ] 1.2 `integration-contract.json`: bump `schemaVersion` 3.2 → 3.3 and register the artifact (path template `openspec/changes/<name>/verification-results.json`, schema file, schema version). First run-time agent artifact in the contract — document that in the entry.
+- [ ] 1.3 `src/installer/__tests__/`: assert the schema file is valid JSON Schema, that its `$id` matches its path, and that `additionalProperties` is false (mirrors how `profile.v1.json` identity is policed).
+
+## 2. Claude reviewer (source of truth for gemini + kimi)
+
+- [ ] 2.1 `templates/agents/sr-reviewer.md`: new `## Verification Results` section after `## Confidence Scoring`, specifying the artifact path with the `${SPECRAILS_REPO_DIR:-.}` wrapper, the required fields, and a worked example. State that writing it is non-optional and independent of outcome.
+- [ ] 2.2 `templates/agents/sr-reviewer.md`: inline the per-runner machine-readable invocations (copied from `templates/commands/specrails/health-check.md:137-145`) and the metric names, so the instruction survives `{{CI_COMMANDS_FULL}}` being stripped to empty. Add the explicit rules: prefer the JSON reporter; unmeasured ⇒ `null`, never `0`; no runner detected ⇒ `status: "not_rerun"` with a note.
+- [ ] 2.3 `templates/agents/sr-reviewer.md`: tie the artifact to the existing § "Verification policy (scoped-first)" — each entry carries `scope` and `ran_by`, and policy step 4 (developer's pass of record) is recorded as its own entry rather than presented as the reviewer's own run.
+- [ ] 2.4 Verify no new `{{PLACEHOLDER}}` token was introduced (`.claude/rules/templates.md`: every placeholder documented, none left unresolved after render).
+
+## 3. Provider parity
+
+- [ ] 3.1 `templates/codex-skills/rails/sr-reviewer/SKILL.md`: replace the free-text `tests: { ran, passed, details }` field with the shared metric shape (`scope`, `ran_by`, `status`, `tool`, `command`, `metrics`), and write `verification-results.json` under the change directory when one exists, else alongside its existing confidence artefact.
+- [ ] 3.2 `specrails-plugin/agents/reviewer.md`: same section as 2.1–2.3, and add the missing `${SPECRAILS_REPO_DIR:-.}` wrapper its `confidence-score.json` path also lacks.
+- [ ] 3.3 `templates/commands/specrails/implement.md`: Phase 4e surfaces the recorded counts in its summary table when the artifact exists, showing scope and author alongside; absent ⇒ the table renders exactly as today.
+- [ ] 3.4 Confirm gemini and kimi need no separate edit (both derive from `templates/agents/` at install time via `placeGeminiAgents` / `writeKimiWorkflowSkill`) and note it in the change.
+
+## 4. Guard rails
+
+- [ ] 4.1 `src/installer/__tests__/template-repo-dir.test.ts`: extend so the new artifact path is covered by the existing repo-dir-wrapper invariant.
+- [ ] 4.2 New template-content test: every reviewer surface (claude agent, codex rail skill, plugin copy) mentions `verification-results.json` and the `not_rerun` status, so a future edit cannot drop one provider silently.
+- [ ] 4.3 Assert the metric names in the reviewer template match those in `health-check.md` — one vocabulary, enforced rather than remembered.
+
+## 5. Validation gate
+
+- [ ] 5.1 `npm run build && npm run typecheck` pass.
+- [ ] 5.2 `npx vitest run` passes, including the new schema and template-content tests.
+- [ ] 5.3 `npm run dogfood` (`init --yes`) produces an installed reviewer whose Verification Results section is fully rendered — no empty placeholder skeleton, unlike today's stripped CI table.
+- [ ] 5.4 Acceptance sweep: `grep -rl 'verification-results' templates/ specrails-plugin/ schemas/ integration-contract.json` lists every surface this change claims to touch.
+
+## 6. Cross-repo (separate PR, non-blocking)
+
+- [ ] 6.1 specrails-desktop: read the artifact at settle in `server/delivery-evidence.ts` alongside `confidence-score.json`, and promote the review packet's test claim from the `ai-reported` tier to `app-verified` ONLY when `scope`/`ran_by` justify it. A `scoped` count stays qualified in the UI; the packet already refuses to print an unsourced number, so the change is additive on that side too.


### PR DESCRIPTION
OpenSpec change only — `proposal.md`, `design.md`, `specs/verification-results/spec.md`, `tasks.md`. **No implementation in this PR.**

## The problem

Verification runs on every pipeline pass. Nothing records what it said.

- `templates/agents/sr-reviewer.md:220` — the ONLY machine-parsed token in the reviewer's entire output is `SECURITY_STATUS:`.
- Test outcomes live in a prose markdown table whose rows are `{{CI_CHECK_TABLE_ROWS}}` — and `renderPlaceholders` (`src/installer/phases/scaffold.ts:2972-2978`) strips every unresolved `{{UPPER_CASE}}` token to **empty** at install time, since the enrich command was retired. The shipped agent improvises both the commands and the rows.
- The one structured reviewer artifact, `confidence-score.json`, carries five self-assigned 0–100 opinions. Its `test_coverage` aspect judges *adequacy* — it is not a count.

Downstream this is already load-bearing: specrails-desktop now presents verification to non-technical reviewers in tiers by source (measured-by-the-app / reported-by-the-AI / the-AI-grading-itself) and **deliberately refuses to print any test count**, because scraping "68 tests passed" out of prose would launder a self-report into a measurement. It shows "the AI reports its verification passed" where it could show "312 of 312 tests passed, 4.1s".

## Why this is delicate, and it is not the counting

`sr-reviewer.md:66-74` § "Verification policy (scoped-first)" already ships. Its step 4:

> If you changed nothing and the scoped runs are green, the developer's full pass stands as the pipeline's verification of record.

So a large share of runs have **no reviewer-executed full suite** — by design, and that design is what made the pipeline affordable. An artifact emitting a bare `tests_passed: 14` would be read downstream as "the suite is green" when it means "the fourteen tests covering the diff are green, and the full suite was somebody else's pass". That is worse than having no artifact, because it looks authoritative.

Hence the three non-negotiables in the spec:

| Rule | Why |
|---|---|
| every entry declares `scope` (`scoped\|full`) and `ran_by` (`reviewer\|developer-pass-of-record`) | a consumer can never read a metric without the qualifier that bounds it |
| a check not re-run is recorded as `status: "not_rerun"`, never omitted | omission is indistinguishable from "the artifact is incomplete" |
| an unmeasured metric is `null` | `tests_failed: 0` must mean "zero measured failures", never "we could not tell" |

## Nothing here invents vocabulary

`templates/commands/specrails/health-check.md:137-147` already specifies the per-runner machine-readable invocations (`jest --json`, `vitest run --reporter=json`, `mocha --reporter json`, `pytest --tb=no -q`, `go test -v`, `cargo test`, `rspec --format json`, `dotnet test`) **and** the exact metric names: `tests_total`, `tests_passed`, `tests_failed`, `tests_skipped`, `pass_rate`, `duration_seconds`. This reuses them verbatim rather than coining a second vocabulary for the same measurements.

The codex rail reviewer already asks itself to "capture the count" — and then puts it in a free-text `tests.details` field ("14/14 passing"). The intent was written down; only the structure was missing.

## Design decisions worth reviewing

- **A new artifact, not a field on `confidence-score.json`.** That file is the reviewer's self-assessment; measured facts in the same envelope collapse exactly the distinction this work exists to make. Follows the `design-confidence.json` precedent from `pipeline-cost-economy`.
- **A real `schemas/verification-results.v1.json`.** Today `openspec/specs/confidence-scoring.md:15` pins its artifact's schema by reference to a `design.md` that lives only under `openspec/changes/archive/`. `schemas/` already ships in the `files` whitelist and `CLAUDE.md` makes `$id` a cross-repo ownership contract, so this artifact gets a normative schema from the start.
- **Registered in `integration-contract.json` (3.2 → 3.3).** The contract describes only install/enrich today — `grep confidence integration-contract.json` returns nothing — which is why desktop's use of `confidence-score.json` is a convention discovered by reading prompts. First run-time artifact registered, hence the minor bump.
- **Self-contained runner detection.** The spec forbids depending on `{{CI_COMMANDS_FULL}}` / `{{CI_CHECK_TABLE_ROWS}}`, since both render empty.

## Out of scope, deliberately

- No gate on the new numbers — the confidence gate at Phase 4b-conf is untouched.
- No reconciliation of the two divergent confidence-score schemas (claude's `overall`/`aspects` vs the codex rail's `overall_score`/domain objects). Separate change; this artifact is additive to both.
- No coverage, lint, complexity or perf metrics, though `health-check.md` defines them. Tests first; the envelope has room.

## Not part of this change

**Delta-scoped verification already shipped** with `pipeline-cost-economy` in 5.0.0. An earlier cross-repo note paired it with this ask; that half is done.

## Backward compatibility

`verification-results.json` is additive: absence preserves pre-change behaviour byte-for-byte, and every consumer requirement treats a missing file as the legacy path. Template changes are not retroactive — a project keeps emitting nothing until its framework updates.

Consumer side (separate desktop PR, non-blocking): read it at settle beside `confidence-score.json` and promote the review packet's test claim from `ai-reported` to `app-verified` **only** when `scope` and `ran_by` justify it. A `scoped` count stays qualified in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQiSBxYKNvJgLqxQequUpV